### PR TITLE
OY-3407

### DIFF
--- a/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija.sql
+++ b/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija.sql
@@ -1,5 +1,6 @@
 SELECT *
 FROM hoksit h
 LEFT OUTER JOIN opiskeluoikeudet oo
-ON h.opiskeluoikeus_oid = oo.oid
-WHERE oo.koulutustoimija_oid = ?;
+                ON h.opiskeluoikeus_oid = oo.oid
+WHERE oo.koulutustoimija_oid = ?
+  AND h.deleted_at IS NULL;

--- a/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija.sql
+++ b/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija.sql
@@ -1,0 +1,5 @@
+SELECT *
+FROM hoksit h
+LEFT OUTER JOIN opiskeluoikeudet oo
+ON h.opiskeluoikeus_oid = oo.oid
+WHERE oo.koulutustoimija_oid = ?;

--- a/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija_and_koski404.sql
+++ b/resources/db/hoksit/select_hoksit_by_oo_koulutustoimija_and_koski404.sql
@@ -3,4 +3,5 @@ FROM hoksit h
 LEFT OUTER JOIN opiskeluoikeudet oo
                 ON h.opiskeluoikeus_oid = oo.oid
 WHERE oo.koulutustoimija_oid = ?
+  AND oo.koski404 = true
   AND h.deleted_at IS NULL;

--- a/src/db/migration/V1_1648636681926__Add_koski404_to_opiskeluoikeudet.sql
+++ b/src/db/migration/V1_1648636681926__Add_koski404_to_opiskeluoikeudet.sql
@@ -1,2 +1,2 @@
 ALTER TABLE opiskeluoikeudet
-    ADD COLUMN koski404 BOOLEAN DEFAULT false;
+    ADD COLUMN koski404 BOOLEAN;

--- a/src/db/migration/V1_1648636681926__Add_koski404_to_opiskeluoikeudet.sql
+++ b/src/db/migration/V1_1648636681926__Add_koski404_to_opiskeluoikeudet.sql
@@ -1,0 +1,2 @@
+ALTER TABLE opiskeluoikeudet
+    ADD COLUMN koski404 BOOLEAN DEFAULT false;

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -498,7 +498,8 @@
     [queries/select-hoksit-by-ensikert-hyvaks-and-saavutettu-tiedot]
     {:row-fn db-ops/from-sql}))
 
-(defn select-hoksit-by-oo-koulutustoimija [koulutustoimija-oid]
+(defn select-hoksit-by-oo-koulutustoimija-and-koski404 [koulutustoimija-oid]
   (db-ops/query
-    [queries/select-hoksit-by-oo-koulutustoimija koulutustoimija-oid]
+    [queries/select-hoksit-by-oo-koulutustoimija-and-koski404
+     koulutustoimija-oid]
     {:row-fn db-ops/from-sql}))

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -497,3 +497,8 @@
   (db-ops/query
     [queries/select-hoksit-by-ensikert-hyvaks-and-saavutettu-tiedot]
     {:row-fn db-ops/from-sql}))
+
+(defn select-hoksit-by-oo-koulutustoimija [koulutustoimija-oid]
+  (db-ops/query
+    [queries/select-hoksit-by-oo-koulutustoimija koulutustoimija-oid]
+    {:row-fn db-ops/from-sql}))

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -146,6 +146,9 @@
 (defq select-hankittavat-paikalliset-tutkinnon-osat-by-module-id)
 (defq select-hankittavat-ammat-tutkinnon-osat-by-module-id)
 (defq select-hankittavat-yhteiset-tutkinnon-osat-by-module-id)
+(defq select-osaamisen-osoittamiset-by-module-id)
+(defq select-osaamisen-hankkimistavat-by-id)
+(defq select-osaamisen-hankkimistavat-by-module-id)
 (defq select-osaamisen-hankkimistavat-by-hoks-id-and-tunniste
       "hoksit/select_osaamisen_hankkimistavat_by_hoks_id_and_tunniste.sql")
 (defq select-kyselylinkit-by-oppija-oid
@@ -169,22 +172,5 @@
       "opiskeluoikeudet/select-hankintakoulutus-oids-by-master-oid.sql")
 (defq select-paattyneet-kyselylinkit-by-date-and-type-temp
       "heratepalvelu/select_paattyneet_kyselylinkit_by_date_and_type_temp.sql")
-(defq select-all-hatos-for-hoks "hoksit/select_all_hatos_for_hoks.sql")
-(defq select-one-hato "hoksit/select_one_hato.sql")
-(defq select-all-hptos-for-hoks "hoksit/select_all_hptos_for_hoks.sql")
-(defq select-one-hpto "hoksit/select_one_hpto.sql")
-(defq select-all-osa-alueet-for-yto "hoksit/select_all_osa_alueet_for_yto.sql")
-(defq select-osaamisen-hankkimistapa-by-id
-      "hoksit/select_osaamisen_hankkimistapa_by_id.sql")
-(defq select-osaamisen-hankkimistavat-by-module-id
-      "hoksit/select_osaamisen_hankkimistavat_by_module_id.sql")
-(defq select-osaamisen-osoittamiset-by-module-id
-      "hoksit/select_osaamisen_osoittamiset_by_module_id.sql")
-(defq select-all-ahatos-for-hoks "hoksit/select_all_ahatos_for_hoks.sql")
-(defq select-one-ahato "hoksit/select_one_ahato.sql")
-(defq select-all-ahptos-for-hoks "hoksit/select_all_ahptos_for_hoks.sql")
-(defq select-one-ahpto "hoksit/select_one_ahpto.sql")
-(defq select-all-osa-alueet-for-ahyto
-      "hoksit/select_all_osa_alueet_for_ahyto.sql")
-(defq select-all-ahytos-for-hoks "hoksit/select_all_ahytos_for_hoks.sql")
-(defq select-one-ahyto "hoksit/select_one_ahyto.sql")
+(defq select-hoksit-by-oo-koulutustoimija
+      "hoksit/select_hoksit_by_oo_koulutustoimija.sql")

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -172,5 +172,24 @@
       "opiskeluoikeudet/select-hankintakoulutus-oids-by-master-oid.sql")
 (defq select-paattyneet-kyselylinkit-by-date-and-type-temp
       "heratepalvelu/select_paattyneet_kyselylinkit_by_date_and_type_temp.sql")
+(defq select-all-hatos-for-hoks "hoksit/select_all_hatos_for_hoks.sql")
+(defq select-one-hato "hoksit/select_one_hato.sql")
+(defq select-all-hptos-for-hoks "hoksit/select_all_hptos_for_hoks.sql")
+(defq select-one-hpto "hoksit/select_one_hpto.sql")
+(defq select-all-osa-alueet-for-yto "hoksit/select_all_osa_alueet_for_yto.sql")
+(defq select-osaamisen-hankkimistapa-by-id
+      "hoksit/select_osaamisen_hankkimistapa_by_id.sql")
+(defq select-osaamisen-hankkimistavat-by-module-id
+      "hoksit/select_osaamisen_hankkimistavat_by_module_id.sql")
+(defq select-osaamisen-osoittamiset-by-module-id
+      "hoksit/select_osaamisen_osoittamiset_by_module_id.sql")
+(defq select-all-ahatos-for-hoks "hoksit/select_all_ahatos_for_hoks.sql")
+(defq select-one-ahato "hoksit/select_one_ahato.sql")
+(defq select-all-ahptos-for-hoks "hoksit/select_all_ahptos_for_hoks.sql")
+(defq select-one-ahpto "hoksit/select_one_ahpto.sql")
+(defq select-all-osa-alueet-for-ahyto
+      "hoksit/select_all_osa_alueet_for_ahyto.sql")
+(defq select-all-ahytos-for-hoks "hoksit/select_all_ahytos_for_hoks.sql")
+(defq select-one-ahyto "hoksit/select_one_ahyto.sql")
 (defq select-hoksit-by-oo-koulutustoimija
       "hoksit/select_hoksit_by_oo_koulutustoimija.sql")

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -188,5 +188,5 @@
       "hoksit/select_all_osa_alueet_for_ahyto.sql")
 (defq select-all-ahytos-for-hoks "hoksit/select_all_ahytos_for_hoks.sql")
 (defq select-one-ahyto "hoksit/select_one_ahyto.sql")
-(defq select-hoksit-by-oo-koulutustoimija
-      "hoksit/select_hoksit_by_oo_koulutustoimija.sql")
+(defq select-hoksit-by-oo-koulutustoimija-and-koski404
+      "hoksit/select_hoksit_by_oo_koulutustoimija_and_koski404.sql")

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -146,9 +146,6 @@
 (defq select-hankittavat-paikalliset-tutkinnon-osat-by-module-id)
 (defq select-hankittavat-ammat-tutkinnon-osat-by-module-id)
 (defq select-hankittavat-yhteiset-tutkinnon-osat-by-module-id)
-(defq select-osaamisen-osoittamiset-by-module-id)
-(defq select-osaamisen-hankkimistavat-by-id)
-(defq select-osaamisen-hankkimistavat-by-module-id)
 (defq select-osaamisen-hankkimistavat-by-hoks-id-and-tunniste
       "hoksit/select_osaamisen_hankkimistavat_by_hoks_id_and_tunniste.sql")
 (defq select-kyselylinkit-by-oppija-oid

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -73,5 +73,5 @@
       (c-api/POST "/opiskeluoikeus-update" request
         :summary "Päivittää aktiivisten hoksien opiskeluoikeudet Koskesta"
         :header-params [caller-id :- s/Str]
-        (future (h/refresh-opiskeluoikeus-hankintakoulutukset))
+        (future (h/update-opiskeluoikeudet))
         (response/no-content)))))

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -540,8 +540,9 @@
                           (:opiskeluoikeus-oid x))) x))
               hoksit-created-in-7-days))
           oo-oids (map :opiskeluoikeus-oid hokses-without-oo)]
-      (log/infof "Päivitetään %s hoksin opiskeluoikeus-hankintakoulutukset"
-                 (count hoksit))
+      (log/infof "Päivitetään opiskeluoikeus-indeksiin koski404 tietoja.
+                  Löydettiin %s hoksia ilman opiskeluoikeutta Koskessa."
+                 (count oo-oids))
       (doseq [oo-oid oo-oids]
         (let [opiskeluoikeus (db-oo/select-opiskeluoikeus-by-oid oo-oid)]
           (when (some? opiskeluoikeus)

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -303,6 +303,9 @@
 (defn set-opiskeluoikeus-paattynyt! [oid timestamp]
   (db-opiskeluoikeus/update-opiskeluoikeus! oid {:paattynyt timestamp}))
 
+(defn set-opiskeluoikeus-koski404 [oid]
+  (db-opiskeluoikeus/update-opiskeluoikeus! oid {:koski404 true}))
+
 (defn oppija-opiskeluoikeus-match?
   "Check that opiskeluoikeus belongs to oppija"
   [opiskeluoikeudet opiskeluoikeus-oid]

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -195,7 +195,7 @@
       (not (op/opiskeluoikeus-tila-inactive?
              (op/get-opiskeluoikeus-tila opiskeluoikeus))))))
 
-(defn get-hoksit-without-opiskeluoikeus-in-koski-by-koulutuksenjarjestaja
+(defn get-hoksit-without-oo-in-koski-by-koulutuksenjarjestaja
   [koulutustoimija-oid]
   (let [hoksit (db-hoks/select-hoksit-by-oo-koulutustoimija
                  koulutustoimija-oid)]
@@ -405,6 +405,14 @@
                 :header-params [caller-id :- s/Str]
                 :path-params [tunnus :- s/Str]
                 (delete-vastaajatunnus tunnus))
+
+              (c-api/GET "/missing-oo-hoksit/:koulutustoimijaoid" []
+                :summary "Palauttaa listan hokseista, joiden
+                          opiskeluoikeus puuttuu"
+                :header-params [caller-id :- s/Str]
+                :path-params [koulutustoimijaoid :- s/Str]
+                (get-hoksit-without-oo-in-koski-by-koulutuksenjarjestaja
+                  koulutustoimijaoid))
 
               (c-api/GET "/paattyneet-kyselylinkit-temp" request
                 :summary "Palauttaa tietoja kyselylinkkeihin liittyvistä

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -199,8 +199,19 @@
   [koulutustoimija-oid]
   (let [hoksit (db-hoks/select-hoksit-by-oo-koulutustoimija
                  koulutustoimija-oid)]
-    (restful/rest-ok {:count (count hoksit)
-                      :hoksit hoksit})))
+    (try
+      (let [hokses-without-oo
+            (filter
+              some?
+              (pmap
+                (fn [x]
+                  (when (nil?
+                          (koski/get-opiskeluoikeus-info
+                            (:opiskeluoikeus-oid x))) x)) hoksit))]
+        (response/ok {:count (count hokses-without-oo)
+                      :hoksit hokses-without-oo}))
+      (catch Exception e
+        (response/bad-request {:error e})))))
 
 (defn- save-hoks [hoks request]
   (try

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -481,7 +481,8 @@
 
               (c-api/GET "/puuttuvat-opiskeluoikeudet-temp" request
                 :summary "Palauttaa listan hoks-id:sta, joiden opiskeluoikeutta
-                ei löydy."
+                ei löydy. Asettaa löydettyjen hoksien oo-indeksiin koski404 =
+                true."
                 :query-params [{limit :- s/Int 2000}
                                {from-id :- s/Int 0}]
                 (let [hoksit (db-hoks/select-hokses-greater-than-id
@@ -499,6 +500,12 @@
                                         (koski/get-opiskeluoikeus-info
                                           (:opiskeluoikeus-oid x))) x)) hoksit))
                           result (map :id hokses-without-oo)]
+                      (doseq [oo-oid (map :opiskeluoikeus-oid
+                                          hokses-without-oo)]
+                        (let [opiskeluoikeus
+                              (db-oo/select-opiskeluoikeus-by-oid oo-oid)]
+                          (when (some? opiskeluoikeus)
+                            (op/set-opiskeluoikeus-koski404 oo-oid))))
                       (response/ok {:count (count result)
                                     :ids result
                                     :last-id last-id}))

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -195,24 +195,6 @@
       (not (op/opiskeluoikeus-tila-inactive?
              (op/get-opiskeluoikeus-tila opiskeluoikeus))))))
 
-(defn get-hoksit-without-oo-in-koski-by-koulutuksenjarjestaja
-  [koulutustoimija-oid]
-  (let [hoksit (db-hoks/select-hoksit-by-oo-koulutustoimija
-                 koulutustoimija-oid)]
-    (try
-      (let [hokses-without-oo
-            (filter
-              some?
-              (pmap
-                (fn [x]
-                  (when (nil?
-                          (koski/get-opiskeluoikeus-info
-                            (:opiskeluoikeus-oid x))) x)) hoksit))]
-        (response/ok {:count (count hokses-without-oo)
-                      :hoksit hokses-without-oo}))
-      (catch Exception e
-        (response/bad-request {:error e})))))
-
 (defn- save-hoks [hoks request]
   (try
     (let [hoks-db (h/save-hoks!
@@ -416,14 +398,6 @@
                 :header-params [caller-id :- s/Str]
                 :path-params [tunnus :- s/Str]
                 (delete-vastaajatunnus tunnus))
-
-              (c-api/GET "/missing-oo-hoksit/:koulutustoimijaoid" []
-                :summary "Palauttaa listan hokseista, joiden
-                          opiskeluoikeus puuttuu"
-                :header-params [caller-id :- s/Str]
-                :path-params [koulutustoimijaoid :- s/Str]
-                (get-hoksit-without-oo-in-koski-by-koulutuksenjarjestaja
-                  koulutustoimijaoid))
 
               (c-api/GET "/paattyneet-kyselylinkit-temp" request
                 :summary "Palauttaa tietoja kyselylinkkeihin liittyvistä

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -195,6 +195,13 @@
       (not (op/opiskeluoikeus-tila-inactive?
              (op/get-opiskeluoikeus-tila opiskeluoikeus))))))
 
+(defn get-hoksit-without-opiskeluoikeus-in-koski-by-koulutuksenjarjestaja
+  [koulutustoimija-oid]
+  (let [hoksit (db-hoks/select-hoksit-by-oo-koulutustoimija
+                 koulutustoimija-oid)]
+    (restful/rest-ok {:count (count hoksit)
+                      :hoksit hoksit})))
+
 (defn- save-hoks [hoks request]
   (try
     (let [hoks-db (h/save-hoks!


### PR DESCRIPTION
Viikottain ajettava update-opiskeluoikeudet funktio asettaa nyt myös koski404 arvon jokaiseen opiskeluoikeuteen, jota ei löydy Koskesta. Funktio hakee vain viimeisen seitsemän päivän ajalta luodut hoksit ja tutkii ne. Ajan kerran massana kaikkiin opiskeluoikeuksiin koski404 tarkastuksen "/puuttuvat-opiskeluoikeudet-temp" endpointilla, johon lisäsin myös koski404 asettamisen. Mukana oleva sql query ja sitä varten luodut funktiot ovat tulevaa käyttöliittymän toiminnallisuutta varten.