### PR TITLE
Eh 984 cas oppija refinement

### DIFF
--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
@@ -84,7 +84,6 @@
           (get-in request [:query-params "service"]) cas-oppija-ticket)))
 
     (GET "/cas-oppija/serviceValidate" request
-      (println "tultiin mock service validointiin")
       (if (= (get-in request [:query-params "ticket"]) cas-oppija-ticket)
         (response/ok
           (format

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -18,7 +18,7 @@
   (let [response (onr/find-student-by-oid oid)
         user-info (:body response)]
     (-> user-info
-        (select-keys [:oidHenkilo :hetu :etunimet :sukunimi :kutsumanimi])
+        (select-keys [:oidHenkilo :etunimet :sukunimi :kutsumanimi])
         (clojure.set/rename-keys {:oidHenkilo :oid
                                   :etunimet :first-name
                                   :sukunimi :surname

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -19,7 +19,10 @@
         user-info (:body response)]
     (-> user-info
         (select-keys [:oidHenkilo :hetu :etunimet :sukunimi :kutsumanimi])
-        (clojure.set/rename-keys {:oidHenkilo :oid}))))
+        (clojure.set/rename-keys {:oidHenkilo :oid
+                                  :etunimet :first-name
+                                  :sukunimi :surname
+                                  :kutsumanimi :common-name}))))
 
 (defn- respond-with-successful-authentication
   "Adds user-info and ticket to response to store them to session-store"

--- a/src/oph/ehoks/oppija/settings_handler.clj
+++ b/src/oph/ehoks/oppija/settings_handler.clj
@@ -3,10 +3,12 @@
             [ring.util.http-response :as response]
             [oph.ehoks.schema :as schema]
             [oph.ehoks.restful :as rest]
-            [oph.ehoks.user-settings :as user-settings]))
+            [oph.ehoks.user-settings :as user-settings]
+            [schema.core :as s]))
 
 (def routes
   (c-api/context "/settings" []
+    :header-params [caller-id :- s/Str]
     (c-api/GET "/" request
       :summary "Istunnon käyttäjän asetukset"
       :return (rest/response schema/UserSettings)

--- a/test/oph/ehoks/oppija/settings_handler_test.clj
+++ b/test/oph/ehoks/oppija/settings_handler_test.clj
@@ -19,11 +19,13 @@
                                    :put
                                    base-url)
                                  (mock/header :cookie session-cookie)
+                                 (mock/header "Caller-Id" "test")
                                  (mock/json-body {})))
           get-response (app (-> (mock/request
                                   :get
                                   base-url)
-                                (mock/header :cookie session-cookie)))
+                                (mock/header :cookie session-cookie)
+                                (mock/header "Caller-Id" "test")))
           body (utils/parse-body (:body get-response))]
       (t/is (= (:status post-response) 201))
       (t/is (= (:status get-response) 200))


### PR DESCRIPTION
Oppijan sessioon tallennettiin oppijan tiedot eri kenttien nimillä kuin mitä bäkkärin skeemassa on. Nimetty kentät skeeman mukaiseksi. Lisätty vielä yksi puuttuva caller-id pakotus.