### PR TITLE
Eh 984 cas oppija error handling

### DIFF
--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -88,34 +88,17 @@
     (c-api/GET "/opintopolku2/" []
       :summary "Oppijan Opintopolku-kirjautumisen endpoint (CAS)"
       :query-params [ticket :- s/Str]
-      (throw (Exception. "Route not in use!"))
-      ;(let [cas-ticket-validation-result (cas/validate-oppija-ticket ticket)
-      ;      user-info (get-user-info-from-onr
-      ;                  (:user-oid cas-ticket-validation-result))]
-      ;  (assoc-in
-      ;    (assoc-in
-      ;      (response/see-other
-      ;        (u/get-url "ehoks-oppija-frontend-after-login"))
-      ;      [:session :user] user-info)
-      ;    [:session :ticket]
-      ;    ticket))
-
-      ;(let [validation-data (cas/validate-ticket
-      ;                        (u/get-url "ehoks.oppija-login-return")
-      ;                        ticket)]
-      ;
-      ;  (if (:success? validation-data)
-      ;    (let [ticket-user (kayttooikeus/get-user-details
-      ;                        (:user validation-data))]
-      ;      (assoc-in
-      ;        (assoc-in
-      ;          (response/see-other (u/get-url
-      ;               "ehoks-oppija-frontend-after-login"))
-      ;          [:session :oppija-user]
-      ;          (merge ticket-user (user/get-auth-info ticket-user)))
-      ;        [:session :ticket]
-      ;        ticket))
-      ;    (do (log/warnf "Ticket validation failed: %s"
-      ;                   (:error validation-data))
-      ;        (response/unauthorized {:error "Invalid ticket"}))))
-)))
+      (let [cas-ticket-validation-result (cas/validate-oppija-ticket ticket)
+            user-info (get-user-info-from-onr
+                        (:user-oid cas-ticket-validation-result))]
+        (if (:success? cas-ticket-validation-result)
+          (assoc-in
+            (assoc-in
+              (response/see-other
+                (u/get-url "ehoks-oppija-frontend-after-login"))
+              [:session :user] user-info)
+            [:session :ticket]
+            ticket)
+          (do (log/warnf "Ticket validation failed: %s"
+                         (:error cas-ticket-validation-result))
+              (response/unauthorized {:error "Invalid ticket"})))))))

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -21,7 +21,8 @@
         (select-keys [:oidHenkilo :hetu :etunimet :sukunimi :kutsumanimi])
         (clojure.set/rename-keys {:oidHenkilo :oid}))))
 
-(defn- respond-with-successful-authentication [user-info ticket]
+(defn- "Adds user-info and ticket to response to store them to session-store"
+  respond-with-successful-authentication [user-info ticket]
   (-> (response/see-other
         (u/get-url "ehoks-oppija-frontend-after-login"))
       (assoc-in [:session :user] user-info)

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -21,8 +21,9 @@
         (select-keys [:oidHenkilo :hetu :etunimet :sukunimi :kutsumanimi])
         (clojure.set/rename-keys {:oidHenkilo :oid}))))
 
-(defn- "Adds user-info and ticket to response to store them to session-store"
-  respond-with-successful-authentication [user-info ticket]
+(defn- respond-with-successful-authentication
+  "Adds user-info and ticket to response to store them to session-store"
+  [user-info ticket]
   (-> (response/see-other
         (u/get-url "ehoks-oppija-frontend-after-login"))
       (assoc-in [:session :user] user-info)

--- a/test/oph/ehoks/oppija/auth_handler_test.clj
+++ b/test/oph/ehoks/oppija/auth_handler_test.clj
@@ -77,24 +77,51 @@
              [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI"
                :yhteystietoArvo "testikayttaja@testi.fi"}]})}})
 
-;TODO work in progress, uncomment when oppija cas authentication is done
-;(deftest successful-cas-authentication
-;  (testing "Successful oppija authentication"
-;    (with-redefs [oph.ehoks.external.cas/call-cas-oppija-ticket-validation
-;                  ticket-validation-mock-response
-;                  oph.ehoks.external.oppijanumerorekisteri/find-student-by-oid
-;                  mock-oppijanumerorekisteri-response]
-;     (let [session-store (atom {})
-;           app (common-api/create-app handler/app-routes
-;                                      (test-session-store session-store))
-;           login-url (format
-;                  "%s/opintopolku2/?ticket=%s"
-;                  base-url
-;                  "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
-;           response (app (mock/request
-;                           :get
-;                           login-url))]
-;       (is (= (:status response) 303))))))
+(deftest successful-cas-authentication
+  (testing "Successful oppija authentication"
+    (with-redefs [oph.ehoks.external.cas/call-cas-oppija-ticket-validation
+                  ticket-validation-mock-response
+                  oph.ehoks.external.oppijanumerorekisteri/find-student-by-oid
+                  mock-oppijanumerorekisteri-response]
+     (let [session-store (atom {})
+           app (common-api/create-app handler/app-routes
+                                      (test-session-store session-store))
+           login-url (format
+                  "%s/opintopolku2/?ticket=%s"
+                  base-url
+                  "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
+           response (app (mock/request
+                           :get
+                           login-url))]
+       (is (= (:status response) 303))))))
+
+(defn ticket-validation-fail-mock-response [ticket]
+  {:status 200
+   :body
+   (str
+     "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>\n"
+     "<cas:authenticationFailure code=\"INVALID_TICKET\">"
+     "Ticket &#39;%s&#39; not recognized"
+     "</cas:authenticationFailure>\n"
+     "</cas:serviceResponse>\n")})
+
+(deftest failed-cas-authentication
+  (testing "Cas fails ticket validation"
+    (with-redefs [oph.ehoks.external.cas/call-cas-oppija-ticket-validation
+                  ticket-validation-fail-mock-response
+                  oph.ehoks.external.oppijanumerorekisteri/find-student-by-oid
+                  mock-oppijanumerorekisteri-response]
+      (let [session-store (atom {})
+            app (common-api/create-app handler/app-routes
+                                       (test-session-store session-store))
+            login-url (format
+                        "%s/opintopolku2/?ticket=%s"
+                        base-url
+                        "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
+            response (app (mock/request
+                            :get
+                            login-url))]
+        (is (= (:status response) 401))))))
 
 (deftest prevent-malformed-authentication
   (testing "Prevents malformed authentication"

--- a/test/oph/ehoks/oppija/auth_handler_test.clj
+++ b/test/oph/ehoks/oppija/auth_handler_test.clj
@@ -83,17 +83,17 @@
                   ticket-validation-mock-response
                   oph.ehoks.external.oppijanumerorekisteri/find-student-by-oid
                   mock-oppijanumerorekisteri-response]
-     (let [session-store (atom {})
-           app (common-api/create-app handler/app-routes
-                                      (test-session-store session-store))
-           login-url (format
-                  "%s/opintopolku2/?ticket=%s"
-                  base-url
-                  "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
-           response (app (mock/request
-                           :get
-                           login-url))]
-       (is (= (:status response) 303))))))
+      (let [session-store (atom {})
+            app (common-api/create-app handler/app-routes
+                                       (test-session-store session-store))
+            login-url (format
+                        "%s/opintopolku2/?ticket=%s"
+                        base-url
+                        "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
+            response (app (mock/request
+                            :get
+                            login-url))]
+        (is (= (:status response) 303))))))
 
 (defn ticket-validation-fail-mock-response [ticket]
   {:status 200


### PR DESCRIPTION
Oppijan cas-kirjautumiseen tarkastelu onko cas:n lähettämä ticket mennyt validoinnista läpi ja poikkeuksen heittäminen jos ei. Laitettu cas-kirjautumisen endpoint aktiiviseksi koska ei päästä enää etenemään jos cas:n validointi ei ole mennyt läpi. Endpoint nimettävä uudelleen kunhan cas-oppija otetaan käyttöön ja shibboleth kirjatuminen poistetaan.