### PR TITLE
OY-3912 Extend vipunen endpoint to return shallow deleted hokses

### DIFF
--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -189,11 +189,10 @@
 (defn from-sql
   "Convert maps returned by database functions to format expected elsewhere."
   ([m operations keep-columns]
-    (let [remove-cols-func #(remove-db-columns % keep-columns)]
-      (-> (convert-sql m operations)
-          remove-nils
-          remove-cols-func
-          to-dash-keys)))
+    (-> (convert-sql m operations)
+        remove-nils
+        (remove-db-columns keep-columns)
+        to-dash-keys))
   ([m operations] (from-sql m operations nil))
   ([m] (from-sql m {} nil)))
 

--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -190,12 +190,12 @@
 (defn from-sql
   "Convert maps returned by database functions to format expected elsewhere."
   ([m operations return-deleted-at?]
-    (let [remove-func (if (true? return-deleted-at?)
-                        remove-db-columns
-                        #(remove-db-columns % :deleted_at))]
+    (let [remove-cols-func (if (true? return-deleted-at?)
+                             remove-db-columns
+                             #(remove-db-columns % :deleted_at))]
       (-> (convert-sql m operations)
           remove-nils
-          remove-func
+          remove-cols-func
           to-dash-keys)))
   ([m operations] (from-sql m operations false))
   ([m] (from-sql m {} false)))

--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -1,5 +1,5 @@
 (ns oph.ehoks.db.db-operations.db-helpers
-  (:require [clojure.set :refer [rename-keys]]
+  (:require [clojure.set :refer [difference rename-keys]]
             [clojure.java.jdbc :as jdbc]
             [oph.ehoks.config :refer [config]]
             [clojure.data.json :as json]
@@ -116,14 +116,13 @@
       (keys m))))
 
 (defn remove-db-columns
-  "Remove keys corresponding to columns used for internal purposes, plus others
-  listed in argument others."
-  [m & others]
-  (apply
-    dissoc m
-    :created_at
-    :updated_at
-    others))
+  "Remove keys corresponding to columns used for internal purposes, keeping
+  columns listed in keep-columns."
+  [m keep-columns]
+  (let [remove-columns (difference #{:created_at :updated_at :deleted_at}
+                                   keep-columns)]
+    (apply
+      dissoc m remove-columns)))
 
 (defn to-underscore-keys
   "Convert dashes in keys to underscores."
@@ -189,16 +188,14 @@
 
 (defn from-sql
   "Convert maps returned by database functions to format expected elsewhere."
-  ([m operations return-deleted-at?]
-    (let [remove-cols-func (if (true? return-deleted-at?)
-                             remove-db-columns
-                             #(remove-db-columns % :deleted_at))]
+  ([m operations keep-columns]
+    (let [remove-cols-func #(remove-db-columns % keep-columns)]
       (-> (convert-sql m operations)
           remove-nils
           remove-cols-func
           to-dash-keys)))
-  ([m operations] (from-sql m operations false))
-  ([m] (from-sql m {} false)))
+  ([m operations] (from-sql m operations nil))
+  ([m] (from-sql m {} nil)))
 
 (defn to-sql
   "Convert maps used elsewhere to those expected by database functions."

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -15,9 +15,10 @@
 (defn hoks-from-sql
   "Muuttaa tietokannasta haetun HOKSin siihen muotoon, joka voi palauttaa
   käyttäjälle."
-  [h]
-  (db-ops/from-sql
-    h))
+  ([h return-deleted-at?]
+    (db-ops/from-sql h {} return-deleted-at?))
+  ([h]
+    (db-ops/from-sql h)))
 
 (defn hoks-to-sql
   "Muuttaa ehoksissa käytetyn HOKSin näin, että sen voi tallentaa hoksit
@@ -385,13 +386,15 @@
 (defn select-hokses-greater-than-id
   "Hakee tietokannasta tietyn määrän HOKSeja, joiden ID:t ovat annettu arvo tai
   sitä isompia, ja jotka on muokattu tietyn ajankohdan jälkeen."
-  [from-id amount updated-after]
-  (db-ops/query [queries/select-hoksit-by-id-paged
-                 from-id
-                 updated-after
-                 updated-after
-                 amount]
-                {:row-fn hoks-from-sql}))
+  ([from-id amount updated-after return-deleted-at?]
+    (db-ops/query [queries/select-hoksit-by-id-paged
+                   from-id
+                   updated-after
+                   updated-after
+                   amount]
+                  {:row-fn #(hoks-from-sql % return-deleted-at?)}))
+  ([from-id amount updated-after]
+    (select-hokses-greater-than-id from-id amount updated-after false)))
 
 (defn select-hoks-by-eid
   "Hakee HOKSin tietokannasta EID:n perustella."

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -15,10 +15,10 @@
 (defn hoks-from-sql
   "Muuttaa tietokannasta haetun HOKSin siihen muotoon, joka voi palauttaa
   käyttäjälle."
-  ([h return-deleted-at?]
-    (db-ops/from-sql h {} return-deleted-at?))
+  ([h keep-columns]
+    (db-ops/from-sql h {} keep-columns))
   ([h]
-    (db-ops/from-sql h)))
+    (db-ops/from-sql h nil)))
 
 (defn hoks-to-sql
   "Muuttaa ehoksissa käytetyn HOKSin näin, että sen voi tallentaa hoksit
@@ -386,15 +386,15 @@
 (defn select-hokses-greater-than-id
   "Hakee tietokannasta tietyn määrän HOKSeja, joiden ID:t ovat annettu arvo tai
   sitä isompia, ja jotka on muokattu tietyn ajankohdan jälkeen."
-  ([from-id amount updated-after return-deleted-at?]
+  ([from-id amount updated-after keep-columns]
     (db-ops/query [queries/select-hoksit-by-id-paged
                    from-id
                    updated-after
                    updated-after
                    amount]
-                  {:row-fn #(hoks-from-sql % return-deleted-at?)}))
+                  {:row-fn #(hoks-from-sql % keep-columns)}))
   ([from-id amount updated-after]
-    (select-hokses-greater-than-id from-id amount updated-after false)))
+    (select-hokses-greater-than-id from-id amount updated-after nil)))
 
 (defn select-hoks-by-eid
   "Hakee HOKSin tietokannasta EID:n perustella."

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -437,8 +437,7 @@
                                 [hoks-schema-vipunen/HOKSVipunen]})
         (let [limit (min (max 1 amount) 1000)
               raw-result (h/get-hokses-from-id from-id limit updated-after)
-              redacted-deleted-result (map h/redact-deleted-hokses raw-result)
-              result (map #(dissoc % :deleted-at) redacted-deleted-result)
+              result (map h/mark-as-deleted raw-result)
               last-id (first (sort > (map :id result)))
               schema-checker (s/checker hoks-schema-vipunen/HOKSVipunen)
               result-after-validation (filter

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -437,13 +437,15 @@
                                 [hoks-schema-vipunen/HOKSVipunen]})
         (let [limit (min (max 1 amount) 1000)
               raw-result (h/get-hokses-from-id from-id limit updated-after)
-              last-id (first (sort > (map :id raw-result)))
+              redacted-deleted-result (map h/redact-deleted-hokses raw-result)
+              result (map #(dissoc % :deleted-at) redacted-deleted-result)
+              last-id (first (sort > (map :id result)))
               schema-checker (s/checker hoks-schema-vipunen/HOKSVipunen)
               result-after-validation (filter
                                         (fn [hoks] (nil? (schema-checker hoks)))
-                                        raw-result)
+                                        result)
               failed-ids (seq (clojure.set/difference
-                                (set (map :id raw-result))
+                                (set (map :id result))
                                 (set (map :id result-after-validation))))]
           (when (not-empty failed-ids)
             (log/info "Failed ids for paged call:" failed-ids

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -12,7 +12,8 @@
             [oph.ehoks.hoks.hankittavat :as ha]
             [oph.ehoks.hoks.opiskeluvalmiuksia-tukevat :as ot]
             [oph.ehoks.external.koski :as k]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [clojure.set :as s])
   (:import (java.time LocalDate)))
 
 (defn get-hoks-values
@@ -152,12 +153,12 @@
                  true)]
     (map enrich-and-filter hokses)))
 
-(defn redact-deleted-hokses
-  "Jos HOKS on passivoitu, se sisältää vain id- ja eid-kentät."
+(defn mark-as-deleted
+  "Jos HOKS on passivoitu, se sisältää poistettu-kentän."
   [hoks]
   (if (nil? (:deleted-at hoks))
     hoks
-    (select-keys hoks [:id :eid :ensikertainen-hyvaksyminen])))
+    (s/rename-keys hoks {:deleted-at :poistettu})))
 
 (defn- new-osaamisen-saavuttamisen-pvm-added?
   "Tarkistaa, onko uusi osaamisen saavuttamisen päivämäärä lisätty kun vanhaa ei

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -157,9 +157,7 @@
   [hoks]
   (if (nil? (:deleted-at hoks))
     hoks
-    {:id (:id hoks)
-     :eid (:eid hoks)
-     :ensikertainen-hyvaksyminen (:ensikertainen-hyvaksyminen hoks)}))
+    (select-keys hoks [:id :eid :ensikertainen-hyvaksyminen])))
 
 (defn- new-osaamisen-saavuttamisen-pvm-added?
   "Tarkistaa, onko uusi osaamisen saavuttamisen päivämäärä lisätty kun vanhaa ei

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -13,7 +13,7 @@
             [oph.ehoks.hoks.opiskeluvalmiuksia-tukevat :as ot]
             [oph.ehoks.external.koski :as k]
             [clojure.tools.logging :as log]
-            [clojure.set :as s])
+            [clojure.set :refer [rename-keys]])
   (:import (java.time LocalDate)))
 
 (defn get-hoks-values
@@ -150,7 +150,7 @@
                  (or id 0)
                  amount
                  updated-after
-                 true)]
+                 #{:deleted_at})]
     (map enrich-and-filter hokses)))
 
 (defn mark-as-deleted
@@ -158,7 +158,7 @@
   [hoks]
   (if (nil? (:deleted-at hoks))
     hoks
-    (s/rename-keys hoks {:deleted-at :poistettu})))
+    (rename-keys hoks {:deleted-at :poistettu})))
 
 (defn- new-osaamisen-saavuttamisen-pvm-added?
   "Tarkistaa, onko uusi osaamisen saavuttamisen päivämäärä lisätty kun vanhaa ei

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -148,8 +148,18 @@
   (let [hokses (db-hoks/select-hokses-greater-than-id
                  (or id 0)
                  amount
-                 updated-after)]
+                 updated-after
+                 true)]
     (map enrich-and-filter hokses)))
+
+(defn redact-deleted-hokses
+  "Jos HOKS on passivoitu, se sisältää vain id- ja eid-kentät."
+  [hoks]
+  (if (nil? (:deleted-at hoks))
+    hoks
+    {:id (:id hoks)
+     :eid (:eid hoks)
+     :ensikertainen-hyvaksyminen (:ensikertainen-hyvaksyminen hoks)}))
 
 (defn- new-osaamisen-saavuttamisen-pvm-added?
   "Tarkistaa, onko uusi osaamisen saavuttamisen päivämäärä lisätty kun vanhaa ei

--- a/src/oph/ehoks/hoks/vipunen_schema.clj
+++ b/src/oph/ehoks/hoks/vipunen_schema.clj
@@ -878,6 +878,10 @@
                 :types {:any s/Inst}
                 :description (str "HOKS-dokumentin viimeisin päivitysaika "
                                   "muodossa YYYY-MM-DDTHH:mm:ss.sssZ")}
+   :poistettu {:methods {:any :optional}
+               :types {:any s/Inst}
+               :description (str "HOKS-dokumentin passivointiaika "
+                                 "muodossa YYYY-MM-DDTHH:mm:ss.sssZ")}
    :osaamisen-saavuttamisen-pvm {:methods {:any :optional}
                                  :types {:any LocalDate}
                                  :description

--- a/src/oph/ehoks/hoks/vipunen_schema.clj
+++ b/src/oph/ehoks/hoks/vipunen_schema.clj
@@ -916,7 +916,7 @@
     (g/generate HOKSModelVipunen :get)
     {:doc "Henkilökohtainen osaamisen kehittämissuunnitelmadokumentti (GET)
        Vipusen käyttöön, poistettu nimiä ja yhteystietoja"
-     :name "HOKS"}))
+     :name "HOKSVipunen"}))
 
 (s/defschema
   kyselylinkki

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -603,6 +603,9 @@
                        first
                        :id)
                    hoks-id))
+            (is (empty? (-> paged-body
+                            :data
+                            :failed-ids)))
             (is (not (nil? (-> paged-body
                                :data
                                :result

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -558,8 +558,8 @@
           post-response (hoks-utils/mock-st-post app base-url hoks-data)]
       (is (= (:status post-response) 200))
       (let [hoks-uri (-> (utils/parse-body (:body post-response))
-                    :data
-                    :uri)
+                         :data
+                         :uri)
             get-response (hoks-utils/mock-st-get app hoks-uri)]
         (is (= (:status get-response) 200))
         (let [hoks (-> (utils/parse-body (:body get-response))

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -549,7 +549,7 @@
                                   "1.2.246.562.24.12312312312")))))))
 
 (deftest get-paged-vipunen-data
-  (testing "GET paged Vipunen data"
+  (testing "GET paged HOKSes for Vipunen"
     (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
                      :oppija-oid "1.2.246.562.24.12312312312"
                      :osaamisen-hankkimisen-tarve true
@@ -571,12 +571,12 @@
                      :data
                      :result
                      first
-                     :eid)
+                     :id)
                  (-> hoks
-                     :eid))))))))
+                     :id))))))))
 
-(deftest get-paged-vipunen-data-deleted
-  (testing "GET paged Vipunen data with deleted HOKS"
+(deftest get-paged-deleted
+  (testing "GET paged HOKSes with deleted item"
     (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
                      :oppija-oid "1.2.246.562.24.12312312312"
                      :osaamisen-hankkimisen-tarve true
@@ -600,7 +600,82 @@
             (is (= (-> paged-body
                        :data
                        :result
-                       first)
-                   {:id hoks-id
-                    :eid (-> hoks :eid)
-                    :ensikertainen-hyvaksyminen "2018-12-15"}))))))))
+                       first
+                       :id)
+                   hoks-id))
+            (is (not (nil? (-> paged-body
+                               :data
+                               :result
+                               first
+                               :poistettu))))))))))
+
+(defn make-timestamp
+  ([plus-millis]
+    (let [tz (java.util.TimeZone/getTimeZone "UTC")
+          df (new java.text.SimpleDateFormat "yyyy-MM-dd'T'HH:mm:ss'Z'")]
+      (.setTimeZone df tz)
+      (.format df (new java.util.Date (+ (.getTime (new java.util.Date))
+                                         plus-millis)))))
+  ([] (make-timestamp 0)))
+
+(deftest get-paged-delta-with-deleted
+  (testing "GET paged delta stream of HOKSes"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
+                     :oppija-oid "1.2.246.562.24.12312312312"
+                     :osaamisen-hankkimisen-tarve true
+                     :ensikertainen-hyvaksyminen "2018-12-15"}
+          app (hoks-utils/create-app nil)
+          post-response (hoks-utils/mock-st-post app base-url hoks-data)]
+      (is (= (:status post-response) 200))
+      (let [hoks-uri (-> (utils/parse-body (:body post-response))
+                         :data
+                         :uri)
+            get-response (hoks-utils/mock-st-get app hoks-uri)]
+        (is (= (:status get-response) 200))
+        (let [hoks (-> (utils/parse-body (:body get-response))
+                       :data)
+              hoks-id (-> hoks :id)
+              paged-response (hoks-utils/mock-st-get
+                               app (format "%s/paged" base-url))
+              paged-body (utils/parse-body (:body paged-response))
+              before-delete-ts (make-timestamp)]
+          (is (= (:status paged-response) 200))
+          (is (= (-> paged-body
+                     :data
+                     :result
+                     first
+                     :id)
+                 hoks-id))
+          (is (not (contains? (-> paged-body
+                                  :data
+                                  :result
+                                  first)
+                              :poistettu)))
+          (db-hoks/shallow-delete-hoks-by-hoks-id hoks-id)
+          (let [before-delete-resp (hoks-utils/mock-st-get
+                                     app (format "%s/paged?updated-after=%s"
+                                                 base-url
+                                                 before-delete-ts))
+                before-delete-body (utils/parse-body (:body before-delete-resp))
+                after-delete-ts (make-timestamp 2000)
+                after-delete-resp (hoks-utils/mock-st-get
+                                    app (format "%s/paged?updated-after=%s"
+                                                base-url
+                                                after-delete-ts))
+                after-delete-body (utils/parse-body (:body after-delete-resp))]
+            (is (= (:status before-delete-resp) 200))
+            (is (= (-> before-delete-body
+                       :data
+                       :result
+                       first
+                       :id)
+                   hoks-id))
+            (is (not (nil? (-> before-delete-body
+                               :data
+                               :result
+                               first
+                               :poistettu))))
+            (is (= (:status after-delete-resp) 200))
+            (is (empty? (-> after-delete-body
+                            :data
+                            :result)))))))))

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -7,6 +7,7 @@
             [oph.ehoks.utils :as utils :refer [eq]]))
 
 (def base-url "/ehoks-virkailija-backend/api/v1/hoks")
+(def base-url-virkailija "/ehoks-virkailija-backend/api/v1/virkailija")
 
 (defn create-app [session-store]
   (cache/clear-cache!)

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -7,7 +7,6 @@
             [oph.ehoks.utils :as utils :refer [eq]]))
 
 (def base-url "/ehoks-virkailija-backend/api/v1/hoks")
-(def base-url-virkailija "/ehoks-virkailija-backend/api/v1/virkailija")
 
 (defn create-app [session-store]
   (cache/clear-cache!)


### PR DESCRIPTION
https://jira.eduuni.fi/browse/OY-3912

Muutos: Päivitetään `updated_at` aikaleima HOKSin passivoinnin yhteydessä. Tämä mahdollistaa passivoitujen HOKSien siirron Vipusen käyttämän delta-rajapinnan kautta. Passivoiduilla HOKSeilla näkyy nyt delta-rajapinnassa `poistettu`-kenttä.