### PR TITLE
Eh 1034 fix update opiskeluoikeus

### DIFF
--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -64,11 +64,11 @@
 
     (c-api/DELETE "/opiskeluoikeus/:opiskeluoikeus-oid" request
       :summary "Poistaa ja hakee uudelleen tiedot opiskeluoikeusindeksiin"
-      :path-params [oid :- s/Str]
+      :path-params [opiskeluoikeus-oid :- s/Str]
       (when
-       (pos? (first (db-opiskeluoikeus/delete-opiskeluoikeus-from-index! oid)))
+       (pos? (first (db-opiskeluoikeus/delete-opiskeluoikeus-from-index! opiskeluoikeus-oid)))
         (a/go
-          (op/update-oppijat-without-index!)
+          (op/update-opiskeluoikeudet-without-index!)
           (response/ok))))
 
     (c-api/DELETE "/opiskeluoikeudet/:koulutustoimija-oid" request
@@ -79,7 +79,7 @@
                     (db-opiskeluoikeus/delete-from-index-by-koulutustoimija!
                       koulutustoimija-oid)))
         (a/go
-          (op/update-oppijat-without-index!)
+          (op/update-opiskeluoikeudet-without-index!)
           (response/ok))))
 
     (c-api/GET "/opiskeluoikeudet/:koulutustoimija-oid/deletion-info" request

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -66,7 +66,8 @@
       :summary "Poistaa ja hakee uudelleen tiedot opiskeluoikeusindeksiin"
       :path-params [opiskeluoikeus-oid :- s/Str]
       (when
-       (pos? (first (db-opiskeluoikeus/delete-opiskeluoikeus-from-index! opiskeluoikeus-oid)))
+       (pos? (first (db-opiskeluoikeus/delete-opiskeluoikeus-from-index!
+                      opiskeluoikeus-oid)))
         (a/go
           (op/update-opiskeluoikeudet-without-index!)
           (response/ok))))


### PR DESCRIPTION
Huomasin, että tuossa edellisessä mergetyssä haarassa eh-1034 oli sittenkin virhe system-handlerissa, jossa käytettiin oid query paramsina, vaikka urlissa oli opiskeluoikeus-oid. Lisäksi kutsuttiin oppijaindeksin päivitystä, vaikka piti päivittää opiskeluoikeusindeksiä. 