### PR TITLE
Eh 984 cas oppija login fix

### DIFF
--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
@@ -80,7 +80,7 @@
     (GET "/cas-oppija/login" request
       (response/see-other
         (format
-          "%s/?ticket=%s"
+          "%s?ticket=%s"
           (get-in request [:query-params "service"]) cas-oppija-ticket)))
 
     (GET "/cas-oppija/logout" request

--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_oppijanumerorekisteri_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_oppijanumerorekisteri_routes.clj
@@ -20,7 +20,7 @@
                  :ryhmaKuvaus "testiryhmä"
                  :yhteystieto
                  [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI"
-                   :yhteystietoArvo "testikayttaja@testi.fi"}
+                   :yhteystietoArvo "testikayttajaONR@testi.fi"}
                   {:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE"
                    :yhteystietoArvo "Mannerheimintie 12 b 3"}
                   {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO"
@@ -46,7 +46,7 @@
                :ryhmaKuvaus "testiryhmä"
                :yhteystieto
                [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI"
-                 :yhteystietoArvo "testikayttaja@testi.fi"}
+                 :yhteystietoArvo "testikayttajaONR@testi.fi"}
                 {:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE"
                  :yhteystietoArvo "Mannerheimintie 12 b 3"}
                 {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO"
@@ -76,7 +76,7 @@
                  :ryhmaKuvaus "testiryhmä"
                  :yhteystieto
                  [{:yhteystietoTyyppi "YHTEYSTIETO_SAHKOPOSTI"
-                   :yhteystietoArvo "testikayttaja@testi.fi"}
+                   :yhteystietoArvo "testikayttajaONR@testi.fi"}
                   {:yhteystietoTyyppi "YHTEYSTIETO_KATUOSOITE"
                    :yhteystietoArvo "Mannerheimintie 12 b 3"}
                   {:yhteystietoTyyppi "YHTEYSTIETO_POSTINUMERO"

--- a/src/oph/ehoks/misc/handler.clj
+++ b/src/oph/ehoks/misc/handler.clj
@@ -23,7 +23,7 @@
              (u/get-url "ehoks.virkailija-login-return"))}
           {:cas-oppija-login-url
            (format
-             "%s?service=%s"
+             "%s?service=%s/"
              (u/get-url "cas-oppija.login")
              (u/get-url "ehoks.oppija-login-return"))}
           {:cas-oppija-logout-url-fi


### PR DESCRIPTION
Korjattu cas-oppija kirjautuminen. Cas callback urlin lopusta puuttui kauttaviiva mikä aiheutti route not found virheen.