### PR TITLE
Tehdään shallow delete oikein

### DIFF
--- a/src/oph/ehoks/db/postgresql/aiemmin_hankitut.clj
+++ b/src/oph/ehoks/db/postgresql/aiemmin_hankitut.clj
@@ -240,22 +240,25 @@
   ([id]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_ammat_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_ammat_tutkinnon_osa_id = ?" id]))
+      ["aiemmin_hankittu_ammat_tutkinnon_osa_id = ? AND deleted_at IS NULL"
+       id]))
   ([id db-conn]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_ammat_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_ammat_tutkinnon_osa_id = ?" id] db-conn)))
+      ["aiemmin_hankittu_ammat_tutkinnon_osa_id = ? AND deleted_at IS NULL" id]
+      db-conn)))
 
 (defn delete-todennettu-arviointi-arvioijat-by-tta-id!
   "Poista todennetun arvioinnin arvioija"
   ([id]
     (db-ops/shallow-delete!
       :todennettu_arviointi_arvioijat
-      ["todennettu_arviointi_lisatiedot_id = ?" id]))
+      ["todennettu_arviointi_lisatiedot_id = ? AND deleted_at IS NULL" id]))
   ([id db-conn]
     (db-ops/shallow-delete!
       :todennettu_arviointi_arvioijat
-      ["todennettu_arviointi_lisatiedot_id = ?" id] db-conn)))
+      ["todennettu_arviointi_lisatiedot_id = ? AND deleted_at IS NULL" id]
+      db-conn)))
 
 (defn update-todennettu-arviointi-lisatiedot-by-id!
   "Päivitä todennetun arvioinnin lisätiedot"
@@ -275,11 +278,16 @@
   ([id]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_paikallisen_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_paikallinen_tutkinnon_osa_id = ?" id]))
+      [(str "aiemmin_hankittu_paikallinen_tutkinnon_osa_id = ? "
+            "AND deleted_at IS NULL")
+       id]))
   ([id db-conn]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_paikallisen_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_paikallinen_tutkinnon_osa_id = ?" id] db-conn)))
+      [(str "aiemmin_hankittu_paikallinen_tutkinnon_osa_id = ? "
+            "AND deleted_at IS NULL")
+       id]
+      db-conn)))
 
 (defn update-aiemmin-hankittu-paikallinen-tutkinnon-osa-by-id!
   "Päivitä aiemmin hankitun paikallisen tutkinnon osa"
@@ -305,22 +313,28 @@
   ([id]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_yhteisen_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ?" id]))
+      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ? AND deleted_at IS NULL"
+       id]))
   ([id db-conn]
     (db-ops/shallow-delete!
       :aiemmin_hankitun_yhteisen_tutkinnon_osan_naytto
-      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ?" id] db-conn)))
+      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ? AND deleted_at IS NULL"
+       id]
+      db-conn)))
 
 (defn delete-aiemmin-hankitut-yto-osa-alueet-by-id!
   "Poista aiemmin hankitun yhteisen tutkinnon osan osa-alue"
   ([id]
     (db-ops/shallow-delete!
       :aiemmin_hankitut_yto_osa_alueet
-      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ?" id]))
+      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ? AND deleted_at IS NULL"
+       id]))
   ([id db-conn]
     (db-ops/shallow-delete!
       :aiemmin_hankitut_yto_osa_alueet
-      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ?" id] db-conn)))
+      ["aiemmin_hankittu_yhteinen_tutkinnon_osa_id = ? AND deleted_at IS NULL"
+       id]
+      db-conn)))
 
 (defn update-aiemmin-hankittu-yhteinen-tutkinnon-osa-by-id!
   "Päivitä aiemmin hankitun yhteisen tutkinnon osa"
@@ -353,18 +367,18 @@
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :aiemmin_hankitut_ammat_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))
 
 (defn delete-aiemmin-hankitut-paikalliset-tutkinnon-osat-by-hoks-id
   "Poista aiemmin hankitut paikalliset tutkinnon osat"
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :aiemmin_hankitut_paikalliset_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))
 
 (defn delete-aiemmin-hankitut-yhteiset-tutkinnon-osat-by-hoks-id
   "Poista aiemmin hankitut yhteiset tutkinnon osat"
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :aiemmin_hankitut_yhteiset_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))

--- a/src/oph/ehoks/db/postgresql/hankittavat.clj
+++ b/src/oph/ehoks/db/postgresql/hankittavat.clj
@@ -359,7 +359,7 @@
   [hyto-id db-conn]
   (db-ops/shallow-delete!
     :yhteisen_tutkinnon_osan_osa_alueet
-    ["yhteinen_tutkinnon_osa_id = ?" hyto-id] db-conn))
+    ["yhteinen_tutkinnon_osa_id = ? AND deleted_at IS NULL" hyto-id] db-conn))
 
 (defn update-hankittava-yhteinen-tutkinnon-osa-by-id!
   "Päivitä hankittavan yhteisen tutkinnon osa"
@@ -374,39 +374,41 @@
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :hankittavat_ammat_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))
 
 (defn delete-hankittavat-paikalliset-tutkinnon-osat-by-hoks-id
   "Poista hankittavat paikalliset tutkinnot osat"
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :hankittavat_paikalliset_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))
 
 (defn delete-hankittavat-yhteiset-tutkinnon-osat-by-hoks-id
   "Poista hankittavat yhteiset tutkinnon osat"
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :hankittavat_yhteiset_tutkinnon_osat
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))
 
 (defn delete-osaamisen-hankkimistavan-muut-oppimisymparistot
   "Poista osaamisen hankkimistavan muut oppimisympäristöt"
   [oht-id db-conn]
   (db-ops/shallow-delete!
     :muut_oppimisymparistot
-    ["osaamisen_hankkimistapa_id = ?" (:id oht-id)] db-conn))
+    ["osaamisen_hankkimistapa_id = ? AND deleted_at IS NULL" (:id oht-id)]
+    db-conn))
 
 (defn delete-osaamisen-hankkimistavan-keskeytymisajanjaksot
   "Poista osaamisen hankkimistavan keskeytymisajanjaksot"
   [oht-id db-conn]
   (db-ops/shallow-delete!
     :keskeytymisajanjaksot
-    ["osaamisen_hankkimistapa_id = ?" (:id oht-id)] db-conn))
+    ["osaamisen_hankkimistapa_id = ? AND deleted_at IS NULL" (:id oht-id)]
+    db-conn))
 
 (defn delete-tyopaikalla-jarjestettava-koulutus
   "Poistaa työpaikalla järjestettävän koulutuksen tietokannasta."
   [tjk-id db-conn]
   (db-ops/shallow-delete! :tyopaikalla_jarjestettavat_koulutukset
-                          ["id = ?" tjk-id]
+                          ["id = ? AND deleted_at IS NULL" tjk-id]
                           db-conn))

--- a/src/oph/ehoks/db/postgresql/opiskeluvalmiuksia_tukevat.clj
+++ b/src/oph/ehoks/db/postgresql/opiskeluvalmiuksia_tukevat.clj
@@ -51,4 +51,4 @@
   [hoks-id db-conn]
   (db-ops/shallow-delete!
     :opiskeluvalmiuksia_tukevat_opinnot
-    ["hoks_id = ?" hoks-id] db-conn))
+    ["hoks_id = ? AND deleted_at IS NULL" hoks-id] db-conn))


### PR DESCRIPTION
Tähän asti shallow delete tehtiin usein näin, että myös aikaisemmin shallow deletoidut rivit merkattiin shallow deletediksi sen hetkisellä päivämäärällä (eli kaikille annettiin sen hetken päivämäärä, vaikka ne olisi jo kauan sitten shallow deletoitu). Muutetaan se niin, että deleted_at asetetaan vain noille riveille, joissa se on vielä NULL.