### PR TITLE
Eh 981 return object for share info

### DIFF
--- a/src/oph/ehoks/oppija/schema.clj
+++ b/src/oph/ehoks/oppija/schema.clj
@@ -24,8 +24,8 @@
    :osaamisala-nimi Translated
    :voimassaolo-alku LocalDate
    :voimassaolo-loppu LocalDate
-   :osaamisen-osoittaminen (s/maybe [OsaamisenOsoittaminen])
-   :osaamisen-hankkimistapa (s/maybe [OsaamisenHankkimistapa])
+   :osaamisen-osoittaminen (s/maybe OsaamisenOsoittaminen)
+   :osaamisen-hankkimistapa (s/maybe OsaamisenHankkimistapa)
    :tutkinnonosa-tyyppi s/Str
    :tutkinnonosa s/Any})
 

--- a/src/oph/ehoks/oppija/share_handler.clj
+++ b/src/oph/ehoks/oppija/share_handler.clj
@@ -34,8 +34,8 @@
           tutkinnonosa (get-tutkinnonosa-details
                          (:tutkinnonosa-tyyppi jakolinkki)
                          (:tutkinnonosa-module-uuid jakolinkki))
-          module (h/get-osaamisenosoittaminen-or-hankkimistapa-of-jakolinkki
-                   jakolinkki)]
+          module (first (h/get-osaamisenosoittaminen-or-hankkimistapa-of-jakolinkki
+                   jakolinkki))]
       (cond
         (= (:shared-module-tyyppi jakolinkki) "osaamisenhankkiminen")
         (assoc oppija

--- a/src/oph/ehoks/oppija/share_handler.clj
+++ b/src/oph/ehoks/oppija/share_handler.clj
@@ -36,7 +36,7 @@
                          (:tutkinnonosa-module-uuid jakolinkki))
           module (first
                    (h/get-osaamisenosoittaminen-or-hankkimistapa-of-jakolinkki
-                   jakolinkki))]
+                     jakolinkki))]
       (cond
         (= (:shared-module-tyyppi jakolinkki) "osaamisenhankkiminen")
         (assoc oppija

--- a/src/oph/ehoks/oppija/share_handler.clj
+++ b/src/oph/ehoks/oppija/share_handler.clj
@@ -34,7 +34,8 @@
           tutkinnonosa (get-tutkinnonosa-details
                          (:tutkinnonosa-tyyppi jakolinkki)
                          (:tutkinnonosa-module-uuid jakolinkki))
-          module (first (h/get-osaamisenosoittaminen-or-hankkimistapa-of-jakolinkki
+          module (first
+                   (h/get-osaamisenosoittaminen-or-hankkimistapa-of-jakolinkki
                    jakolinkki))]
       (cond
         (= (:shared-module-tyyppi jakolinkki) "osaamisenhankkiminen")

--- a/test/oph/ehoks/oppija/share_handler_test.clj
+++ b/test/oph/ehoks/oppija/share_handler_test.clj
@@ -122,8 +122,7 @@
                                share-id)))
           data (:data (utils/parse-body (:body response)))]
       (t/is (= 200 (:status response)))
-      (t/is (= (get-in data [:osaamisen-hankkimistapa 0
-                             :module-id]) module-uuid))
+      (t/is (= (:module-id (:osaamisen-hankkimistapa data)) module-uuid))
       (t/is (nil? (:osaamisen-osoittaminen data)))
       (t/is (= (get-in data [:tutkinnonosa :module-id]) tuo-uuid)))))
 
@@ -151,8 +150,7 @@
                                share-id)))
           data (:data (utils/parse-body (:body response)))]
       (t/is (= 200 (:status response)))
-      (t/is (= (get-in data [:osaamisen-osoittaminen 0
-                             :module-id]) module-uuid))
+      (t/is (= (:module-id (:osaamisen-osoittaminen data)) module-uuid))
       (t/is (nil? (:osaamisen-hankkimistapa data)))
       (t/is (= (get-in data [:tutkinnonosa :module-id]) tuo-uuid)))))
 
@@ -183,8 +181,7 @@
                                share-id)))
           data (:data (utils/parse-body (:body response)))]
       (t/is (= 200 (:status response)))
-      (t/is (= (get-in data [:osaamisen-osoittaminen 0
-                             :module-id]) module-uuid))
+      (t/is (= (:module-id (:osaamisen-osoittaminen data)) module-uuid))
       (t/is (nil? (:osaamisen-hankkimistapa data)))
       (t/is (= (get-in data [:tutkinnonosa :module-id]) tuo-uuid)))))
 
@@ -215,8 +212,7 @@
                                share-id)))
           data (:data (utils/parse-body (:body response)))]
       (t/is (= 200 (:status response)))
-      (t/is (= (get-in data [:osaamisen-hankkimistapa 0
-                             :module-id]) module-uuid))
+      (t/is (= (:module-id (:osaamisen-hankkimistapa data)) module-uuid))
       (t/is (nil? (:osaamisen-osoittaminen data)))
       (t/is (= (get-in data [:tutkinnonosa :module-id]) tuo-uuid)))))
 


### PR DESCRIPTION
Vaihdettiin sharehandlerin palautettavaksi arvoksi objekti arrayn sijaan, koska jaettavia osaamisen-osoittamisia tai osaamisen-hankkimistapoja on aina vain yksi. 