### PR TITLE
Eh 889 hankintakoulutuksen toteuttaja

### DIFF
--- a/src/db/migration/V1_1586954509834__Add_hankintakoulutus_info_to_opiskeluoikeus.sql
+++ b/src/db/migration/V1_1586954509834__Add_hankintakoulutus_info_to_opiskeluoikeus.sql
@@ -1,0 +1,4 @@
+ALTER TABLE opiskeluoikeudet
+    ADD COLUMN hankintakoulutus_jarjestaja_oid VARCHAR(256);
+ALTER TABLE opiskeluoikeudet
+    ADD COLUMN hankintakoulutus_opiskeluoikeus_oid VARCHAR(256);

--- a/src/oph/ehoks/external/koski.clj
+++ b/src/oph/ehoks/external/koski.clj
@@ -75,3 +75,8 @@
   (get-in
     (get-opiskeluoikeus-info opiskeluoikeus-oid)
     [:oppilaitos :oid]))
+
+(defn fetch-opiskeluoikeudet-by-oppija-id
+  "Fetches list of opiskeluoikeudet from Koski for oppija"
+  [oppija-oid]
+  (get-oppija-opiskeluoikeudet oppija-oid))

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -293,7 +293,7 @@
           {:error (ex-message e)})
         :else (throw e)))))
 
-(defn- add-hankintakoulutukset [hoks opiskeluoikeudet]
+(defn- add-hankintakoulutukset-to-index [hoks opiskeluoikeudet]
   (oppijaindex/add-oppija-hankintakoulutukset opiskeluoikeudet
                                               (:opiskeluoikeus-oid hoks)
                                               (:oppija-oid hoks)))
@@ -333,7 +333,7 @@
           (check-opiskeluoikeus-match hoks opiskeluoikeudet)
           (add-oppija-to-index hoks)
           (add-opiskeluoikeus-to-index hoks)
-          (add-hankintakoulutukset hoks opiskeluoikeudet))
+          (add-hankintakoulutukset-to-index hoks opiskeluoikeudet))
         (m/check-hoks-access! hoks request)
         (save-hoks hoks request))
 

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -17,6 +17,7 @@
             [oph.ehoks.logging.audit :refer [wrap-audit-logger]]
             [schema.core :as s]
             [oph.ehoks.oppijaindex :as oppijaindex]
+            [oph.ehoks.external.koski :as koski]
             [oph.ehoks.hoks.middleware :as m]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
             [cheshire.core :as cheshire]))
@@ -328,7 +329,7 @@
         :summary "Luo uuden HOKSin"
         :body [hoks hoks-schema/HOKSLuonti]
         :return (rest/response schema/POSTResponse :id s/Int)
-        (let [opiskeluoikeudet (oppijaindex/fetch-opiskeluoikeudet-by-oppija-id
+        (let [opiskeluoikeudet (koski/fetch-opiskeluoikeudet-by-oppija-id
                                  (:oppija-oid hoks))]
           (check-opiskeluoikeus-match hoks opiskeluoikeudet)
           (add-oppija-to-index hoks)

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -275,11 +275,6 @@
 (defn set-opiskeluoikeus-paattynyt! [oid timestamp]
   (db-opiskeluoikeus/update-opiskeluoikeus! oid {:paattynyt timestamp}))
 
-(defn fetch-opiskeluoikeudet-by-oppija-id
-  "Fetches list of opiskeluoikeudet from Koski for oppija"
-  [oppija-oid]
-  (k/get-oppija-opiskeluoikeudet oppija-oid))
-
 (defn oppija-opiskeluoikeus-match?
   "Check that opiskeluoikeus belongs to oppija"
   [opiskeluoikeudet opiskeluoikeus-oid]

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -149,6 +149,22 @@
   (db-opiskeluoikeus/insert-opiskeluoikeus!
     (get-opiskeluoikeus-info oid oppija-oid)))
 
+(defn- insert-hankintakoulutus-opiskeluoikeus!
+  [opiskeluoikeus-oid oppija-oid opiskeluoikeus]
+  (let [jarjestaja_oid (get-in opiskeluoikeus
+                               [:sisältyyOpiskeluoikeuteen :oppilaitos :oid])
+        opiskeluoikeus_oid (get-in opiskeluoikeus
+                                   [:sisältyyOpiskeluoikeuteen :oid])]
+    (try
+      (db-opiskeluoikeus/insert-opiskeluoikeus!
+        (assoc
+          (get-opiskeluoikeus-info opiskeluoikeus-oid oppija-oid)
+          :hankintakoulutus_jarjestaja_oid jarjestaja_oid
+          :hankintakoulutus_opiskeluoikeus_oid opiskeluoikeus_oid))
+      (catch Exception e
+        (log-opiskeluoikeus-insert-error! opiskeluoikeus-oid oppija-oid e)
+        (throw e)))))
+
 (defn- insert-new-opiskeluoikeus-without-error-forwarding! [oid oppija-oid]
   (try
     (insert-opiskeluoikeus oid oppija-oid)
@@ -259,12 +275,31 @@
 (defn set-opiskeluoikeus-paattynyt! [oid timestamp]
   (db-opiskeluoikeus/update-opiskeluoikeus! oid {:paattynyt timestamp}))
 
+(defn fetch-opiskeluoikeudet-by-oppija-id
+  "Fetches list of opiskeluoikeudet from Koski for oppija"
+  [oppija-oid]
+  (k/get-oppija-opiskeluoikeudet oppija-oid))
+
 (defn oppija-opiskeluoikeus-match?
   "Check that opiskeluoikeus belongs to oppija"
-  [oppija-oid opiskeluoikeus-oid]
+  [opiskeluoikeudet opiskeluoikeus-oid]
   (if (:enforce-opiskeluoikeus-match config)
-    (let [opiskeluoikeudet (k/get-oppija-opiskeluoikeudet oppija-oid)]
-      (boolean
-        (seq
-          (filter #(= opiskeluoikeus-oid (:oid %)) opiskeluoikeudet))))
+    (boolean
+      (seq
+        (filter #(= opiskeluoikeus-oid (:oid %)) opiskeluoikeudet)))
     true))
+
+(defn filter-hankintakoulutukset
+  "Filters hankintakoulutukset from opiskeluoikeudet"
+  [opiskeluoikeudet]
+  (if (seq? opiskeluoikeudet)
+    (filter :sisältyyOpiskeluoikeuteen opiskeluoikeudet)
+    (filter :sisältyyOpiskeluoikeuteen (list opiskeluoikeudet))))
+
+(defn add-oppija-hankintakoulutukset
+  "Adds all hankintakoulutukset for oppija"
+  [opiskeluoikeudet opiskeluoikeus-oid oppija-oid]
+  (let [hankintakoulutukset (filter-hankintakoulutukset opiskeluoikeudet)]
+    (doseq [hankintakoulutus hankintakoulutukset]
+      (insert-hankintakoulutus-opiskeluoikeus!
+        opiskeluoikeus-oid oppija-oid hankintakoulutus))))

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -284,9 +284,7 @@
   "Check that opiskeluoikeus belongs to oppija"
   [opiskeluoikeudet opiskeluoikeus-oid]
   (if (:enforce-opiskeluoikeus-match config)
-    (boolean
-      (seq
-        (filter #(= opiskeluoikeus-oid (:oid %)) opiskeluoikeudet)))
+    (some #(= opiskeluoikeus-oid (:oid %)) opiskeluoikeudet)
     true))
 
 (defn filter-hankintakoulutukset

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -174,7 +174,7 @@
 
 (defn- post-oppija [hoks request]
   (let [opiskeluoikeudet
-        (op/fetch-opiskeluoikeudet-by-oppija-id (:oppija-oid hoks))]
+        (koski/fetch-opiskeluoikeudet-by-oppija-id (:oppija-oid hoks))]
     (check-opiskeluoikeus-match hoks opiskeluoikeudet)
     (add-oppija hoks)
     (add-opiskeluoikeus hoks)

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -129,7 +129,7 @@
           {:error (ex-message e)})
         :else (throw e)))))
 
-(defn- add-hankintakoulutukset [hoks opiskeluoikeudet]
+(defn- add-hankintakoulutukset-to-index [hoks opiskeluoikeudet]
   (op/add-oppija-hankintakoulutukset opiskeluoikeudet
                                      (:opiskeluoikeus-oid hoks)
                                      (:oppija-oid hoks)))
@@ -178,7 +178,7 @@
     (check-opiskeluoikeus-match hoks opiskeluoikeudet)
     (add-oppija hoks)
     (add-opiskeluoikeus hoks)
-    (add-hankintakoulutukset hoks opiskeluoikeudet))
+    (add-hankintakoulutukset-to-index hoks opiskeluoikeudet))
   (check-virkailija-privileges hoks request)
   (save-hoks hoks request))
 

--- a/test/oph/ehoks/hoks/handler_test.clj
+++ b/test/oph/ehoks/hoks/handler_test.clj
@@ -20,7 +20,6 @@
     :hankittavat-yhteiset-tutkinnon-osat []
     :aiemmin-hankitut-paikalliset-tutkinnon-osat []
     :opiskeluvalmiuksia-tukevat-opinnot []))
-;; TODO: Refactor all the with-redefs parts into a single helper/place
 
 (deftest get-created-hoks
   (testing "GET newly created HOKS"

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -7,7 +7,6 @@
             [oph.ehoks.utils :as utils :refer [eq]]))
 
 (def base-url "/ehoks-virkailija-backend/api/v1/hoks")
-;; TODO: Refactor all the with-redefs parts into a single helper/place
 
 (defn create-app [session-store]
   (cache/clear-cache!)

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -315,3 +315,23 @@
             "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")))
       (t/is
         (nil? (sut/get-opiskeluoikeus-by-oid "1.2.246.562.15.00000000001"))))))
+
+(t/deftest hankintakoulutus-filter-test
+  (t/testing "Existing hankintakoulutus is filtered from opiskeluoikeudet"
+    (let [opiskeluoikeudet (assoc
+                             opiskeluoikeus-data
+                             :sisältyyOpiskeluoikeuteen
+                             {:oppilaitos {:oppilaitosnumero
+                                           {:koodiarvo "10076"}
+                                           :nimi
+                                           {:fi "Testi-yliopisto"
+                                            :sv "Testi-universitetet"
+                                            :en "Testi University"}}
+                              :oid "1.2.246.562.15.99999123"})]
+      (t/is
+        (= (count (sut/filter-hankintakoulutukset opiskeluoikeudet)) 1))))
+
+  (t/testing "Empty list returned if no hankintakoulutus in opiskeluoikeudet"
+    (let [opiskeluoikeudet opiskeluoikeus-data]
+      (t/is
+        (= (count (sut/filter-hankintakoulutukset opiskeluoikeudet)) 0)))))

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -259,28 +259,25 @@
 
 (t/deftest oppija-opiskeluoikeus-match-test
   (with-redefs [oph.ehoks.config/config {:enforce-opiskeluoikeus-match true}]
-    (t/testing "Opintooikeus belonging to oppija return true"
-      (utils/match-oppija-and-opintooikeus
-        "1.2.246.562.24.48727587473"
-        "1.2.246.562.15.55003456345")
+    (let [opiskeluoikeudet [{:oid "1.2.246.562.15.55003456345"
+                             :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                                    :nimi {:fi "TestiFi"
+                                           :sv "TestiSv"
+                                           :en "TestiEn"}}
+                             :alkamispäivä "2020-03-12"}]]
+
+      (t/testing "Opintooikeus belonging to oppija return true"
       (t/is
         (sut/oppija-opiskeluoikeus-match?
-          "1.2.246.562.24.48727587473"
-          "1.2.246.562.15.55003456345"))
-      (utils/reset-client-mocks))))
+          opiskeluoikeudet
+          "1.2.246.562.15.55003456345")))
 
-(t/deftest oppija-opiskeluoikeus-mismatch-test
-  (with-redefs [oph.ehoks.config/config {:enforce-opiskeluoikeus-match true}]
     (t/testing "Opintooikeus not belonging to oppija return false"
-      (utils/match-oppija-and-opintooikeus
-        "1.2.246.562.24.48727587473"
-        "1.2.246.562.15.55003456345")
       (t/is
         (not
           (sut/oppija-opiskeluoikeus-match?
-            "1.2.246.562.24.48727587473"
-            "1.2.246.562.15.55003456347")))
-      (utils/reset-client-mocks))))
+            opiskeluoikeudet
+            "1.2.246.562.15.55003456347")))))))
 
 (t/deftest hankintakoulutus-opiskeluoikeus-test
   (t/testing "Save opiskeluoikeus with sisältyyOpiskeluoikeuteen information"

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -261,23 +261,23 @@
   (with-redefs [oph.ehoks.config/config {:enforce-opiskeluoikeus-match true}]
     (let [opiskeluoikeudet [{:oid "1.2.246.562.15.55003456345"
                              :oppilaitos {:oid "1.2.246.562.10.12000000000"
-                                    :nimi {:fi "TestiFi"
-                                           :sv "TestiSv"
-                                           :en "TestiEn"}}
+                                          :nimi {:fi "TestiFi"
+                                                 :sv "TestiSv"
+                                                 :en "TestiEn"}}
                              :alkamispäivä "2020-03-12"}]]
 
       (t/testing "Opintooikeus belonging to oppija return true"
-      (t/is
-        (sut/oppija-opiskeluoikeus-match?
-          opiskeluoikeudet
-          "1.2.246.562.15.55003456345")))
-
-    (t/testing "Opintooikeus not belonging to oppija return false"
-      (t/is
-        (not
+        (t/is
           (sut/oppija-opiskeluoikeus-match?
             opiskeluoikeudet
-            "1.2.246.562.15.55003456347")))))))
+            "1.2.246.562.15.55003456345")))
+
+      (t/testing "Opintooikeus not belonging to oppija return false"
+        (t/is
+          (not
+            (sut/oppija-opiskeluoikeus-match?
+              opiskeluoikeudet
+              "1.2.246.562.15.55003456347")))))))
 
 (t/deftest hankintakoulutus-opiskeluoikeus-test
   (t/testing "Save opiskeluoikeus with sisältyyOpiskeluoikeuteen information"

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -140,12 +140,12 @@
           {:status 200
            :body [{:henkilö {:oid "1.2.246.562.24.44000000001"}
                    :opiskeluoikeudet
-                            [{:oid "1.2.246.562.15.76000000001"
-                              :oppilaitos {:oid "1.2.246.562.10.12000000000"
-                                           :nimi {:fi "TestiFi"
-                                                  :sv "TestiSv"
-                                                  :en "TestiEn"}}
-                              :alkamispäivä "2020-03-12"}]}]})))
+                   [{:oid "1.2.246.562.15.76000000001"
+                     :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                                  :nimi {:fi "TestiFi"
+                                         :sv "TestiSv"
+                                         :en "TestiEn"}}
+                     :alkamispäivä "2020-03-12"}]}]})))
     (client/set-get!
       (fn [url options]
         (cond (.endsWith url "/serviceValidate")

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -134,7 +134,18 @@
            :headers {"location" "http://test.ticket/1234"}}
           (= url "http://test.ticket/1234")
           {:status 200
-           :body "ST-1234-testi"})))
+           :body "ST-1234-testi"}
+          (.endsWith
+            url "/koski/api/sure/oids")
+          {:status 200
+           :body [{:henkilö {:oid "1.2.246.562.24.44000000001"}
+                   :opiskeluoikeudet
+                            [{:oid "1.2.246.562.15.76000000001"
+                              :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                                           :nimi {:fi "TestiFi"
+                                                  :sv "TestiSv"
+                                                  :en "TestiEn"}}
+                              :alkamispäivä "2020-03-12"}]}]})))
     (client/set-get!
       (fn [url options]
         (cond (.endsWith url "/serviceValidate")
@@ -197,21 +208,6 @@
       result))
   ([app request]
     (with-service-ticket app request nil)))
-
-(defn match-oppija-and-opintooikeus [oppija-oid opiskeluoikeus-oid]
-  (client/set-post!
-    (fn [url options]
-      (cond
-        (.endsWith url "/koski/api/sure/oids")
-        {:status 200
-         :body [{:henkilö {:oid oppija-oid}
-                 :opiskeluoikeudet
-                 [{:oid opiskeluoikeus-oid
-                   :oppilaitos
-                   {:oid "1.2.246.562.10.12944436166"}}]}]}))))
-
-(defn reset-client-mocks []
-  (client/reset-functions!))
 
 (defn parse-body [body]
   (cheshire/parse-string (slurp body) true))

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -78,7 +78,20 @@
            (.endsWith
              url "/koski/api/opiskeluoikeus/1.2.246.562.15.000000000020")
            {:status 200
-            :body {:oppilaitos {:oid "1.2.246.562.10.1200000000200"}}}))]
+            :body {:oppilaitos {:oid "1.2.246.562.10.1200000000200"}}}))
+       (fn [url options]
+         (cond
+           (.endsWith
+             url "/koski/api/sure/oids")
+           {:status 200
+            :body [{:henkilö {:oid "1.2.246.562.24.44000000001"}
+                    :opiskeluoikeudet
+                    [{:oid "1.2.246.562.15.76000000001"
+                      :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                                   :nimi {:fi "TestiFi"
+                                          :sv "TestiSv"
+                                          :en "TestiEn"}}
+                      :alkamispäivä "2020-03-12"}]}]}))]
       (let [session "12345678-1234-1234-1234-1234567890ab"
             cookie (str "ring-session=" session)
             store (atom


### PR DESCRIPTION
Lisätty hoksien luontiin steppi missä lisätään mahdolliset hankintakoulutus-opiskeluoikeudet kantaan. Erottelu muista opiskeluoikeuksista sen perusteella, että hankintakoulutuksissa kannassa on järjestäjän ja opiskeluoikeuden oidit. Rajapinta näiden hakemiselle on varmaan parempi tehdä kunhan näitä tarvitaan käytännössä.