### PR TITLE
Fix broken dummy data import functionality

### DIFF
--- a/resources/dev/src/oph/ehoks/import.clj
+++ b/resources/dev/src/oph/ehoks/import.clj
@@ -10,7 +10,7 @@
   #{:luotu :hyvaksytty :ensikertainen-hyvaksyminen :paivitetty})
 
 (def dates
-  #{:alku :loppu})
+  #{:alku :loppu :osaamisen-saavuttamisen-pvm :lahetetty-arvioitavaksi})
 
 (defn parse-date [s]
   (coerce/to-date (f/parse s)))


### PR DESCRIPTION
Importing dummy data wasn't working because some HOKS date values were having type `character varying` when they were being inserted to the DB.