### PR TITLE
New api for yllapito

### DIFF
--- a/resources/db/hoksit/select_count_all_hoksit.sql
+++ b/resources/db/hoksit/select_count_all_hoksit.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(DISTINCT id) FROM hoksit

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -296,3 +296,7 @@
   (db-ops/query
     [queries/select-kyselylinkit-by-oppija-oid oid]
     {:row-fn db-ops/from-sql}))
+
+(defn select-count-all-hoks []
+  (db-ops/query
+    [queries/select-count-all-hoks]))

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -47,6 +47,7 @@
                       (generate-select-by (parse-sql (str (quote ~query-name))))
                       (read-sql-file (cstr/join (quote ~filename))))))
 
+(defq select-count-all-hoks "hoksit/select_count_all_hoksit.sql")
 (defq select-hoksit "hoksit/select.sql")
 (defq select-hoksit-by-oppija-oid)
 (defq select-hoksit-by-id)

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -32,6 +32,11 @@
          (:koulutustoimija-oid params)
          (db-opiskeluoikeus/get-like (:nimi params))]))))
 
+(defn get-amount-of-hoks
+  "Get total amount of hokses now"
+  []
+  (first (db-hoks/select-count-all-hoks)))
+
 (defn get-oppijat-without-index
   "Get hoks oppijat without index"
   []

--- a/src/oph/ehoks/virkailija/schema.clj
+++ b/src/oph/ehoks/virkailija/schema.clj
@@ -21,4 +21,5 @@
             :max Long}
    :oppijaindex {:unindexedOppijat Long
                  :unindexedOpiskeluoikeudet Long
-                 :unindexedTutkinnot Long}})
+                 :unindexedTutkinnot Long}
+   :hoksit {:amount s/Any}})

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -7,7 +7,10 @@
             [oph.ehoks.external.cache :as c]
             [oph.ehoks.oppijaindex :as op]
             [clojure.core.async :as a]
-            [ring.util.http-response :as response]))
+            [ring.util.http-response :as response]
+            [clojure.tools.logging :as log]
+            [oph.ehoks.db.db-operations.hoks :as db-hoks]
+            [schema.core :as s]))
 
 (def routes
   (route-middleware
@@ -28,7 +31,8 @@
             :unindexedOpiskeluoikeudet
             (op/get-opiskeluoikeudet-without-index-count)
             :unindexedTutkinnot
-            (op/get-opiskeluoikeudet-without-tutkinto-count)}})))
+            (op/get-opiskeluoikeudet-without-tutkinto-count)}
+           :hoksit {:amount (:count (op/get-amount-of-hoks))}})))
 
     (c-api/POST "/index" []
       :summary "Indeksoi oppijat ja opiskeluoikeudet"
@@ -41,4 +45,20 @@
     (c-api/DELETE "/cache" []
       :summary "Välimuistin tyhjennys"
       (c/clear-cache!)
-      (response/ok))))
+      (response/ok))
+
+    (c-api/GET "/opiskeluoikeus/:opiskeluoikeus-oid" request
+      :summary "Palauttaa HOKSin opiskeluoikeuden oidilla"
+      :path-params [opiskeluoikeus-oid :- s/Str]
+      :return (restful/response {:id s/Int})
+      (let [hoks (first (db-hoks/select-hoksit-by-opiskeluoikeus-oid
+                          opiskeluoikeus-oid))]
+        (if hoks
+          (do
+            (restful/rest-ok {:id (:id hoks)}))
+          (do
+            (log/warn "No HOKS found with given opiskeluoikeus "
+                      opiskeluoikeus-oid)
+            (response/not-found
+              {:error "No HOKS found with given opiskeluoikeus"})))))
+    ))

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -54,8 +54,7 @@
       (let [hoks (first (db-hoks/select-hoksit-by-opiskeluoikeus-oid
                           opiskeluoikeus-oid))]
         (if hoks
-          (do
-            (restful/rest-ok {:id (:id hoks)}))
+          (restful/rest-ok {:id (:id hoks)})
           (do
             (log/warn "No HOKS found with given opiskeluoikeus "
                       opiskeluoikeus-oid)

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -59,5 +59,4 @@
             (log/warn "No HOKS found with given opiskeluoikeus "
                       opiskeluoikeus-oid)
             (response/not-found
-              {:error "No HOKS found with given opiskeluoikeus"})))))
-    ))
+              {:error "No HOKS found with given opiskeluoikeus"})))))))


### PR DESCRIPTION
Tässä branchissa siis apit sitä varten, että ylläpitovälilehdelle saa näytettyä hoksien koko lukumäärän sekä haettua opiskeluoikeudella hoks-id:n, kun tätä asiakas on paljon kysellyt (ja sitten mä kaivelen näitä tuotannon kannasta). 

Pistin nämä systemhandleriin, kun siinä on näppärästi ne superuser-oikat tarkastettuna ja tämähän on vaan oph-pääkäyttäjä-oikille tarkoitettu. Muuten käytetään aikalailla olemassaolevia juttuja, yhden queryn kirjoitin kans.

(Frontin muutokset ovat branchissa new-buttons-for-yllapito, josta teen oman pr:n aikanaan. )

![Screenshot 2020-02-26 at 16 39 51](https://user-images.githubusercontent.com/4289418/75356299-721dbe00-58b8-11ea-9953-bf82dca6cdf8.png)
