### PR TITLE
Added migration for tarkentavat_tiedot_arvioija foreign key for

### DIFF
--- a/src/db/migration/V1_1559718030330__Add_tarkentavat_tiedot_arvioija_fkey_for_oopto_and_ooyto.sql
+++ b/src/db/migration/V1_1559718030330__Add_tarkentavat_tiedot_arvioija_fkey_for_oopto_and_ooyto.sql
@@ -1,0 +1,11 @@
+ALTER TABLE olemassa_olevat_paikalliset_tutkinnon_osat
+  ADD COLUMN tarkentavat_tiedot_arvioija_id integer,
+  ADD CONSTRAINT olemassa_olevat_paikalliset__tarkentavat_tiedot_arvioija__fkey
+    FOREIGN KEY (tarkentavat_tiedot_arvioija_id)
+      REFERENCES todennettu_arviointi_lisatiedot (id);
+
+ALTER TABLE olemassa_olevat_yhteiset_tutkinnon_osat
+  ADD COLUMN tarkentavat_tiedot_arvioija_id integer,
+  ADD CONSTRAINT olemassa_olevat_yhteiset__tarkentavat_tiedot_arvioija__fkey
+    FOREIGN KEY (tarkentavat_tiedot_arvioija_id)
+      REFERENCES todennettu_arviointi_lisatiedot (id);


### PR DESCRIPTION
olemassa_olevat_ammatilliset_tutkinnon_osat taululla oli viittaus todennettu_arviointi_lisatiedot tauluun. Lisätty sama viittaus myös olemassa_olevat_paikalliset_tutkinnon_osat ja olemassa_olevat_yhteiset_tutkinnon_osat tauluille.