### PR TITLE
OY-3885: Handle not found eperusteet data

### DIFF
--- a/src/oph/ehoks/external/eperusteet.clj
+++ b/src/oph/ehoks/external/eperusteet.clj
@@ -78,24 +78,27 @@
                   "eperusteet-service.external-api.find-perusteet-by-koodi")
            :options {:as :json
                      :query-params {:koodi koodiUri}}})
-        body (get-in result [:body :data])
-        id (:id (first body))
-        peruste (get-peruste-by-id id)
-        koulutuksenOsat (:koulutuksenOsat peruste)
-        koulutuksenOsa
-        (filter #(= koodiUri (get-in % [:nimiKoodi :uri])) koulutuksenOsat)
-        ;; TODO: tarvittava id UI:n ePerusteet urlia varten
-        ;; ATM lähetetään vain 12345
-        koulutuksenOsaPeruste
-        (map
-          (fn [v]
-            (-> (select-keys v [:id :nimi :osaamisalat])
-                (update :nimi select-keys [:fi :en :sv])
-                (update
-                  :osaamisalat (fn [x] (map #(select-keys % [:nimi]) x)))
-                (assoc :koulutuksenOsaId "12345")))
-          koulutuksenOsa)]
-    koulutuksenOsaPeruste))
+        body (get-in result [:body :data])]
+    (when (empty? (seq body))
+      (throw (ex-info (str "eperusteet not found with koodiUri " koodiUri)
+                      {:status 404})))
+    (let [id (:id (first body))
+          peruste (get-peruste-by-id id)
+          koulutuksenOsat (:koulutuksenOsat peruste)
+          koulutuksenOsa
+          (filter #(= koodiUri (get-in % [:nimiKoodi :uri])) koulutuksenOsat)
+          ;; TODO: tarvittava id UI:n ePerusteet urlia varten
+          ;; ATM lähetetään vain 12345
+          koulutuksenOsaPeruste
+          (map
+            (fn [v]
+              (-> (select-keys v [:id :nimi :osaamisalat])
+                  (update :nimi select-keys [:fi :en :sv])
+                  (update
+                    :osaamisalat (fn [x] (map #(select-keys % [:nimi]) x)))
+                  (assoc :koulutuksenOsaId "12345")))
+            koulutuksenOsa)]
+      koulutuksenOsaPeruste)))
 
 (defn search-perusteet-info
   "Search for perusteet that match a particular name"

--- a/src/oph/ehoks/oppija/oppija_external.clj
+++ b/src/oph/ehoks/oppija/oppija_external.clj
@@ -66,7 +66,14 @@
                            haku Koodisto-Koodi-Urilla."
         :return (rest/response [s/Any])
         (rest/rest-ok (eperusteet/adjust-tutkinnonosa-arviointi
-                        (eperusteet/find-tutkinnon-osat koodi-uri)))))
+                        (eperusteet/find-tutkinnon-osat koodi-uri))))
+
+      (c-api/GET "/koulutuksenOsa/:koodi-uri" [:as request]
+        :summary "Hakee koulutuksenOsan ePerusteet-palvelusta"
+        :path-params [koodi-uri :- s/Str]
+        :return (restful/response  [s/Any])
+        (restful/with-not-found-handling
+          (eperusteet/get-koulutuksenOsa-by-koodiUri koodi-uri))))
 
     (c-api/context "/eperusteet-amosaa" []
       (c-api/GET "/koodi/:koodi" []

--- a/src/oph/ehoks/oppija/oppija_external.clj
+++ b/src/oph/ehoks/oppija/oppija_external.clj
@@ -71,8 +71,8 @@
       (c-api/GET "/koulutuksenOsa/:koodi-uri" [:as request]
         :summary "Hakee koulutuksenOsan ePerusteet-palvelusta"
         :path-params [koodi-uri :- s/Str]
-        :return (restful/response  [s/Any])
-        (restful/with-not-found-handling
+        :return (rest/response  [s/Any])
+        (rest/with-not-found-handling
           (eperusteet/get-koulutuksenOsa-by-koodiUri koodi-uri))))
 
     (c-api/context "/eperusteet-amosaa" []

--- a/src/oph/ehoks/virkailija/external_handler.clj
+++ b/src/oph/ehoks/virkailija/external_handler.clj
@@ -127,7 +127,7 @@
         :summary "Hakee koulutuksenOsan ePerusteet-palvelusta"
         :path-params [koodi-uri :- s/Str]
         :return (restful/response  [s/Any])
-        (restful/rest-ok
+        (restful/with-not-found-handling
           (eperusteet/get-koulutuksenOsa-by-koodiUri koodi-uri))))
 
     (c-api/context "/eperusteet-amosaa" []

--- a/test/oph/ehoks/external/eperusteet_test.clj
+++ b/test/oph/ehoks/external/eperusteet_test.clj
@@ -83,6 +83,19 @@
       (is (thrown? clojure.lang.ExceptionInfo
                    (ep/get-tutkinnon-osa-viitteet 100000))))))
 
+(deftest get-koulutuksenOsa-by-koodiUri-not-found
+  (testing "Not getting koulutuksenOsa by koodiUri items"
+    (client/with-mock-responses
+      [(fn [_ __] {:status 200
+                   :body {:data []
+                          :sivuja 0
+                          :kokonaismäärä 0
+                          :sivukoko 25
+                          :sivu 0}})]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (ep/get-koulutuksenOsa-by-koodiUri
+                     "koulutuksenosattuva_404"))))))
+
 (deftest find-tutkinto-not-found
   (testing "Not finding any tutkinto items"
     (client/with-mock-responses


### PR DESCRIPTION
Bugi: TUVA-HOKSiin tallennetun koulutuksen osan nimi ei näy

- lisätty puuttuva rajapinta oppijan puolelle
- korjattu eperusteet-palvelun virheenkäsittely virkailijan puolen rajapintaan
- eperusteiden data on julkaistu uudelleen, korjasi "puuttuneet" koulutuksenosatuva-koodit