### PR TITLE
Eh 42 redirect auth

### DIFF
--- a/src/oph/ehoks/auth/handler.clj
+++ b/src/oph/ehoks/auth/handler.clj
@@ -1,7 +1,6 @@
 (ns oph.ehoks.auth.handler
   (:require [compojure.api.sweet :refer [context GET POST DELETE]]
-            [ring.util.http-response
-             :refer [bad-request! no-content see-other]]
+            [ring.util.http-response :refer [bad-request! see-other]]
             [schema.core :as s]
             [oph.ehoks.schema :as schema]
             [oph.ehoks.restful :refer [response rest-ok]]

--- a/src/oph/ehoks/auth/handler.clj
+++ b/src/oph/ehoks/auth/handler.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.auth.handler
   (:require [compojure.api.sweet :refer [context GET POST DELETE]]
-            [ring.util.http-response :refer [bad-request! no-content]]
+            [ring.util.http-response
+             :refer [bad-request! no-content see-other]]
             [schema.core :as s]
             [oph.ehoks.schema :as schema]
             [oph.ehoks.restful :refer [response rest-ok]]
@@ -26,10 +27,15 @@
       (assoc (rest-ok []) :session nil))
 
     (POST "/opintopolku/" [:as request]
-      :summary "Creates new Opintopolku session"
-      :return (response [s/Any])
+      :summary "Creates new Opintopolku session and redirects to frontend"
+      :description "Creates new Opintopolku session. After storing session
+                    http status 'See Other' (303) will be returned with url of
+                    frontend in configuration."
       (when (not= (get-in request [:headers "referer"])
                   (:opintopolku-login-url config))
         (bad-request! "Misconfigured authentication"))
       (let [values (opintopolku/parse (:form-params request))]
-        (assoc-in (rest-ok []) [:session :user] values)))))
+        (assoc-in
+          (see-other
+            (format "%s:%d" (:frontend-url config) (:frontend-port config)))
+          [:session :user] values)))))

--- a/test/oph/ehoks/auth/handler_test.clj
+++ b/test/oph/ehoks/auth/handler_test.clj
@@ -29,9 +29,7 @@
 (deftest session-authenticate
   (testing "POST authenticate"
     (let [response (authenticate)]
-      (is (= (:status response) 200))
-      (is (empty? (get-in response [:body :data])))
-      (is (empty? (get-in response [:body :meta]))))))
+      (is (= (:status response) 303)))))
 
 (deftest session-authenticated
   (testing "GET current authenticated session"

--- a/test/oph/ehoks/auth/handler_test.clj
+++ b/test/oph/ehoks/auth/handler_test.clj
@@ -33,13 +33,13 @@
 
 (deftest prevent-illegal-authentication
   (testing "Prevents illegal authentication"
-    (let [response (app (-> (mock/request
-                              :post "/api/v1/session/opintopolku/"
-                              {"FirstName" "Teuvo Taavetti"
-                               "cn" "Teuvo"
-                               "givenName" "Teuvo"
-                               "hetu" "010203-XXXX"
-                               "sn" "Testaaja"})))]
+    (let [response (app (mock/request
+                          :post "/api/v1/session/opintopolku/"
+                          {"FirstName" "Teuvo Taavetti"
+                           "cn" "Teuvo"
+                           "givenName" "Teuvo"
+                           "hetu" "010203-XXXX"
+                           "sn" "Testaaja"}))]
       (is (= (:status response) 400)))))
 
 (deftest session-authenticated

--- a/test/oph/ehoks/auth/handler_test.clj
+++ b/test/oph/ehoks/auth/handler_test.clj
@@ -31,6 +31,17 @@
     (let [response (authenticate)]
       (is (= (:status response) 303)))))
 
+(deftest prevent-illegal-authentication
+  (testing "Prevents illegal authentication"
+    (let [response (app (-> (mock/request
+                              :post "/api/v1/session/opintopolku/"
+                              {"FirstName" "Teuvo Taavetti"
+                               "cn" "Teuvo"
+                               "givenName" "Teuvo"
+                               "hetu" "010203-XXXX"
+                               "sn" "Testaaja"})))]
+      (is (= (:status response) 400)))))
+
 (deftest session-authenticated
   (testing "GET current authenticated session"
     (let [auth-response (authenticate)


### PR DESCRIPTION
Lisätään erikoistapaus, missä on redirect autentikoinnin jälkeen.

Tämä ominaisuus saattaa poistua myöhemmin, riippuen käyttöliittymän toteutuksesta.