### PR TITLE
Eh 984 cas oppija logout

### DIFF
--- a/resources/dev/ehoks-oph.properties
+++ b/resources/dev/ehoks-oph.properties
@@ -51,8 +51,6 @@ koski.get-opiskeluoikeus=${koski-url}/opiskeluoikeus/$1
 
 lokalisointi-url=${virkailija-url}/lokalisointi/cxf/rest/v1/localisation
 
-virkailijan-tyopoyta=${virkailija-url}/virkailijan-tyopoyta
-
 organisaatio-service-url=${virkailija-url}/organisaatio-service/rest
 organisaatio-service.get-organisaatio=${organisaatio-service-url}/organisaatio/v4/$1
 organisaatio-service.find-organisaatiot=${organisaatio-service-url}/organisaatio/v4/findbyoids

--- a/resources/dev/ehoks-oph.properties
+++ b/resources/dev/ehoks-oph.properties
@@ -7,7 +7,6 @@ ehoks.virkailija-login-return=${ehoks-virkailija-backend-url}/api/v1/virkailija/
 ehoks-oppija-backend-url=${opintopolku-url}/ehoks-oppija-backend
 ehoks.oppija-login-return=${ehoks-oppija-backend-url}/api/v1/oppija/session/opintopolku2
 ehoks-virkailija-frontend=http://localhost:4000/ehoks-virkailija-ui
-ehoks-oppija-frontend-after-login=http://localhost:8080/ehoks/suunnittelu
 
 koodisto-service-url=${virkailija-url}/koodisto-service
 koodisto-service.get-latest-by-uri=${koodisto-service-url}/rest/codeelement/latest/$1

--- a/resources/dev/ehoks-oph.properties
+++ b/resources/dev/ehoks-oph.properties
@@ -23,6 +23,7 @@ cas.login=${cas-url}/login
 cas-oppija-url=${opintopolku-url}/cas-oppija
 cas-oppija.validate-service=${cas-oppija-url}/serviceValidate
 cas-oppija.login=${cas-oppija-url}/login
+cas-oppija.logout=${cas-oppija-url}/logout
 
 oppijanumerorekisteri-url=${virkailija-url}/oppijanumerorekisteri-service
 oppijanumerorekisteri.search-henkilo=${oppijanumerorekisteri-url}/henkilo

--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
@@ -83,6 +83,9 @@
           "%s/?ticket=%s"
           (get-in request [:query-params "service"]) cas-oppija-ticket)))
 
+    (GET "/cas-oppija/logout" request
+      (response/see-other (get-in request [:query-params "service"])))
+
     (GET "/cas-oppija/serviceValidate" request
       (if (= (get-in request [:query-params "ticket"]) cas-oppija-ticket)
         (response/ok

--- a/resources/prod/ehoks-oph.properties
+++ b/resources/prod/ehoks-oph.properties
@@ -7,7 +7,6 @@ ehoks.virkailija-login-return=${ehoks-virkailija-backend-url}/api/v1/virkailija/
 ehoks-oppija-backend-url=${opintopolku-url}/ehoks-oppija-backend
 ehoks.oppija-login-return=${ehoks-oppija-backend-url}/api/v1/oppija/session/opintopolku2
 ehoks-virkailija-frontend=${virkailija-url}/ehoks-virkailija-ui
-ehoks-oppija-frontend-after-login=${opintopolku-url}/ehoks/suunnittelu
 
 koodisto-service-url=${virkailija-url}/koodisto-service
 koodisto-service.get-latest-by-uri=${koodisto-service-url}/rest/codeelement/latest/$1

--- a/resources/prod/ehoks-oph.properties
+++ b/resources/prod/ehoks-oph.properties
@@ -51,8 +51,6 @@ koski.get-opiskeluoikeus=${koski-url}/opiskeluoikeus/$1
 
 lokalisointi-url=${virkailija-url}/lokalisointi/cxf/rest/v1/localisation
 
-virkailijan-tyopoyta=${virkailija-url}/virkailijan-tyopoyta
-
 organisaatio-service-url=${virkailija-url}/organisaatio-service/rest
 organisaatio-service.get-organisaatio=${organisaatio-service-url}/organisaatio/v4/$1
 organisaatio-service.find-organisaatiot=${organisaatio-service-url}/organisaatio/v4/findbyoids

--- a/resources/prod/ehoks-oph.properties
+++ b/resources/prod/ehoks-oph.properties
@@ -23,6 +23,7 @@ cas.login=${cas-url}/login
 cas-oppija-url=${opintopolku-url}/cas-oppija
 cas-oppija.validate-service=${cas-oppija-url}/serviceValidate
 cas-oppija.login=${cas-oppija-url}/login
+cas-oppija.logout=${cas-oppija-url}/logout
 
 oppijanumerorekisteri-url=${virkailija-url}/oppijanumerorekisteri-service
 oppijanumerorekisteri.search-henkilo=${oppijanumerorekisteri-url}/henkilo

--- a/src/oph/ehoks/misc/handler.clj
+++ b/src/oph/ehoks/misc/handler.clj
@@ -26,6 +26,18 @@
              "%s?service=%s"
              (u/get-url "cas-oppija.login")
              (u/get-url "ehoks.oppija-login-return"))}
+          {:cas-oppija-logout-url-fi
+           (format
+             "%s?service=%s/%s?lang=fi"
+             (u/get-url "cas-oppija.logout")
+             (:frontend-url-fi config)
+             (:frontend-url-path config))}
+          {:cas-oppija-logout-url-sv
+           (format
+             "%s?service=%s/%s?lang=sv"
+             (u/get-url "cas-oppija.logout")
+             (:frontend-url-sv config)
+             (:frontend-url-path config))}
           {:raamit-url (u/get-url "virkailija-raamit-url")}
           (select-keys config [:opintopolku-login-url-fi
                                :opintopolku-login-url-sv

--- a/src/oph/ehoks/misc/schema.clj
+++ b/src/oph/ehoks/misc/schema.clj
@@ -10,4 +10,6 @@
               :opintopolku-logout-url-sv s/Str
               :virkailija-login-url s/Str
               :cas-oppija-login-url s/Str
+              :cas-oppija-logout-url-fi s/Str
+              :cas-oppija-logout-url-sv s/Str
               :raamit-url s/Str})

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -27,8 +27,12 @@
 (defn- respond-with-successful-authentication
   "Adds user-info and ticket to response to store them to session-store"
   [user-info ticket]
+  (println "tullaaan autentikoinnin jalkeen redirectiin")
   (-> (response/see-other
-        (u/get-url "ehoks-oppija-frontend-after-login"))
+        (format
+          "%s/%s"
+          (:frontend-url-fi config)
+          (:frontend-url-path config)))
       (assoc-in [:session :user] user-info)
       (assoc-in [:session :ticket] ticket)))
 

--- a/src/oph/ehoks/oppija/auth_handler.clj
+++ b/src/oph/ehoks/oppija/auth_handler.clj
@@ -27,7 +27,14 @@
 (defn- respond-with-successful-authentication
   "Adds user-info and ticket to response to store them to session-store"
   [user-info ticket]
-  (println "tullaaan autentikoinnin jalkeen redirectiin")
+  ; There propably should be localized versions of /misc/environment route
+  ; return value for cas-oppija-login-url (same as logout urls). We could then
+  ; redirect here to the correct hostname based on locale.
+  ; Now when the student begins with www.studieinfo.fi/ehoks, after login
+  ; cas will call /api/v1/oppija/session/opintopolku which here below
+  ; redirects the student to www.opintopolku.fi/ehoks. However only the
+  ; hostname changes and user still has swedish ui as locale is
+  ; stored to cookie.
   (-> (response/see-other
         (format
           "%s/%s"


### PR DESCRIPTION
Lisätty logout route cas-oppijalle. Korjattu onnistuneen cas-kirjautumisen jälkeinen redirect ehoksin etusivulle, prod konfiguraatiossa käytettiin frontin hostnamen sijasta bäkkärin. Tähän redirectiin pitäisi mahdollisesti tehdä vielä localen päättely jotta studieinfo:sta ei kirjautumisen jälkeen päädytä opintopolkuun.