### PR TITLE
eh-548 added missing field olennainen_seikka to aiemmin_hankitut_paik…

### DIFF
--- a/src/db/migration/V1_1568032761000__Add_olennainen_seikka_to_paikalliset.sql
+++ b/src/db/migration/V1_1568032761000__Add_olennainen_seikka_to_paikalliset.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aiemmin_hankitut_paikalliset_tutkinnon_osat ADD COLUMN
+olennainen_seikka BOOLEAN;


### PR DESCRIPTION
Puuttui siis vaan yksi migraatio, minkä takia oli epätasapaino skeeman, jossa olennainen-seikka oli myös aiemmin-hankitut-paikalliset-tutkinnon-osat -osassa, mutta kannassa taas ei oltu lisätty aiemmin_hankitut_paikalliset_tutkinnon_osat-tauluun sitä olennainne_seikka -kenttää, vaikka muihin oli (ahyto osa-alueet, ahato, hpto). Elikäs siis vaan yksi migraatio tämä tässä. 
