### PR TITLE
Student info fix

### DIFF
--- a/src/oph/ehoks/external/oppijanumerorekisteri.clj
+++ b/src/oph/ehoks/external/oppijanumerorekisteri.clj
@@ -31,13 +31,32 @@
          :yhteystietoTyyppi :type}))
     contact-item))
 
-(defn- convert-contacts [group]
+(defn- has-value [contact]
+  (some? (:value contact)))
+
+(defn- remove-empty-contact-values [contact-item]
+  (filter has-value contact-item))
+
+(defn- convert-contacts [contact-groups]
   (map
     #(-> %
          (select-keys [:id :yhteystieto])
          (rename-keys {:yhteystieto :contact})
-         (update :contact convert-contact-values))
-    group))
+         (update :contact convert-contact-values)
+         (update :contact remove-empty-contact-values))
+    contact-groups))
+
+(defn- has-contact-info [contact-group]
+  (not-empty (:contact contact-group)))
+
+(defn- remove-empty-contact-groups [contact-groups]
+  (filter has-contact-info contact-groups))
+
+(defn- update-contacts [student-info]
+  (let [converted-student-info
+        (update student-info :contact-values-group convert-contacts)]
+    (update converted-student-info
+            :contact-values-group remove-empty-contact-groups)))
 
 (defn convert-student-info
   "Convert student info to snake case"
@@ -52,5 +71,5 @@
                           :kutsumanimi :common-name
                           :yhteystiedotRyhma :contact-values-group}))]
     (if (seq (:contact-values-group converted-values))
-      (update converted-values :contact-values-group convert-contacts)
+      (update-contacts converted-values)
       converted-values)))

--- a/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
+++ b/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
@@ -29,3 +29,111 @@
             '({:id 0
                :contact [{:value "kayttaja@domain.local"
                           :type "YHTEYSTIETO_SAHKOPOSTI"}]})}))))
+
+(def student-info {:oppijanumero "1.2.246.562.24.62444477777",
+                   :etunimet "Pauliina Joku",
+                   :asiointiKieli {:kieliKoodi "fi", :kieliTyyppi "suomi"},
+                   :syntymaaika "1975-04-20",
+                   :aidinkieli {:kieliKoodi "fi", :kieliTyyppi "suomi"},
+                   :sukunimi "Pouta",
+                   :kansalaisuus [{:kansalaisuusKoodi "246"}],
+                   :hetu "200475-0000",
+                   :oidHenkilo "1.2.246.562.24.62444477777",
+                   :kutsumanimi "Pauliina",
+                   :yhteystiedotRyhma
+                   [{:id 118888872,
+                     :ryhmaKuvaus "yhteystietotyyppi4",
+                     :ryhmaAlkuperaTieto "alkupera1",
+                     :yhteystieto
+                     [{:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE",
+                       :yhteystietoArvo "Mannerheimintie 20 E 15"}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_KAUPUNKI",
+                       :yhteystietoArvo "HELSINKI"}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_MAA",
+                       :yhteystietoArvo "Suomi"}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO",
+                       :yhteystietoArvo "00820"}]}
+                    {:id 118888877,
+                     :ryhmaKuvaus "yhteystietotyyppi8",
+                     :readOnly true,
+                     :yhteystieto [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI",
+                                    :yhteystietoArvo "testi.maili@gmail.com"}]}
+                    {:id 155888715,
+                     :ryhmaKuvaus "yhteystietotyyppi2",
+                     :ryhmaAlkuperaTieto "alkupera6",
+                     :yhteystieto
+                     [{:yhteystietoTyyppi "YHTEYSTIETO_KUNTA",
+                       :yhteystietoArvo nil}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_MATKAPUHELINNUMERO",
+                       :yhteystietoArvo nil}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE",
+                       :yhteystietoArvo nil}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO",
+                       :yhteystietoArvo nil}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI",
+                       :yhteystietoArvo "testi.maili@oph.fi"}
+                      {:yhteystietoTyyppi "YHTEYSTIETO_PUHELINNUMERO",
+                       :yhteystietoArvo nil}]}]})
+
+(def converted-student-info {:oid "1.2.246.562.24.62444477777"
+            :first-name "Pauliina Joku"
+            :surname "Pouta"
+            :common-name "Pauliina"
+            :contact-values-group
+            '({:id 118888872
+               :contact [{:value "Mannerheimintie 20 E 15"
+                          :type "YHTEYSTIETO_KATUOSOITE"}
+                         {:value "HELSINKI"
+                          :type "YHTEYSTIETO_KAUPUNKI"}
+                         {:value "Suomi"
+                          :type "YHTEYSTIETO_MAA"}
+                         {:value "00820"
+                          :type "YHTEYSTIETO_POSTINUMERO"}]}
+              {:id 118888877
+               :contact [{:value "testi.maili@gmail.com"
+                          :type "YHTEYSTIETO_SAHKOPOSTI"}]}
+              {:id 155888715
+               :contact [{:value "testi.maili@oph.fi"
+                          :type "YHTEYSTIETO_SAHKOPOSTI"}
+                         ]})})
+
+(deftest convert-nil-contact-info
+  (testing "nil contact values should be pruned"
+    (is (= (onr/convert-student-info student-info)
+           converted-student-info))))
+
+(deftest convert-all-nil-contact-info
+  (testing "contact group containg only nil contact values should be pruned"
+    (is (= (onr/convert-student-info
+             {:oppijanumero "1.2.246.562.24.62444477777",
+              :etunimet "Pauliina Joku",
+              :sukunimi "Pouta",
+              :oidHenkilo "1.2.246.562.24.62444477777",
+              :kutsumanimi "Pauliina",
+              :yhteystiedotRyhma
+              [{:id 118888872,
+                :yhteystieto [{:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE",
+                               :yhteystietoArvo "Mannerheimintie 20 E 15"}
+                              {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO",
+                               :yhteystietoArvo "00820"}]}
+               {:id 118888877,
+                :yhteystieto [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI",
+                               :yhteystietoArvo "testi.maili@gmail.com"}]}
+               {:id 155888715,
+                :yhteystieto [{:yhteystietoTyyppi "YHTEYSTIETO_KUNTA",
+                               :yhteystietoArvo nil}
+                              {:yhteystietoTyyppi "YHTEYSTIETO_PUHELINNUMERO",
+                               :yhteystietoArvo nil}]}]})
+           {:oid "1.2.246.562.24.62444477777"
+            :first-name "Pauliina Joku"
+            :surname "Pouta"
+            :common-name "Pauliina"
+            :contact-values-group
+            '({:id 118888872
+               :contact [{:value "Mannerheimintie 20 E 15"
+                          :type "YHTEYSTIETO_KATUOSOITE"}
+                         {:value "00820"
+                          :type "YHTEYSTIETO_POSTINUMERO"}]}
+              {:id 118888877
+               :contact [{:value "testi.maili@gmail.com"
+                          :type "YHTEYSTIETO_SAHKOPOSTI"}]})}))))

--- a/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
+++ b/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
@@ -76,26 +76,25 @@
                        :yhteystietoArvo nil}]}]})
 
 (def converted-student-info {:oid "1.2.246.562.24.62444477777"
-            :first-name "Pauliina Joku"
-            :surname "Pouta"
-            :common-name "Pauliina"
-            :contact-values-group
-            '({:id 118888872
-               :contact [{:value "Mannerheimintie 20 E 15"
-                          :type "YHTEYSTIETO_KATUOSOITE"}
-                         {:value "HELSINKI"
-                          :type "YHTEYSTIETO_KAUPUNKI"}
-                         {:value "Suomi"
-                          :type "YHTEYSTIETO_MAA"}
-                         {:value "00820"
-                          :type "YHTEYSTIETO_POSTINUMERO"}]}
-              {:id 118888877
-               :contact [{:value "testi.maili@gmail.com"
-                          :type "YHTEYSTIETO_SAHKOPOSTI"}]}
-              {:id 155888715
-               :contact [{:value "testi.maili@oph.fi"
-                          :type "YHTEYSTIETO_SAHKOPOSTI"}
-                         ]})})
+                             :first-name "Pauliina Joku"
+                             :surname "Pouta"
+                             :common-name "Pauliina"
+                             :contact-values-group
+                             '({:id 118888872
+                                :contact [{:value "Mannerheimintie 20 E 15"
+                                           :type "YHTEYSTIETO_KATUOSOITE"}
+                                          {:value "HELSINKI"
+                                           :type "YHTEYSTIETO_KAUPUNKI"}
+                                          {:value "Suomi"
+                                           :type "YHTEYSTIETO_MAA"}
+                                          {:value "00820"
+                                           :type "YHTEYSTIETO_POSTINUMERO"}]}
+                                {:id 118888877
+                                 :contact [{:value "testi.maili@gmail.com"
+                                            :type "YHTEYSTIETO_SAHKOPOSTI"}]}
+                                {:id 155888715
+                                 :contact [{:value "testi.maili@oph.fi"
+                                            :type "YHTEYSTIETO_SAHKOPOSTI"}]})})
 
 (deftest convert-nil-contact-info
   (testing "nil contact values should be pruned"
@@ -134,6 +133,6 @@
                           :type "YHTEYSTIETO_KATUOSOITE"}
                          {:value "00820"
                           :type "YHTEYSTIETO_POSTINUMERO"}]}
-              {:id 118888877
-               :contact [{:value "testi.maili@gmail.com"
-                          :type "YHTEYSTIETO_SAHKOPOSTI"}]})}))))
+               {:id 118888877
+                :contact [{:value "testi.maili@gmail.com"
+                           :type "YHTEYSTIETO_SAHKOPOSTI"}]})}))))


### PR DESCRIPTION
Jos oppijanumerorekisteristä palautui null-arvoja yhteystietoihin liittyen, vastaus ei mennyt skeemavalidoinnista läpi joten nyt filtteröidään null tiedot pois ja jos koko contact groupin arvot ovat nullia karsitaan group vastauksesta pois.