### PR TITLE
Eh 168 move oppija

### DIFF
--- a/src/oph/ehoks/handler.clj
+++ b/src/oph/ehoks/handler.clj
@@ -49,7 +49,7 @@
         (c-api/context "/v1" []
           :tags ["v1"]
           oppija-handler/routes
-          auth-handler/routes
+          (c-api/undocumented auth-handler/routes)
           hoks-handler/routes
           healthcheck-handler/routes
           lokalisointi-handler/routes

--- a/src/oph/ehoks/handler.clj
+++ b/src/oph/ehoks/handler.clj
@@ -18,7 +18,7 @@
             [oph.ehoks.hoks.handler :as hoks-handler]
             [oph.ehoks.tyopaikan-toimija.handler :as tt-handler]
             [oph.ehoks.oppija.handler :as oppija-handler]
-            [oph.ehoks.auth.handler :as auth-handler]
+            [oph.ehoks.oppija.auth-handler :as auth-handler]
             [oph.ehoks.validation.handler :as validation-handler]
             [oph.ehoks.virkailija.handler :as virkailija-handler]))
 

--- a/src/oph/ehoks/middleware.clj
+++ b/src/oph/ehoks/middleware.clj
@@ -14,7 +14,7 @@
     (some #(when (matches-route? request %) %) routes)))
 
 (defn- authenticated? [request]
-  (some? (seq (:session request))))
+  (some? (get-in request [:session :user])))
 
 (defn wrap-authorize [handler]
   (fn

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -13,7 +13,6 @@
 
 (def routes
   (c-api/context "/session" []
-    :tags ["auth"]
 
     (route-middleware
       [wrap-authorize]

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -1,4 +1,4 @@
-(ns oph.ehoks.auth.handler
+(ns oph.ehoks.oppija.auth-handler
   (:require [compojure.api.sweet :as c-api]
             [compojure.api.core :refer [route-middleware]]
             [ring.util.http-response :as response]
@@ -6,7 +6,7 @@
             [oph.ehoks.schema :as schema]
             [oph.ehoks.restful :as rest]
             [oph.ehoks.config :refer [config]]
-            [oph.ehoks.auth.opintopolku :as opintopolku]
+            [oph.ehoks.oppija.opintopolku :as opintopolku]
             [oph.ehoks.external.oppijanumerorekisteri :as onr]
             [oph.ehoks.middleware :refer [wrap-authorize]]
             [clojure.tools.logging :as log]))

--- a/src/oph/ehoks/oppija/handler.clj
+++ b/src/oph/ehoks/oppija/handler.clj
@@ -16,6 +16,7 @@
 
 (def routes
   (c-api/context "/oppija" []
+    :tags ["oppija"]
 
     auth-handler/routes
 

--- a/src/oph/ehoks/oppija/handler.clj
+++ b/src/oph/ehoks/oppija/handler.clj
@@ -11,10 +11,13 @@
             [oph.ehoks.external.koodisto :as koodisto]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.eperusteet :as eperusteet]
-            [oph.ehoks.middleware :refer [wrap-authorize]]))
+            [oph.ehoks.middleware :refer [wrap-authorize]]
+            [oph.ehoks.oppija.auth-handler :as auth-handler]))
 
 (def routes
   (c-api/context "/oppija" []
+
+    auth-handler/routes
 
     (c-api/context "/external" []
       :tags ["oppija-external"]

--- a/src/oph/ehoks/oppija/opintopolku.clj
+++ b/src/oph/ehoks/oppija/opintopolku.clj
@@ -1,4 +1,4 @@
-(ns oph.ehoks.auth.opintopolku
+(ns oph.ehoks.oppija.opintopolku
   (:require [clojure.walk :refer [keywordize-keys]]
             [clojure.set :refer [rename-keys]]
             [clojure.string :refer [lower-case]])

--- a/test/oph/ehoks/oppija/auth_handler_test.clj
+++ b/test/oph/ehoks/oppija/auth_handler_test.clj
@@ -1,4 +1,4 @@
-(ns oph.ehoks.auth.handler-test
+(ns oph.ehoks.oppija.auth-handler-test
   (:require [clojure.test :refer [deftest testing is]]
             [oph.ehoks.handler :refer [app]]
             [ring.mock.request :as mock]
@@ -6,7 +6,7 @@
 
 (defn authenticate []
   (app (-> (mock/request
-             :get "/ehoks-backend/api/v1/session/opintopolku/")
+             :get "/ehoks-backend/api/v1/oppija/session/opintopolku/")
            (mock/header "FirstName" "Teuvo Testi")
            (mock/header "cn" "Teuvo")
            (mock/header "givenname" "Teuvo")
@@ -17,7 +17,7 @@
   (testing "GET current session without authentication"
     (let [response (app (mock/request
                           :get
-                          "/ehoks-backend/api/v1/session/"))]
+                          "/ehoks-backend/api/v1/oppija/session/"))]
       (is (= (:status response) 401))
       (is (empty? (:body response))))))
 
@@ -28,16 +28,17 @@
 
 (deftest prevent-malformed-authentication
   (testing "Prevents malformed authentication"
-    (let [response (app (-> (mock/request
-                              :get "/ehoks-backend/api/v1/session/opintopolku/"
-                              {"FirstName" "Teuvo Testi"
-                               "cn" "Teuvo"
-                               "hetu" "190384-9245"
-                               "sn" "Testaaja"})
-                            (mock/header "FirstName" "Teuvo Testi")
-                            (mock/header "cn" "Teuvo")
-                            (mock/header "givenname" "Teuvo")
-                            (mock/header "sn" "Testaaja")))]
+    (let [response
+          (app (-> (mock/request
+                     :get "/ehoks-backend/api/v1/oppija/session/opintopolku/"
+                     {"FirstName" "Teuvo Testi"
+                      "cn" "Teuvo"
+                      "hetu" "190384-9245"
+                      "sn" "Testaaja"})
+                   (mock/header "FirstName" "Teuvo Testi")
+                   (mock/header "cn" "Teuvo")
+                   (mock/header "givenname" "Teuvo")
+                   (mock/header "sn" "Testaaja")))]
       (is (= (:status response) 400)))))
 
 (deftest session-authenticated
@@ -46,7 +47,7 @@
           session-cookie (first (get-in auth-response [:headers "Set-Cookie"]))
           response (app (-> (mock/request
                               :get
-                              "/ehoks-backend/api/v1/session/")
+                              "/ehoks-backend/api/v1/oppija/session/")
                             (mock/header :cookie session-cookie)))
           body (parse-body (:body response))]
       (is (= (:status response) 200))
@@ -61,17 +62,17 @@
           authenticated-response
           (app (-> (mock/request
                      :get
-                     "/ehoks-backend/api/v1/session/")
+                     "/ehoks-backend/api/v1/oppija/session/")
                    (mock/header :cookie session-cookie)))
           authenticated-body (parse-body (:body authenticated-response))
           delete-response
           (app (-> (mock/request
                      :delete
-                     "/ehoks-backend/api/v1/session/")
+                     "/ehoks-backend/api/v1/oppija/session/")
                    (mock/header :cookie session-cookie)))
           response (app (-> (mock/request
                               :get
-                              "/ehoks-backend/api/v1/session/")
+                              "/ehoks-backend/api/v1/oppija/session/")
                             (mock/header :cookie session-cookie)))]
       (is (= (:status authenticated-response) 200))
       (is (= (:data authenticated-body)

--- a/test/oph/ehoks/oppija/opintopolku_test.clj
+++ b/test/oph/ehoks/oppija/opintopolku_test.clj
@@ -1,6 +1,6 @@
-(ns oph.ehoks.auth.opintopolku-test
+(ns oph.ehoks.oppija.opintopolku-test
   (:require [clojure.test :refer [deftest testing is]]
-            [oph.ehoks.auth.opintopolku :as o])
+            [oph.ehoks.oppija.opintopolku :as o])
   (:import [java.nio.charset StandardCharsets]))
 
 (deftest keys-to-lower-test

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -7,7 +7,7 @@
             [oph.ehoks.external.http-client :as client]))
 
 (defn get-auth-cookie [app]
-  (-> (mock/request :get "/ehoks-backend/api/v1/session/opintopolku/")
+  (-> (mock/request :get "/ehoks-backend/api/v1/oppija/session/opintopolku/")
       (mock/header "FirstName" "Teuvo Testi")
       (mock/header "cn" "Teuvo")
       (mock/header "givenname" "Teuvo")


### PR DESCRIPTION
Siirretään oppijan tunnistautuminen oppijan nimiavaruuteen.

Tämä vaatii muutokset fronttiin:

`/ehoks-backend/api/v1/session/*` -> `/ehoks-backend/api/v1/oppija/session/*`

ja 

Shibbolethiin:

`/ehoks-backend/api/v1/session/opintopolku/` -> `/ehoks-backend/api/v1/oppija/session/opintopolku/`

Vanhat endpointit toimii vielä toistaiseksi, mutta niitä ei nää enää swaggerin kautta. Tätä ei versioitu, koska endpointeja ei käytä, kuin meidän sisäiset järjestelmät.