### PR TITLE
Eh 605 tutkinto and osaamisala remove

### DIFF
--- a/resources/db/oppijat/select_oppilaitos_oppijat.sql
+++ b/resources/db/oppijat/select_oppilaitos_oppijat.sql
@@ -3,9 +3,7 @@ SELECT o.oid,
        oo.oid AS opiskeluoikeus_oid,
        oo.oppilaitos_oid,
        oo.koulutustoimija_oid,
-       oo.tutkinto,
        oo.tutkinto_nimi,
-       oo.osaamisala,
        oo.osaamisala_nimi
 FROM oppijat AS o
        LEFT OUTER JOIN opiskeluoikeudet AS oo

--- a/resources/dev/src/oph/ehoks/dev_tools.clj
+++ b/resources/dev/src/oph/ehoks/dev_tools.clj
@@ -77,8 +77,6 @@
               :oppija-oid s/Str
               :oppilaitos-oid s/Str
               :koulutustoimija-oid s/Str
-              :tutkinto s/Str
-              :osaamisala s/Str
               :tutkinto-nimi {s/Keyword s/Str}
               :osaamisala-nimi {s/Keyword s/Str}
               :paattynyt s/Inst})

--- a/src/db/migration/V1_1571210000601__Remove_tutkinto_and_osaamisala.sql
+++ b/src/db/migration/V1_1571210000601__Remove_tutkinto_and_osaamisala.sql
@@ -1,0 +1,3 @@
+ALTER TABLE opiskeluoikeudet DROP COLUMN IF EXISTS tutkinto;
+ALTER TABLE opiskeluoikeudet DROP COLUMN IF EXISTS osaamisala;
+

--- a/src/oph/ehoks/common/schema.clj
+++ b/src/oph/ehoks/common/schema.clj
@@ -41,8 +41,6 @@
   {:oid s/Str
    :nimi s/Str
    :opiskeluoikeus-oid s/Str
-   (s/optional-key :tutkinto) s/Str
-   (s/optional-key :osaamisala) s/Str
    (s/optional-key :tutkinto-nimi) {(s/optional-key :fi) s/Str
                                     (s/optional-key :en) s/Str
                                     (s/optional-key :sv) s/Str}
@@ -62,8 +60,6 @@
    :oppija-oid s/Str
    :oppilaitos-oid s/Str
    (s/optional-key :koulutustoimija-oid) (s/maybe s/Str)
-   :tutkinto s/Str
-   :osaamisala s/Str
    (s/optional-key :tutkinto-nimi) {(s/optional-key :fi) s/Str
                                     (s/optional-key :en) s/Str
                                     (s/optional-key :sv) s/Str}

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -111,12 +111,12 @@
         "Opiskeluoikeus %s has multiple osaamisala. First one is used." oid))
     (let [tutkinto (get-tutkinto-nimi opiskeluoikeus)
           osaamisala (get-osaamisala-nimi opiskeluoikeus)]
-      (-> {:oid oid
-           :oppija_oid oppija-oid
-           :oppilaitos_oid (get-in opiskeluoikeus [:oppilaitos :oid])
-           :koulutustoimija_oid (get-in opiskeluoikeus [:koulutustoimija :oid])
-           :tutkinto_nimi tutkinto
-           :osaamisala_nimi osaamisala}))))
+      {:oid oid
+       :oppija_oid oppija-oid
+       :oppilaitos_oid (get-in opiskeluoikeus [:oppilaitos :oid])
+       :koulutustoimija_oid (get-in opiskeluoikeus [:koulutustoimija :oid])
+       :tutkinto_nimi tutkinto
+       :osaamisala_nimi osaamisala})))
 
 (defn add-new-opiskeluoikeus! [oid oppija-oid]
   (try

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -116,10 +116,7 @@
            :oppilaitos_oid (get-in opiskeluoikeus [:oppilaitos :oid])
            :koulutustoimija_oid (get-in opiskeluoikeus [:koulutustoimija :oid])
            :tutkinto_nimi tutkinto
-           :osaamisala_nimi osaamisala}
-          (cond-> (some? (:fi tutkinto)) (assoc :tutkinto (:fi tutkinto)))
-          (cond-> (some? (:fi osaamisala))
-            (assoc :osaamisala (:fi osaamisala)))))))
+           :osaamisala_nimi osaamisala}))))
 
 (defn add-new-opiskeluoikeus! [oid oppija-oid]
   (try

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -108,7 +108,8 @@
                             (assoc :osaamisala osaamisala))
                           oppijat (mapv
                                     #(dissoc
-                                       % :oppilaitos-oid :koulutustoimija-oid)
+                                       % :oppilaitos-oid :koulutustoimija-oid
+                                       :tutkinto :osaamisala)
                                     (op/search search-params))]
                       (restful/rest-ok
                         oppijat

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -108,8 +108,7 @@
                             (assoc :osaamisala osaamisala))
                           oppijat (mapv
                                     #(dissoc
-                                       % :oppilaitos-oid :koulutustoimija-oid
-                                       :tutkinto :osaamisala)
+                                       % :oppilaitos-oid :koulutustoimija-oid)
                                     (op/search search-params))]
                       (restful/rest-ok
                         oppijat

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -187,7 +187,7 @@
         {:oid "1.2.246.562.15.00000000001"
          :oppija-oid "1.2.246.562.24.111111111111"
          :oppilaitos-oid "1.2.246.562.10.222222222222"
-         :tutkinto "Testialan perustutkinto"
+         :tutkinto ""
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
@@ -222,7 +222,7 @@
         {:oid "1.2.246.562.15.00000000001"
          :oppija-oid "1.2.246.562.24.111111111111"
          :oppilaitos-oid "1.2.246.562.10.222222222222"
-         :tutkinto "Testialan perustutkinto"
+         :tutkinto ""
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -61,18 +61,17 @@
        :nimi "Testi Oppija"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000002"
-       :oppija_oid "1.2.246.562.24.11111111111"
-       :tutkinto "Testitutkinto 1"})
+       :oppija_oid "1.2.246.562.24.11111111111"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000003"
-       :oppija_oid "1.2.246.562.24.11111111111"
-       :tutkinto "Testitutkinto 2"})
+       :oppija_oid "1.2.246.562.24.11111111111"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000004"
        :oppija_oid "1.2.246.562.24.11111111111"
        :tutkinto-nimi {:fi "Testitutkinto" :sv "test"}})
     (let [results (vec (sort-by :oid
                                 (sut/get-opiskeluoikeudet-without-tutkinto)))]
+      (clojure.pprint/pprint results)
       (t/is (= (get-in results [0 :oid])
                "1.2.246.562.15.76000000002"))
       (t/is (= (get-in results [1 :oid])
@@ -85,12 +84,10 @@
        :nimi "Testi Oppija"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000002"
-       :oppija_oid "1.2.246.562.24.11111111111"
-       :tutkinto "Testitutkinto 1"})
+       :oppija_oid "1.2.246.562.24.11111111111"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000003"
-       :oppija_oid "1.2.246.562.24.11111111111"
-       :tutkinto "Testitutkinto 2"})
+       :oppija_oid "1.2.246.562.24.11111111111"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
       {:oid "1.2.246.562.15.76000000004"
        :oppija_oid "1.2.246.562.24.11111111111"

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -71,7 +71,6 @@
        :tutkinto-nimi {:fi "Testitutkinto" :sv "test"}})
     (let [results (vec (sort-by :oid
                                 (sut/get-opiskeluoikeudet-without-tutkinto)))]
-      (clojure.pprint/pprint results)
       (t/is (= (get-in results [0 :oid])
                "1.2.246.562.15.76000000002"))
       (t/is (= (get-in results [1 :oid])
@@ -110,19 +109,13 @@
     (t/is
       (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.11111111111")
          [{:oid "1.2.246.562.15.22222222222"
-           :oppija-oid "1.2.246.562.24.11111111111"
-           :tutkinto ""
-           :osaamisala ""}
+           :oppija-oid "1.2.246.562.24.11111111111"}
           {:oid "1.2.246.562.15.22222222224"
-           :oppija-oid "1.2.246.562.24.11111111111"
-           :tutkinto ""
-           :osaamisala ""}]))
+           :oppija-oid "1.2.246.562.24.11111111111"}]))
     (t/is
       (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.11111111112")
          [{:oid "1.2.246.562.15.22222222223"
-           :oppija-oid "1.2.246.562.24.11111111112"
-           :tutkinto ""
-           :osaamisala ""}]))))
+           :oppija-oid "1.2.246.562.24.11111111112"}]))))
 
 (t/deftest get-oppija-by-oid
   (t/testing "Get oppija by oid"
@@ -147,14 +140,10 @@
        :oppija_oid "1.2.246.562.24.11111111111"})
     (t/is (= (sut/get-opiskeluoikeus-by-oid "1.2.246.562.15.22222222222")
              {:oid "1.2.246.562.15.22222222222"
-              :oppija-oid "1.2.246.562.24.11111111111"
-              :tutkinto ""
-              :osaamisala ""}))
+              :oppija-oid "1.2.246.562.24.11111111111"}))
     (t/is (= (sut/get-opiskeluoikeus-by-oid "1.2.246.562.15.22222222223")
              {:oid "1.2.246.562.15.22222222223"
-              :oppija-oid "1.2.246.562.24.11111111111"
-              :tutkinto ""
-              :osaamisala ""}))))
+              :oppija-oid "1.2.246.562.24.11111111111"}))))
 
 (t/deftest add-oppija-opiskeluoikeus
   (t/testing "Add oppija and opiskeluoikeus"
@@ -184,11 +173,9 @@
         {:oid "1.2.246.562.15.00000000001"
          :oppija-oid "1.2.246.562.24.111111111111"
          :oppilaitos-oid "1.2.246.562.10.222222222222"
-         :tutkinto ""
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
-         :osaamisala ""
          :osaamisala-nimi {:fi "" :sv ""}}))))
 
 (t/deftest update-oppija-opiskeluoikeus
@@ -219,11 +206,9 @@
         {:oid "1.2.246.562.15.00000000001"
          :oppija-oid "1.2.246.562.24.111111111111"
          :oppilaitos-oid "1.2.246.562.10.222222222222"
-         :tutkinto ""
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
-         :osaamisala ""
          :osaamisala-nimi {:fi "" :sv ""}}))
 
     (utils/with-ticket-auth
@@ -252,9 +237,7 @@
         {:oid "1.2.246.562.15.00000000001"
          :oppija-oid "1.2.246.562.24.111111111111"
          :oppilaitos-oid "1.2.246.562.10.222222222223"
-         :tutkinto ""
          :tutkinto-nimi {:fi "" :sv ""}
-         :osaamisala ""
          :osaamisala-nimi {:fi "" :sv ""}}))))
 
 (t/deftest set-paattynyt-test

--- a/test/oph/ehoks/user_test.clj
+++ b/test/oph/ehoks/user_test.clj
@@ -56,15 +56,15 @@
          :oppija_oid "1.2.246.562.24.44000000002"
          :oppilaitos_oid "1.2.246.562.10.00000000003"
          :koulutustoimija_oid "1.2.246.562.10.00000000002"
-         :tutkinto "Testitutkinto 1"
-         :osaamisala "Testiosaamisala numero 1"})
+         :tutkinto_nimi {:fi "Testitutkinto 1"}
+         :osaamisala_nimi {:fi "Testiosaamisala numero 1"}})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.76000000003"
          :oppija_oid "1.2.246.562.24.44000000002"
          :oppilaitos_oid "1.2.246.562.10.00000000004"
          :koulutustoimija_oid "1.2.246.562.10.00000000002"
-         :tutkinto "Testitutkinto 1"
-         :osaamisala "Testiosaamisala numero 1"})
+         :tutkinto_nimi {:fi "Testitutkinto 1"}
+         :osaamisala_nimi {:fi "Testiosaamisala numero 1"}})
       (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76000000002"
                              :oppija_oid "1.2.246.562.24.44000000002"
                              :ensikertainen_hyvaksyminen

--- a/test/oph/ehoks/user_test.clj
+++ b/test/oph/ehoks/user_test.clj
@@ -56,15 +56,15 @@
          :oppija_oid "1.2.246.562.24.44000000002"
          :oppilaitos_oid "1.2.246.562.10.00000000003"
          :koulutustoimija_oid "1.2.246.562.10.00000000002"
-         :tutkinto_nimi {:fi "Testitutkinto 1"}
-         :osaamisala_nimi {:fi "Testiosaamisala numero 1"}})
+         :tutkinto-nimi {:fi "Testitutkinto 1"}
+         :osaamisala-nimi {:fi "Testiosaamisala numero 1"}})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.76000000003"
          :oppija_oid "1.2.246.562.24.44000000002"
          :oppilaitos_oid "1.2.246.562.10.00000000004"
          :koulutustoimija_oid "1.2.246.562.10.00000000002"
-         :tutkinto_nimi {:fi "Testitutkinto 1"}
-         :osaamisala_nimi {:fi "Testiosaamisala numero 1"}})
+         :tutkinto-nimi {:fi "Testitutkinto 1"}
+         :osaamisala-nimi {:fi "Testiosaamisala numero 1"}})
       (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76000000002"
                              :oppija_oid "1.2.246.562.24.44000000002"
                              :ensikertainen_hyvaksyminen

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -164,8 +164,6 @@
                :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
                :oppilaitos-oid "1.2.246.562.10.12000000000"
                :tutkinto-nimi {:fi "Testitutkinto 1" :sv "Testskrivning 1"}
-               :tutkinto "Testitutkinto 1"
-               :osaamisala "Testiosaamisala numero 1"
                :osaamisala-nimi
                {:fi "Testiosaamisala numero 1" :sv "Kunnande 1"}
                :koulutustoimija-oid ""})
@@ -174,8 +172,6 @@
                :opiskeluoikeus-oid "1.2.246.562.15.76000000002"
                :oppilaitos-oid "1.2.246.562.10.12000000001"
                :tutkinto-nimi {:fi "Testitutkinto 2" :sv "Testskrivning 2"}
-               :tutkinto "Testitutkinto 2"
-               :osaamisala "Testiosaamisala numero 2"
                :osaamisala-nimi
                {:fi "Testiosaamisala numero 2" :sv "Kunnande 2"}
                :koulutustoimija-oid ""})
@@ -184,15 +180,13 @@
                :opiskeluoikeus-oid "1.2.246.562.15.76000000003"
                :oppilaitos-oid "1.2.246.562.10.12000000000"
                :tutkinto-nimi {:fi "Testitutkinto 3" :sv "Testskrivning 3"}
-               :tutkinto "Testitutkinto 3"
-               :osaamisala "Osaamisala Kolme"
                :osaamisala-nimi {:fi "Osaamisala Kolme" :sv "Kunnande 3"}
                :koulutustoimija-oid ""})
   (add-oppija {:oid "1.2.246.562.24.44000000004"
                :nimi "Oiva Oppivainen"
                :opiskeluoikeus-oid "1.2.246.562.15.76000000004"
                :oppilaitos-oid "1.2.246.562.10.12000000000"
-               :tutkinto "Tutkinto 4"
+               :tutkinto-nimi {:fi "Tutkinto 4"}
                :koulutustoimija-oid ""}))
 
 (t/deftest get-oppijat-without-filtering
@@ -282,8 +276,6 @@
                    :opiskeluoikeus-oid "1.2.246.562.15.76000000003"
                    :oppilaitos-oid "1.2.246.562.10.12000000000"
                    :tutkinto-nimi {:fi "Testitutkinto 3" :sv "Testskrivning 3"}
-                   :tutkinto "Testitutkinto 3"
-                   :osaamisala "Osaamisala Kolme"
                    :osaamisala-nimi {:fi "Osaamisala Kolme"}
                    :koulutustoimija-oid ""})
       (let [body (get-search {:order-by-column "tutkinto"
@@ -301,16 +293,16 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto_nimi {:fi "Testitutkinto 1"}
-                   :osaamisala_nimi {:fi "Testiosaamisala numero 1"}
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000020"
          :koulutustoimija_oid ""
-         :tutkinto_nimi {:fi "Tutkinto 2"}
-         :osaamisala_nimi {:fi "Osaamisala 2"}})
+         :tutkinto-nimi {:fi "Tutkinto 2"}
+         :osaamisala-nimi {:fi "Osaamisala 2"}})
 
       (let [body (get-search
                    {:oppilaitos-oid "1.2.246.562.10.1200000000020"}
@@ -399,15 +391,15 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000200"
-         :tutkinto_nimi {:fi "Testitutkinto 2"}
-         :osaamisala_nimi {:fi "Testiosaamisala 2"}})
+         :tutkinto-nimi {:fi "Testitutkinto 2"}
+         :osaamisala-nimi {:fi "Testiosaamisala 2"}})
       (let [response
             (with-test-virkailija
               (mock/json-body
@@ -436,8 +428,8 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
                    :oppilaitos-oid "1.2.246.562.10.12000000000"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (let [response
             (with-test-virkailija
@@ -485,8 +477,8 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
                    :oppilaitos-oid "1.2.246.562.10.12000000001"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (let [response
             (with-test-virkailija
@@ -528,8 +520,8 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (let [response
             (with-test-virkailija
@@ -584,15 +576,15 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000200"
-         :tutkinto_nimi {:fi "Testitutkinto 2"}
-         :osaamisala_nimi {:fi "Testiosaamisala 2"}})
+         :tutkinto-nimi {:fi "Testitutkinto 2"}
+         :osaamisala-nimi {:fi "Testiosaamisala 2"}})
       (let [response
             (with-test-virkailija
               (mock/json-body
@@ -696,8 +688,8 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto-nimi {:fi "Testitutkinto 1"}
+                   :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (let [response
             (with-test-virkailija

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -131,12 +131,10 @@
      :oppija_oid (:oid oppija)
      :oppilaitos_oid (:oppilaitos-oid oppija)
      :koulutustoimija_oid (:koulutustoimija-oid oppija)
-     :tutkinto (:tutkinto oppija "")
      :tutkinto-nimi (:tutkinto-nimi oppija
                                     {:fi "Testialan perustutkinto"
                                      :sv "Grundexamen inom testsbranschen"
                                      :en "Testing"})
-     :osaamisala (:osaamisala oppija "")
      :osaamisala-nimi (:osaamisala-nimi oppija
                                         {:fi "Osaamisala suomeksi"
                                          :sv "På svenska"})}))
@@ -303,16 +301,16 @@
                    :nimi "Teuvo Testaaja"
                    :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
                    :oppilaitos-oid "1.2.246.562.10.1200000000010"
-                   :tutkinto "Testitutkinto 1"
-                   :osaamisala "Testiosaamisala numero 1"
+                   :tutkinto_nimi {:fi "Testitutkinto 1"}
+                   :osaamisala_nimi {:fi "Testiosaamisala numero 1"}
                    :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000020"
          :koulutustoimija_oid ""
-         :tutkinto "Tutkinto 2"
-         :osaamisala "Osaamisala 2"})
+         :tutkinto_nimi {:fi "Tutkinto 2"}
+         :osaamisala_nimi {:fi "Osaamisala 2"}})
 
       (let [body (get-search
                    {:oppilaitos-oid "1.2.246.562.10.1200000000020"}
@@ -408,8 +406,8 @@
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000200"
-         :tutkinto "Testitutkinto 2"
-         :osaamisala "Testiosaamisala 2"})
+         :tutkinto_nimi {:fi "Testitutkinto 2"}
+         :osaamisala_nimi {:fi "Testiosaamisala 2"}})
       (let [response
             (with-test-virkailija
               (mock/json-body
@@ -593,8 +591,8 @@
         {:oid "1.2.246.562.15.760000000020"
          :oppija_oid "1.2.246.562.24.44000000001"
          :oppilaitos_oid "1.2.246.562.10.1200000000200"
-         :tutkinto "Testitutkinto 2"
-         :osaamisala "Testiosaamisala 2"})
+         :tutkinto_nimi {:fi "Testitutkinto 2"}
+         :osaamisala_nimi {:fi "Testiosaamisala 2"}})
       (let [response
             (with-test-virkailija
               (mock/json-body


### PR DESCRIPTION
Poistettu opiskeluoikeudelta tutkinto osaamisala kentät koska niitä ei tarvittu enää mihinkään.