### PR TITLE
Eh 733 opiskeluoikeus not allowed to update

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -336,12 +336,13 @@
                     :audit-data
                     {:new  hoks-values}))
                 (catch Exception e
-                  (assoc
-                    (response/bad-request!
-                      {:error
-                       (.getMessage e)})
-                    :audit-data {:new hoks-values})
-                  (throw e)))
+                  (if (= (:error (ex-data e)) :disallowed-update)
+                    (assoc
+                      (response/bad-request!
+                        {:error
+                         (.getMessage e)})
+                      :audit-data {:new hoks-values})
+                    (throw e))))
               (response/not-found
                 {:error "HOKS not found with given HOKS ID"})))
 
@@ -362,8 +363,8 @@
                       (response/bad-request!
                         {:error
                          (.getMessage e)})
-                      :audit-data {:new hoks-values}))
-                  (throw e)))
+                      :audit-data {:new hoks-values})
+                    (throw e))))
               (response/not-found
                 {:error "HOKS not found with given HOKS ID"})))
 

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -315,49 +315,48 @@
 
       (c-api/context "/:hoks-id" []
 
-        route-middleware
-        [m/wrap-hoks m/wrap-hoks-access]
+        (route-middleware
+          [m/wrap-hoks m/wrap-hoks-access]
 
-        (c-api/GET "/" request
-          :summary "Palauttaa HOKSin"
-          :return (rest/response hoks-schema/HOKS)
-          (rest/rest-ok (h/get-hoks-values (:hoks request))))
+          (c-api/GET "/" request
+            :summary "Palauttaa HOKSin"
+            :return (rest/response hoks-schema/HOKS)
+            (rest/rest-ok (h/get-hoks-values (:hoks request))))
 
-        (c-api/PATCH "/" request
-          :summary
-          "Päivittää olemassa olevan HOKSin ylätason arvoa tai arvoja"
-          :body [values hoks-schema/HOKSPaivitys]
-          (if (not-empty (:hoks request))
-            (do
-              (h/update-hoks! (get-in request [:hoks :id])
-                              (dissoc values :oppija-oid :opiskeluoikeus-oid))
-              (response/no-content))
-            (response/not-found
-              {:error "HOKS not found with given HOKS ID"})))
-
-        (c-api/PUT "/" request
-          :summary "Ylikirjoittaa olemassa olevan HOKSin arvon tai arvot"
-          :body [values hoks-schema/HOKSKorvaus]
-          (let [hoks-id (get-in request [:hoks :id])
-                oid (:opiskeluoikeus-oid (h/get-hoks-by-id hoks-id))
-                new-oid (:opiskeluoikeus-oid values)]
-            (cond
-              (and (some? new-oid) (not= oid new-oid))
-              (response/bad-request!
-                {:error "Opiskeluoikeus-oid update not allowed!"})
-              (not-empty (:hoks request))
+          (c-api/PATCH "/" request
+            :summary
+            "Päivittää olemassa olevan HOKSin ylätason arvoa tai arvoja"
+            :body [values hoks-schema/HOKSPaivitys]
+            (if (not-empty (:hoks request))
               (do
-                (h/replace-hoks!
-                  hoks-id (dissoc values :oppija-oid :opiskeluoikeus-oid))
+                (h/update-hoks! (get-in request [:hoks :id])
+                                (dissoc values :oppija-oid :opiskeluoikeus-oid))
                 (response/no-content))
-              :else
-              (response/not-found {:error "HOKS not found with HOKS ID"}))))
+              (response/not-found
+                {:error "HOKS not found with given HOKS ID"})))
 
+          (c-api/PUT "/" request
+            :summary "Ylikirjoittaa olemassa olevan HOKSin arvon tai arvot"
+            :body [values hoks-schema/HOKSKorvaus]
+            (let [hoks-id (get-in request [:hoks :id])
+                  oid (:opiskeluoikeus-oid (h/get-hoks-by-id hoks-id))
+                  new-oid (:opiskeluoikeus-oid values)]
+              (cond
+                (and (some? new-oid) (not= oid new-oid))
+                (response/bad-request!
+                  {:error "Opiskeluoikeus-oid update not allowed!"})
+                (not-empty (:hoks request))
+                (do
+                  (h/replace-hoks!
+                    hoks-id (dissoc values :oppija-oid :opiskeluoikeus-oid))
+                  (response/no-content))
+                :else
+                (response/not-found {:error "HOKS not found with HOKS ID"}))))
 
-        aiemmin-hankittu-ammat-tutkinnon-osa
-        aiemmin-hankittu-paikallinen-tutkinnon-osa
-        aiemmin-hankittu-yhteinen-tutkinnon-osa
-        hankittava-ammat-tutkinnon-osa
-        hankittava-paikallinen-tutkinnon-osa
-        hankittava-yhteinen-tutkinnon-osa
-        opiskeluvalmiuksia-tukevat-opinnot))))
+          aiemmin-hankittu-ammat-tutkinnon-osa
+          aiemmin-hankittu-paikallinen-tutkinnon-osa
+          aiemmin-hankittu-yhteinen-tutkinnon-osa
+          hankittava-ammat-tutkinnon-osa
+          hankittava-paikallinen-tutkinnon-osa
+          hankittava-yhteinen-tutkinnon-osa
+          opiskeluvalmiuksia-tukevat-opinnot)))))

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -336,19 +336,11 @@
                     :audit-data
                     {:new  hoks-values}))
                 (catch Exception e
-                  (cond
-                    (= (:error (ex-data e)) :opiskeluoikeus-update)
-                    (assoc
-                      (response/bad-request!
-                        {:error
-                         (str "Opiskeluoikeus update not allowed!")})
-                      :audit-data {:new hoks-values})
-                    (= (:error (ex-data e)) :oppija-update)
-                    (assoc
-                      (response/bad-request!
-                        {:error
-                         "Oppija-oid update not allowed!"})
-                      :audit-data {:new hoks-values}))
+                  (assoc
+                    (response/bad-request!
+                      {:error
+                       (.getMessage e)})
+                    :audit-data {:new hoks-values})
                   (throw e)))
               (response/not-found
                 {:error "HOKS not found with given HOKS ID"})))
@@ -365,18 +357,11 @@
                     :audit-data
                     {:new  hoks-values}))
                 (catch Exception e
-                  (cond
-                    (= (:error (ex-data e)) :opiskeluoikeus-update)
+                  (if (= (:error (ex-data e)) :disallowed-update)
                     (assoc
                       (response/bad-request!
                         {:error
-                         (str "Opiskeluoikeus update not allowed!")})
-                      :audit-data {:new hoks-values})
-                    (= (:error (ex-data e)) :oppija-update)
-                    (assoc
-                      (response/bad-request!
-                        {:error
-                         "Oppija-oid update not allowed!"})
+                         (.getMessage e)})
                       :audit-data {:new hoks-values}))
                   (throw e)))
               (response/not-found

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -129,41 +129,43 @@
       hoks-id new-ahyto-values)))
 
 (defn replace-hoks! [hoks-id new-values]
-  (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))
-        old-oppija-oid (:oppija-oid (get-hoks-by-id hoks-id))
-        new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-values)
-        new-oppija-oid (:oppija-oid new-values)]
-    (cond
-      (and (some? new-opiskeluoikeus-oid)
-           (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
-      (throw (ex-info
-               "Opiskeluoikeus update not allowed!"
-               {:error :opiskeluoikeus-update}))
-      (and (some? new-oppija-oid) (not= new-oppija-oid old-oppija-oid))
-      (throw (ex-info
-               "Oppija-oid update not allowed!"
-               {:error :oppija-update}))
-      :else
-      (jdbc/with-db-transaction
-        [db-conn (db-ops/get-db-connection)]
-        (replace-main-hoks! hoks-id new-values db-conn)
-        (replace-oto! hoks-id (:opiskeluvalmiuksia-tukevat-opinnot new-values)
-                      db-conn)
-        (replace-hato! hoks-id (:hankittavat-ammat-tutkinnon-osat new-values)
-                       db-conn)
-        (replace-hpto! hoks-id
-                       (:hankittavat-paikalliset-tutkinnon-osat new-values)
-                       db-conn)
-        (replace-hyto! hoks-id (:hankittavat-yhteiset-tutkinnon-osat new-values)
-                       db-conn)
-        (replace-ahato! hoks-id
-                        (:aiemmin-hankitut-ammat-tutkinnon-osat new-values)
+  (jdbc/with-db-transaction
+    [db-conn (db-ops/get-db-connection)]
+    (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))
+          old-oppija-oid (:oppija-oid (get-hoks-by-id hoks-id))
+          new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-values)
+          new-oppija-oid (:oppija-oid new-values)]
+      (cond
+        (and (some? new-opiskeluoikeus-oid)
+             (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
+        (throw (ex-info
+                 "Opiskeluoikeus update not allowed!"
+                 {:error :disallowed-update}))
+        (and (some? new-oppija-oid) (not= new-oppija-oid old-oppija-oid))
+        (throw (ex-info
+                 "Oppija-oid update not allowed!"
+                 {:error :disallowed-update}))
+        :else
+        (do
+          (replace-main-hoks! hoks-id new-values db-conn)
+          (replace-oto! hoks-id (:opiskeluvalmiuksia-tukevat-opinnot new-values)
                         db-conn)
-        (replace-ahpto! hoks-id (:aiemmin-hankitut-paikalliset-tutkinnon-osat
-                                  new-values)
-                        db-conn)
-        (replace-ahyto! hoks-id (:aiemmin-hankitut-yhteiset-tutkinnon-osat
-                                  new-values))))))
+          (replace-hato! hoks-id (:hankittavat-ammat-tutkinnon-osat new-values)
+                         db-conn)
+          (replace-hpto! hoks-id
+                         (:hankittavat-paikalliset-tutkinnon-osat new-values)
+                         db-conn)
+          (replace-hyto! hoks-id
+                         (:hankittavat-yhteiset-tutkinnon-osat new-values)
+                         db-conn)
+          (replace-ahato! hoks-id
+                          (:aiemmin-hankitut-ammat-tutkinnon-osat new-values)
+                          db-conn)
+          (replace-ahpto! hoks-id (:aiemmin-hankitut-paikalliset-tutkinnon-osat
+                                    new-values)
+                          db-conn)
+          (replace-ahyto! hoks-id (:aiemmin-hankitut-yhteiset-tutkinnon-osat
+                                    new-values)))))))
 
 (defn update-hoks! [hoks-id new-values]
   (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -166,4 +166,19 @@
                                   new-values))))))
 
 (defn update-hoks! [hoks-id new-values]
-  (db-hoks/update-hoks-by-id! hoks-id new-values))
+  (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))
+        old-oppija-oid (:oppija-oid (get-hoks-by-id hoks-id))
+        new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-values)
+        new-oppija-oid (:oppija-oid new-values)]
+    (cond
+      (and (some? new-opiskeluoikeus-oid)
+           (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
+      (throw (ex-info
+               "Opiskeluoikeus update not allowed!"
+               {:error :opiskeluoikeus-update}))
+      (and (some? new-oppija-oid) (not= new-oppija-oid old-oppija-oid))
+      (throw (ex-info
+               "Oppija-oid update not allowed!"
+               {:error :oppija-update}))
+      :else
+      (db-hoks/update-hoks-by-id! hoks-id new-values))))

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -131,8 +131,9 @@
 (defn replace-hoks! [hoks-id new-values]
   (jdbc/with-db-transaction
     [db-conn (db-ops/get-db-connection)]
-    (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))
-          old-oppija-oid (:oppija-oid (get-hoks-by-id hoks-id))
+    (let [hoks (get-hoks-by-id hoks-id)
+          old-opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
+          old-oppija-oid (:oppija-oid hoks)
           new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-values)
           new-oppija-oid (:oppija-oid new-values)]
       (cond
@@ -177,10 +178,10 @@
            (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
       (throw (ex-info
                "Opiskeluoikeus update not allowed!"
-               {:error :opiskeluoikeus-update}))
+               {:error :disallowed-update}))
       (and (some? new-oppija-oid) (not= new-oppija-oid old-oppija-oid))
       (throw (ex-info
                "Oppija-oid update not allowed!"
-               {:error :oppija-update}))
+               {:error :disallowed-update}))
       :else
       (db-hoks/update-hoks-by-id! hoks-id new-values))))

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -129,24 +129,41 @@
       hoks-id new-ahyto-values)))
 
 (defn replace-hoks! [hoks-id new-values]
-  (jdbc/with-db-transaction
-    [db-conn (db-ops/get-db-connection)]
-    (replace-main-hoks! hoks-id new-values db-conn)
-    (replace-oto! hoks-id (:opiskeluvalmiuksia-tukevat-opinnot new-values)
-                  db-conn)
-    (replace-hato! hoks-id (:hankittavat-ammat-tutkinnon-osat new-values)
-                   db-conn)
-    (replace-hpto! hoks-id (:hankittavat-paikalliset-tutkinnon-osat new-values)
-                   db-conn)
-    (replace-hyto! hoks-id (:hankittavat-yhteiset-tutkinnon-osat new-values)
-                   db-conn)
-    (replace-ahato! hoks-id (:aiemmin-hankitut-ammat-tutkinnon-osat new-values)
-                    db-conn)
-    (replace-ahpto! hoks-id (:aiemmin-hankitut-paikalliset-tutkinnon-osat
-                              new-values)
-                    db-conn)
-    (replace-ahyto! hoks-id (:aiemmin-hankitut-yhteiset-tutkinnon-osat
-                              new-values))))
+  (let [old-opiskeluoikeus-oid (:opiskeluoikeus-oid (get-hoks-by-id hoks-id))
+        old-oppija-oid (:oppija-oid (get-hoks-by-id hoks-id))
+        new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-values)
+        new-oppija-oid (:oppija-oid new-values)]
+    (cond
+      (and (some? new-opiskeluoikeus-oid)
+           (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
+      (throw (ex-info
+               "Opiskeluoikeus update not allowed!"
+               {:error :opiskeluoikeus-update}))
+      (and (some? new-oppija-oid) (not= new-oppija-oid old-oppija-oid))
+      (throw (ex-info
+               "Oppija-oid update not allowed!"
+               {:error :oppija-update}))
+      :else
+      (jdbc/with-db-transaction
+        [db-conn (db-ops/get-db-connection)]
+        (replace-main-hoks! hoks-id new-values db-conn)
+        (replace-oto! hoks-id (:opiskeluvalmiuksia-tukevat-opinnot new-values)
+                      db-conn)
+        (replace-hato! hoks-id (:hankittavat-ammat-tutkinnon-osat new-values)
+                       db-conn)
+        (replace-hpto! hoks-id
+                       (:hankittavat-paikalliset-tutkinnon-osat new-values)
+                       db-conn)
+        (replace-hyto! hoks-id (:hankittavat-yhteiset-tutkinnon-osat new-values)
+                       db-conn)
+        (replace-ahato! hoks-id
+                        (:aiemmin-hankitut-ammat-tutkinnon-osat new-values)
+                        db-conn)
+        (replace-ahpto! hoks-id (:aiemmin-hankitut-paikalliset-tutkinnon-osat
+                                  new-values)
+                        db-conn)
+        (replace-ahyto! hoks-id (:aiemmin-hankitut-yhteiset-tutkinnon-osat
+                                  new-values))))))
 
 (defn update-hoks! [hoks-id new-values]
   (db-hoks/update-hoks-by-id! hoks-id new-values))

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -245,21 +245,13 @@
                                   :audit-data
                                   {:new  hoks-values}))
                               (catch Exception e
-                                (cond
-                                  (= (:error (ex-data e))
-                                     :opiskeluoikeus-update)
+                                (if (= (:error (ex-data e)) :disallowed-update)
                                   (assoc
                                     (response/bad-request!
                                       {:error
-                                       "Opiskeluoikeus update not allowed!"})
+                                       (.getMessage e)})
                                     :audit-data {:new hoks-values})
-                                  (= (:error (ex-data e)) :oppija-update)
-                                  (assoc
-                                    (response/bad-request!
-                                      {:error
-                                       "Oppija-oid update not allowed!"})
-                                    :audit-data {:new hoks-values}))
-                                (throw e))))
+                                  (throw e)))))
 
                           (c-api/PATCH "/" request
                             :body [hoks-values hoks-schema/HOKSPaivitys]
@@ -272,21 +264,13 @@
                                   :audit-data
                                   {:new  hoks-values}))
                               (catch Exception e
-                                (cond
-                                  (= (:error (ex-data e))
-                                     :opiskeluoikeus-update)
+                                (if (= (:error (ex-data e)) :disallowed-update)
                                   (assoc
                                     (response/bad-request!
                                       {:error
-                                       "Opiskeluoikeus update not allowed!"})
+                                       (.getMessage e)})
                                     :audit-data {:new hoks-values})
-                                  (= (:error (ex-data e)) :oppija-update)
-                                  (assoc
-                                    (response/bad-request!
-                                      {:error
-                                       "Oppija-oid update not allowed!"})
-                                    :audit-data {:new hoks-values}))
-                                (throw e))))))
+                                  (throw e)))))))
 
                       (route-middleware
                         [m/wrap-oph-super-user]

--- a/test/oph/ehoks/hoks/handler_test.clj
+++ b/test/oph/ehoks/hoks/handler_test.clj
@@ -303,6 +303,24 @@
       (eq (:opiskeluvalmiuksia-tukevat-opinnot test-data/hoks-data)
           (:opiskeluvalmiuksia-tukevat-opinnot get-response-data)))))
 
+(deftest prevent-updating-hoks-with-existing-opiskeluoikeus
+  (testing "Prevent PUT HOKS with existing opiskeluoikeus"
+    (let [app (hoks-utils/create-app nil)
+          post-response
+          (hoks-utils/create-mock-post-request
+            ""
+            (dissoc test-data/hoks-data :opiskeluvalmiuksia-tukevat-opinnot)
+            app)
+          put-response (hoks-utils/create-mock-hoks-put-request
+                         1
+                         (-> test-data/hoks-data
+                             (assoc :id 1)
+                             (dissoc :opiskeluoikeus-oid :oppija-oid)
+                             (assoc :opiskeluoikeus-oid "1.2.246.562.15.00000000002"))
+                         app)]
+      (is (= (:status post-response) 200))
+      (is (= (:status put-response) 400)))))
+
 (deftest patching-of-hoks-part-not-allowed
   (testing "PATCH of HOKS can't be used to update sub entities of HOKS"
     (let [app (hoks-utils/create-app nil)

--- a/test/oph/ehoks/hoks/handler_test.clj
+++ b/test/oph/ehoks/hoks/handler_test.clj
@@ -316,7 +316,8 @@
                          (-> test-data/hoks-data
                              (assoc :id 1)
                              (dissoc :opiskeluoikeus-oid :oppija-oid)
-                             (assoc :opiskeluoikeus-oid "1.2.246.562.15.00000000002"))
+                             (assoc :opiskeluoikeus-oid
+                                    "1.2.246.562.15.00000000002"))
                          app)]
       (is (= (:status post-response) 200))
       (is (= (:status put-response) 400)))))

--- a/test/oph/ehoks/hoks/handler_test.clj
+++ b/test/oph/ehoks/hoks/handler_test.clj
@@ -303,7 +303,7 @@
       (eq (:opiskeluvalmiuksia-tukevat-opinnot test-data/hoks-data)
           (:opiskeluvalmiuksia-tukevat-opinnot get-response-data)))))
 
-(deftest prevent-updating-hoks-with-existing-opiskeluoikeus
+(deftest prevent-updating-opiskeluoikeus
   (testing "Prevent PUT HOKS with existing opiskeluoikeus"
     (let [app (hoks-utils/create-app nil)
           post-response
@@ -320,7 +320,30 @@
                                     "1.2.246.562.15.00000000002"))
                          app)]
       (is (= (:status post-response) 200))
-      (is (= (:status put-response) 400)))))
+      (is (= (:status put-response) 400))
+      (is (= (utils/parse-body (:body put-response))
+             {:error "Opiskeluoikeus update not allowed!"})))))
+
+(deftest prevent-updating-oppija-oid
+  (testing "Prevent PUT HOKS with existing opiskeluoikeus"
+    (let [app (hoks-utils/create-app nil)
+          post-response
+          (hoks-utils/create-mock-post-request
+            ""
+            (dissoc test-data/hoks-data :opiskeluvalmiuksia-tukevat-opinnot)
+            app)
+          put-response (hoks-utils/create-mock-hoks-put-request
+                         1
+                         (-> test-data/hoks-data
+                             (assoc :id 1)
+                             (dissoc :opiskeluoikeus-oid :oppija-oid)
+                             (assoc :oppija-oid
+                                    "1.2.246.562.24.12312312313"))
+                         app)]
+      (is (= (:status post-response) 200))
+      (is (= (:status put-response) 400))
+      (is (= (utils/parse-body (:body put-response))
+             {:error "Oppija-oid update not allowed!"})))))
 
 (deftest patching-of-hoks-part-not-allowed
   (testing "PATCH of HOKS can't be used to update sub entities of HOKS"

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -627,6 +627,60 @@
                  :privileges #{:read}}]})]
         (t/is (= (:status patch-response) 403))))))
 
+(t/deftest prevent-patch-hoks-with-updated-opiskeluoikeus
+  (t/testing "PATCH hoks virkailija"
+    (utils/with-db
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (let [post-response
+            (post-new-hoks
+              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010")
+            body (utils/parse-body (:body post-response))
+            hoks-url (get-in body [:data :uri])
+            patch-response
+            (with-test-virkailija
+              (mock/json-body
+                (mock/request
+                  :patch
+                  hoks-url)
+                {:osaamisen-hankkimisen-tarve true
+                 :id (get-in body [:meta :id])
+                 :opiskeluoikeus-oid "1.2.246.562.15.760000000011"})
+              {:name "Testivirkailija"
+               :kayttajaTyyppi "VIRKAILIJA"
+               :organisation-privileges
+               [{:oid "1.2.246.562.10.1200000000010"
+                 :privileges #{:write :read :update :delete}}]})]
+        (t/is (= (:status patch-response) 400))
+        (t/is (= (utils/parse-body (:body patch-response))
+                 {:error "Opiskeluoikeus update not allowed!"}))))))
+
+(t/deftest prevent-patch-hoks-with-updated-oppija-oid
+  (t/testing "PATCH hoks virkailija"
+    (utils/with-db
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (let [post-response
+            (post-new-hoks
+              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010")
+            body (utils/parse-body (:body post-response))
+            hoks-url (get-in body [:data :uri])
+            patch-response
+            (with-test-virkailija
+              (mock/json-body
+                (mock/request
+                  :patch
+                  hoks-url)
+                {:osaamisen-hankkimisen-tarve true
+                 :id (get-in body [:meta :id])
+                 :oppija-oid "1.2.246.562.10.1200000000011"})
+              {:name "Testivirkailija"
+               :kayttajaTyyppi "VIRKAILIJA"
+               :organisation-privileges
+               [{:oid "1.2.246.562.10.1200000000010"
+                 :privileges #{:write :read :update :delete}}]})]
+        (t/is (= (:status patch-response) 400))
+        (t/is (= (utils/parse-body (:body patch-response))
+                 {:error "Oppija-oid update not allowed!"}))))))
+
 (def hoks-data
   {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
    :oppija-oid "1.2.246.562.24.44000000001"


### PR DESCRIPTION
Lisätty siis put-kutsujen hanskaukseen vaan yksi selvitys, missä katsotaan, yritetäänkö päivittää opiskeluoikeus-oidia ja jos yritetään (eli lähetetty oid on eri kuin olemassaoleva oid), niin päräytetään virhe. Ja sama homma sitten oppija-oidille, kun eihän sitäkään saa korvata. 