### PR TITLE
Eh 1001 uudelleenlähetys

### DIFF
--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -90,7 +90,6 @@
     (log/error "No työelämäpalaute queue!")))
 
 (defn send-palaute-resend-message [msg]
-  (log/info msg)
   (if (some? resend-queue-url)
     (send-message msg resend-queue-url)
     (log/error "No resend queue!")))

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -90,6 +90,7 @@
     (log/error "No työelämäpalaute queue!")))
 
 (defn send-palaute-resend-message [msg]
+  (log/info msg)
   (if (some? resend-queue-url)
     (send-message msg resend-queue-url)
     (log/error "No resend queue!")))

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -69,10 +69,15 @@
    :tyopaikkaohjaaja-nimi (:tyopaikkaohjaaja_nimi msg)})
 
 (defn send-message [msg queue-url]
-  (.sendMessage sqs-client (-> (SendMessageRequest/builder)
-                               (.queueUrl queue-url)
-                               (.messageBody (json/write-str msg))
-                               (.build))))
+  (let [resp (.sendMessage sqs-client (-> (SendMessageRequest/builder)
+                                          (.queueUrl queue-url)
+                                          (.messageBody (json/write-str msg))
+                                          (.build)))]
+    (when-not (some? (.messageId resp))
+      (log/error "Failed to send message " msg)
+      (throw (ex-info
+               "Failed to send SQS message"
+               {:error :sqs-error})))))
 
 (defn send-amis-palaute-message [msg]
   (if (some? herate-queue-url)

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -389,8 +389,11 @@
         (c-api/PATCH "/kyselylinkki" request
           :summary "Lisää lähetystietoja kyselylinkille"
           :body [data hoks-schema/kyselylinkki-lahetys]
-          (h/update-kyselylinkki! data)
-          (response/no-content)))
+          (let [res (h/update-kyselylinkki! data)]
+            (if (empty? res)
+              (response/not-found
+                {:error "No kyselylinkki found"})
+              (response/no-content)))))
 
       (c-api/context "/:hoks-id" []
 

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -389,11 +389,11 @@
         (c-api/PATCH "/kyselylinkki" request
           :summary "Lisää lähetystietoja kyselylinkille"
           :body [data hoks-schema/kyselylinkki-lahetys]
-          (let [res (h/update-kyselylinkki! data)]
-            (if (empty? res)
+          (let [updated-count (first (h/update-kyselylinkki! data))]
+            (if (pos? updated-count)
+              (response/no-content)
               (response/not-found
-                {:error "No kyselylinkki found"})
-              (response/no-content)))))
+                {:error "No kyselylinkki found"})))))
 
       (c-api/context "/:hoks-id" []
 

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -779,6 +779,8 @@
   {:kyselylinkki s/Str
    :alkupvm LocalDate
    :tyyppi s/Str
+   (s/optional-key :lahetyspvm) LocalDate
+   (s/optional-key :sahkoposti) s/Str
    (s/optional-key :lahetystila) s/Str})
 
 (s/defschema

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -790,5 +790,4 @@
 
 (s/defschema
   palaute-resend
-  {:alkupvm LocalDate
-   :tyyppi s/Str})
+  {:tyyppi s/Str})

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -335,12 +335,13 @@
                         (let [kyselylinkit
                               (heratepalvelu/get-oppija-kyselylinkit
                                 oppija-oid)
-                              kyselylinkki (first
-                                             (filter
-                                               #(and (= (:hoks-id %1) hoks-id)
-                                                     (= (:tyyppi %1)
-                                                        (:tyyppi data)))
-                                               kyselylinkit))
+                              kyselylinkki (:kyselylinkki
+                                             (first
+                                               (filter
+                                                 #(and (= (:hoks-id %1) hoks-id)
+                                                       (= (:tyyppi %1)
+                                                          (:tyyppi data)))
+                                                 kyselylinkit)))
                               hoks (db-hoks/select-hoks-by-id hoks-id)]
                           (sqs/send-palaute-resend-message
                             {:kyselylinkki kyselylinkki


### PR DESCRIPTION
- Muutettu uudelleenlähetyksen logiikka käyttämään kyselylinkkejä avainten päättelyn sijaan
- Lähetysdatan paych palauttaa 404 jos kyselylinkkiä ei löydy kannasta
- Lisätty tuplavarmistus sqs-viestien lähetyksen onnistumisesta (jos paluu arvossa ei ole messageId:tä, viestin jonoon asettamisessa on tapahtunut jotain outoa, mutta jos id löytyy viesti on jonossa normaalisti. Aws-sdk:n sqs-clientin pitäisi heittää virhettä tälläisissä tilanteissa, mutta puuttuvien herätteiden tutkimisesta on jäänyt tunne että viestejä on kadonnut jonnekin)