### PR TITLE
Truncate long table names

### DIFF
--- a/src/db/migration/V1_1554888506062__Create_database.sql
+++ b/src/db/migration/V1_1554888506062__Create_database.sql
@@ -116,7 +116,7 @@ CREATE TABLE olemassa_olevat_ammatilliset_tutkinnon_osat(
   tarkentavat_tiedot_arvioija_id INTEGER REFERENCES todennettu_arviointi_lisatiedot(id)
 );
 
-CREATE TABLE olemassa_olevan_ammatillisen_tutkinnon_osan_hankitun_osaamisen_naytto(
+CREATE TABLE olemassa_olevan_ammatillisen_tutkinnon_osan_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   olemassa_oleva_ammatillinen_tutkinnon_osa_id INTEGER REFERENCES olemassa_olevat_ammatilliset_tutkinnon_osat(id),
@@ -141,7 +141,7 @@ CREATE TABLE olemassa_olevat_paikalliset_tutkinnon_osat(
   lahetetty_arvioitavaksi DATE
 );
 
-CREATE TABLE olemassa_olevan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto(
+CREATE TABLE olemassa_olevan_paikallisen_tutkinnon_osan_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   olemassa_oleva_paikallinen_tutkinnon_osa_id INTEGER REFERENCES olemassa_olevat_paikalliset_tutkinnon_osat(id),
@@ -171,7 +171,7 @@ CREATE TABLE puuttuvat_paikalliset_tutkinnon_osat(
   vaatimuksista_tai_tavoitteista_poikkeaminen TEXT
 );
 
-CREATE TABLE puuttuvan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto(
+CREATE TABLE puuttuvan_paikallisen_tutkinnon_osan_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   puuttuva_paikallinen_tutkinnon_osa_id INTEGER REFERENCES puuttuvat_paikalliset_tutkinnon_osat(id),
@@ -265,7 +265,7 @@ CREATE TABLE olemassa_olevat_yhteiset_tutkinnon_osat(
   lahetetty_arvioitavaksi DATE
 );
 
-CREATE TABLE olemassa_olevan_yhteisen_tutkinnon_osan_hankitun_osaamisen_naytto(
+CREATE TABLE olemassa_olevan_yhteisen_tutkinnon_osan_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   olemassa_oleva_yhteinen_tutkinnon_osa_id INTEGER REFERENCES olemassa_olevat_yhteiset_tutkinnon_osat(id),
@@ -295,7 +295,7 @@ CREATE TABLE olemassa_olevat_yto_osa_alueet(
   valittu_todentamisen_prosessi_koodi_versio INTEGER
 );
 
-CREATE TABLE olemassa_olevan_yto_osa_alueen_hankitun_osaamisen_naytto(
+CREATE TABLE olemassa_olevan_yto_osa_alueen_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   olemassa_oleva_yto_osa_alue_id INTEGER REFERENCES olemassa_olevat_yto_osa_alueet(id),
@@ -315,7 +315,7 @@ CREATE TABLE puuttuvat_ammatilliset_tutkinnon_osat(
   koulutuksen_jarjestaja_oid VARCHAR(26)
 );
 
-CREATE TABLE puuttuvan_ammatillisen_tutkinnon_osan_hankitun_osaamisen_naytto(
+CREATE TABLE puuttuvan_ammatillisen_tutkinnon_osan_naytto(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   puuttuva_ammatillinen_tutkinnon_osa_id INTEGER REFERENCES puuttuvat_ammatilliset_tutkinnon_osat(id),
@@ -373,7 +373,7 @@ CREATE TABLE yhteisen_tutkinnon_osan_osa_alueen_osaamisen_hankkimistavat(
   PRIMARY KEY(yhteisen_tutkinnon_osan_osa_alue_id, osaamisen_hankkimistapa_id)
 );
 
-CREATE TABLE yhteisen_tutkinnon_osan_osa_alueen_hankitun_osaamisen_naytot(
+CREATE TABLE yhteisen_tutkinnon_osan_osa_alueen_naytot(
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
   deleted_at TIMESTAMP WITH TIME ZONE,
   yhteisen_tutkinnon_osan_osa_alue_id INTEGER REFERENCES yhteisen_tutkinnon_osan_osa_alueet(id),

--- a/src/oph/ehoks/db/postgresql.clj
+++ b/src/oph/ehoks/db/postgresql.clj
@@ -124,13 +124,13 @@
 
 (defn insert-ooato-hankitun-osaamisen-naytto! [ooato n]
   (insert-one!
-    :olemassa_olevan_ammatillisen_tutkinnon_osan_hankitun_osaamisen_naytto
+    :olemassa_olevan_ammatillisen_tutkinnon_osan_naytto
     {:olemassa_oleva_ammatillinen_tutkinnon_osa_id (:id ooato)
      :hankitun_osaamisen_naytto_id (:id n)}))
 
 (defn insert-ooyto-hankitun-osaamisen-naytto! [ooyto n]
   (insert-one!
-    :olemassa_olevan_yhteisen_tutkinnon_osan_hankitun_osaamisen_naytto
+    :olemassa_olevan_yhteisen_tutkinnon_osan_naytto
     {:olemassa_oleva_yhteinen_tutkinnon_osa_id (:id ooyto)
      :hankitun_osaamisen_naytto_id (:id n)}))
 
@@ -292,7 +292,7 @@
   "Puuttuvan paikallisen tutkinnon osan hankitun osaamisen näyttö"
   [ppto h]
   (insert-one!
-    :puuttuvan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto
+    :puuttuvan_paikallisen_tutkinnon_osan_naytto
     {:puuttuva_paikallinen_tutkinnon_osa_id (:id ppto)
      :hankitun_osaamisen_naytto_id (:id h)}))
 
@@ -303,7 +303,7 @@
                 :hankitun_osaamisen_naytot
                 (map h/hankitun-osaamisen-naytto-to-sql c))]
     (insert-multi!
-      :puuttuvan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto
+      :puuttuvan_paikallisen_tutkinnon_osan_naytto
       (map #(hash-map
               :puuttuva_paikallinen_tutkinnon_osa_id (:id ppto)
               :hankitun_osaamisen_naytto_id (:id %))
@@ -401,7 +401,7 @@
 
 (defn insert-oopto-hankitun-osaamisen-naytto! [oopto-id naytto-id]
   (insert-one!
-    :olemassa_olevan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto
+    :olemassa_olevan_paikallisen_tutkinnon_osan_naytto
     {:olemassa_oleva_paikallinen_tutkinnon_osa_id oopto-id
      :hankitun_osaamisen_naytto_id naytto-id}))
 
@@ -431,7 +431,7 @@
 
 (defn insert-ooyto-osa-alue-hankitun-osaamisen-naytto! [osa-alue-id naytto-id]
   (insert-one!
-    :olemassa_olevan_yto_osa_alueen_hankitun_osaamisen_naytto
+    :olemassa_olevan_yto_osa_alueen_naytto
     {:olemassa_oleva_yto_osa_alue_id osa-alue-id
      :hankitun_osaamisen_naytto_id naytto-id}))
 
@@ -467,7 +467,7 @@
 
 (defn insert-pato-hankitun-osaamisen-naytto! [pato-id naytto-id]
   (insert-one!
-    :puuttuvan_ammatillisen_tutkinnon_osan_hankitun_osaamisen_naytto
+    :puuttuvan_ammatillisen_tutkinnon_osan_naytto
     {:puuttuva_ammatillinen_tutkinnon_osa_id pato-id
      :hankitun_osaamisen_naytto_id naytto-id}))
 
@@ -533,7 +533,7 @@
 
 (defn insert-yto-osa-alueen-hankitun-osaamisen-naytto! [yto-id naytto-id]
   (insert-one!
-    :yhteisen_tutkinnon_osan_osa_alueen_hankitun_osaamisen_naytot
+    :yhteisen_tutkinnon_osan_osa_alueen_naytot
     {:yhteisen_tutkinnon_osan_osa_alue_id yto-id
      :hankitun_osaamisen_naytto_id naytto-id}))
 

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -41,8 +41,7 @@
 (def select-hankitun-osaamisen-naytot-by-ooato-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join (str "olemassa_olevan_ammatillisen_tutkinnon_osan_"
-                "hankitun_osaamisen_naytto")
+     :join "olemassa_olevan_ammatillisen_tutkinnon_osan_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "olemassa_oleva_ammatillinen_tutkinnon_osa_id"}))
@@ -59,8 +58,7 @@
 (def select-tarkentavat-tiedot-naytto-by-oopto-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join
-     "olemassa_olevan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto"
+     :join "olemassa_olevan_paikallisen_tutkinnon_osan_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "olemassa_oleva_paikallinen_tutkinnon_osa_id"}))
@@ -75,7 +73,7 @@
 (def select-hankitun-osaamisen-naytot-by-ppto-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join "puuttuvan_paikallisen_tutkinnon_osan_hankitun_osaamisen_naytto"
+     :join "puuttuvan_paikallisen_tutkinnon_osan_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "puuttuva_paikallinen_tutkinnon_osa_id"}))
@@ -125,14 +123,14 @@
 (def select-hankitun-osaamisen-naytot-by-ooyto-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join "olemassa_olevan_yhteisen_tutkinnon_osan_hankitun_osaamisen_naytto"
+     :join "olemassa_olevan_yhteisen_tutkinnon_osan_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "olemassa_oleva_yhteinen_tutkinnon_osa_id"}))
 (def select-hankitun-osaamisen-naytot-by-ooyto-osa-alue-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join "olemassa_olevan_yto_osa_alueen_hankitun_osaamisen_naytto"
+     :join "olemassa_olevan_yto_osa_alueen_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "olemassa_oleva_yto_osa_alue_id"}))
@@ -151,7 +149,7 @@
 (def select-hankitun-osaamisen-naytot-by-pato-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join "puuttuvan_ammatillisen_tutkinnon_osan_hankitun_osaamisen_naytto"
+     :join "puuttuvan_ammatillisen_tutkinnon_osan_naytto"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "puuttuva_ammatillinen_tutkinnon_osa_id"}))
@@ -178,7 +176,7 @@
 (def select-hankitun-osaamisen-naytot-by-yto-osa-alue-id
   (generate-select-join
     {:table "hankitun_osaamisen_naytot"
-     :join "yhteisen_tutkinnon_osan_osa_alueen_hankitun_osaamisen_naytot"
+     :join "yhteisen_tutkinnon_osan_osa_alueen_naytot"
      :secondary-column "hankitun_osaamisen_naytto_id"
      :primary-column "id"
      :column "yhteisen_tutkinnon_osan_osa_alue_id"}))


### PR DESCRIPTION
Tietokannan taulujen nimien lyhentäminen.

Huomaa, että tämä muuttaa ensimmäistä migraatiota.