### PR TITLE
Eh 980 jakolinkkitauluun hoks

### DIFF
--- a/src/db/migration/V1_1590752147461__Add_hoks_id_to_shared_modules.sql
+++ b/src/db/migration/V1_1590752147461__Add_hoks_id_to_shared_modules.sql
@@ -1,0 +1,4 @@
+ALTER TABLE shared_modules
+    ADD COLUMN hoks_eid VARCHAR(36) NOT NULL,
+    ADD CONSTRAINT shared_modules__hoksit__fkey
+        FOREIGN KEY (hoks_eid) REFERENCES hoksit (eid);

--- a/src/oph/ehoks/oppija/schema.clj
+++ b/src/oph/ehoks/oppija/schema.clj
@@ -20,7 +20,8 @@
    :shared-module-uuid java.util.UUID
    :shared-module-tyyppi s/Str
    :voimassaolo-alku LocalDate
-   :voimassaolo-loppu LocalDate})
+   :voimassaolo-loppu LocalDate
+   :hoks-eid s/Str})
 
 (s/defschema
   JakolinkkiLuonti
@@ -30,4 +31,5 @@
    :shared-module-uuid s/Str
    :shared-module-tyyppi s/Str
    :voimassaolo-alku LocalDate
-   :voimassaolo-loppu LocalDate})
+   :voimassaolo-loppu LocalDate
+   :hoks-eid s/Str})


### PR DESCRIPTION
Jakolinkkiä luodessa vaaditaan nyt myös hoksin eid, jotta linkkiin liittyvien tietojen hakeminen myöhemmin olisi helpompaa.