### PR TITLE
Eh 668 add oid to audit logs

### DIFF
--- a/src/oph/ehoks/logging/audit.clj
+++ b/src/oph/ehoks/logging/audit.clj
@@ -88,6 +88,7 @@
                         :post operation-new
                         :patch operation-modify
                         :delete operation-delete
+                        :put operation-modify
                         operation-read))
           changes (build-changes response)]
       (.log audit

--- a/src/oph/ehoks/logging/audit.clj
+++ b/src/oph/ehoks/logging/audit.clj
@@ -30,6 +30,7 @@
 (def operation-read (create-operation "read"))
 (def operation-new (create-operation "create"))
 (def operation-modify (create-operation "update"))
+(def operation-overwrite (create-operation "overwrite"))
 (def operation-delete (create-operation "delete"))
 
 (defn- get-user-oid [request]
@@ -88,9 +89,12 @@
                         :post operation-new
                         :patch operation-modify
                         :delete operation-delete
-                        :put operation-modify
+                        :put operation-overwrite
                         operation-read))
-          changes (build-changes response)]
+          changes
+          (if (method :put)
+            (build-changes (assoc {} :audit-data {:new (get-in request :hoks)}))
+            (build-changes response))]
       (.log audit
             user
             operation

--- a/src/oph/ehoks/logging/audit.clj
+++ b/src/oph/ehoks/logging/audit.clj
@@ -91,10 +91,7 @@
                         :delete operation-delete
                         :put operation-overwrite
                         operation-read))
-          changes
-          (if (method :put)
-            (build-changes (assoc {} :audit-data {:new (get-in request :hoks)}))
-            (build-changes response))]
+          changes (build-changes response)]
       (.log audit
             user
             operation

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -170,11 +170,13 @@
                       (try
                         (let [hoks-db (h/save-hoks!
                                         (assoc hoks :manuaalisyotto true))]
-                          (restful/rest-ok
+                         (assoc
+                           (restful/rest-ok
                             {:uri (format "%s/%d"
                                           (:uri request)
                                           (:id hoks-db))}
-                            :id (:id hoks-db)))
+                            :id (:id hoks-db))
+                           :audit-data {:new hoks}))
                         (catch Exception e
                           (if (= (:error (ex-data e)) :duplicate)
                             (do
@@ -235,7 +237,11 @@
                               (dissoc hoks-values
                                       :oppija-oid
                                       :opiskeluoikeus-oid))
-                            (response/no-content))
+                            (assoc
+                              (response/no-content)
+                              :audit-data {:new  (dissoc hoks-values
+                                                         :oppija-oid
+                                                         :opiskeluoikeus-oid)}))
 
                           (c-api/PATCH "/" request
                             :body [hoks-values hoks-schema/HOKSPaivitys]
@@ -246,7 +252,11 @@
                                 hoks-values
                                 :opiskeluoikeus-oid
                                 :oppija-oid))
-                            (response/no-content))))
+                            (assoc
+                              (response/no-content)
+                              :audit-data {:new  (dissoc hoks-values
+                                                         :oppija-oid
+                                                         :opiskeluoikeus-oid)}))))
 
                       (route-middleware
                         [m/wrap-oph-super-user]

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -170,13 +170,13 @@
                       (try
                         (let [hoks-db (h/save-hoks!
                                         (assoc hoks :manuaalisyotto true))]
-                         (assoc
-                           (restful/rest-ok
-                            {:uri (format "%s/%d"
-                                          (:uri request)
-                                          (:id hoks-db))}
-                            :id (:id hoks-db))
-                           :audit-data {:new hoks}))
+                          (assoc
+                            (restful/rest-ok
+                              {:uri (format "%s/%d"
+                                            (:uri request)
+                                            (:id hoks-db))}
+                              :id (:id hoks-db))
+                            :audit-data {:new hoks}))
                         (catch Exception e
                           (if (= (:error (ex-data e)) :duplicate)
                             (do

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -254,9 +254,10 @@
                                 :oppija-oid))
                             (assoc
                               (response/no-content)
-                              :audit-data {:new  (dissoc hoks-values
-                                                         :oppija-oid
-                                                         :opiskeluoikeus-oid)}))))
+                              :audit-data {:new
+                                           (dissoc hoks-values
+                                                   :oppija-oid
+                                                   :opiskeluoikeus-oid)}))))
 
                       (route-middleware
                         [m/wrap-oph-super-user]


### PR DESCRIPTION
Lisätty :put metodi audit.clj:hin ja sille oma operation overwrite. Lisäksi lisätty virkailijan handleriin post, put ja patch :audit {:new ...}, jotta myös changes tulee logille. 