### PR TITLE
EH-1351

### DIFF
--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -240,7 +240,7 @@
 (defn save-hoks!
   "Tallentaa yhden HOKSin arvot tietokantaan."
   [h]
-  (let [saved-hoks-id
+  (let [saved-hoks-obj
         (jdbc/with-db-transaction
           [conn (db-ops/get-db-connection)]
           (let [saved-hoks (db-hoks/insert-hoks! h conn)
@@ -293,13 +293,13 @@
     (future
       (when (and (:osaamisen-hankkimisen-tarve h)
                  (false? (tuva-related-hoks? h)))
-        (send-aloituskysely saved-hoks-id h))
+        (send-aloituskysely (:id saved-hoks-obj) h))
       (when (and (:osaamisen-saavuttamisen-pvm h)
                  (false? (tuva-related-hoks? h)))
-        (send-paattokysely saved-hoks-id
+        (send-paattokysely (:id saved-hoks-obj)
                            (:osaamisen-saavuttamisen-pvm h)
                            h)))
-    saved-hoks-id))
+    saved-hoks-obj))
 
 (defn- merge-not-given-hoks-values
   "Varmistaa, että tietyt kentät ovat olemassa HOKSissa, vaikka niissä olisi

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -240,7 +240,7 @@
 (defn save-hoks!
   "Tallentaa yhden HOKSin arvot tietokantaan."
   [h]
-  (let [saved-hoks-obj
+  (let [hoks-db
         (jdbc/with-db-transaction
           [conn (db-ops/get-db-connection)]
           (let [saved-hoks (db-hoks/insert-hoks! h conn)
@@ -293,13 +293,13 @@
     (future
       (when (and (:osaamisen-hankkimisen-tarve h)
                  (false? (tuva-related-hoks? h)))
-        (send-aloituskysely (:id saved-hoks-obj) h))
+        (send-aloituskysely (:id hoks-db) h))
       (when (and (:osaamisen-saavuttamisen-pvm h)
                  (false? (tuva-related-hoks? h)))
-        (send-paattokysely (:id saved-hoks-obj)
+        (send-paattokysely (:id hoks-db)
                            (:osaamisen-saavuttamisen-pvm h)
                            h)))
-    saved-hoks-obj))
+    hoks-db))
 
 (defn- merge-not-given-hoks-values
   "Varmistaa, että tietyt kentät ovat olemassa HOKSissa, vaikka niissä olisi

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -290,14 +290,15 @@
                 (:id saved-hoks)
                 (:hankittavat-koulutuksen-osat h)
                 conn))))]
-    (when (and (:osaamisen-hankkimisen-tarve h)
-               (false? (tuva-related-hoks? h)))
-      (send-aloituskysely saved-hoks-id h))
-    (when (and (:osaamisen-saavuttamisen-pvm h)
-               (false? (tuva-related-hoks? h)))
-      (send-paattokysely saved-hoks-id
-                         (:osaamisen-saavuttamisen-pvm h)
-                         h))
+    (future
+      (when (and (:osaamisen-hankkimisen-tarve h)
+                 (false? (tuva-related-hoks? h)))
+        (send-aloituskysely saved-hoks-id h))
+      (when (and (:osaamisen-saavuttamisen-pvm h)
+                 (false? (tuva-related-hoks? h)))
+        (send-paattokysely saved-hoks-id
+                           (:osaamisen-saavuttamisen-pvm h)
+                           h)))
     saved-hoks-id))
 
 (defn- merge-not-given-hoks-values

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -7,6 +7,7 @@
             [oph.ehoks.external.cache :as c]
             [oph.ehoks.oppijaindex :as op]
             [oph.ehoks.heratepalvelu.heratepalvelu :as hp]
+            [oph.ehoks.hoks.hoks :as h]
             [clojure.core.async :as a]
             [ring.util.http-response :as response]
             [clojure.tools.logging :as log]
@@ -198,8 +199,7 @@
         (if hoks
           (if (:osaamisen-hankkimisen-tarve hoks)
             (do
-              (sqs/send-amis-palaute-message (sqs/build-hoks-hyvaksytty-msg
-                                               hoks-id hoks))
+              (h/send-aloituskysely hoks-id hoks)
               (response/no-content))
             (do
               (log/warn "Osaamisen hankkimisen tarve false "

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -460,9 +460,8 @@
           (assoc data :aiemmin-hankitun-osaamisen-arvioijat [])))))
 
 (deftest get-hoks-test-send-msg-fail
-  (testing
-    (str "Save HOKS but fail in sending msg, "
-         "test that HOKS saving is not rolled back")
+  (testing (str "Save HOKS but fail in sending msg, "
+                "test that HOKS saving is not rolled back")
     (with-redefs [oph.ehoks.external.aws-sqs/send-amis-palaute-message
                   #(throw (Exception. "fail"))]
       (eq (h/get-hoks-by-id 1) {:aiemmin-hankitut-ammat-tutkinnon-osat []

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -459,21 +459,6 @@
             (ah/get-tarkentavat-tiedot-osaamisen-arvioija (:id tta)))
           (assoc data :aiemmin-hankitun-osaamisen-arvioijat [])))))
 
-(deftest get-hoks-test-send-msg-fail
-  (testing
-   "Save HOKS but fail in sending msg, test that HOKS saving is rolled back"
-    (with-redefs [oph.ehoks.external.aws-sqs/send-amis-palaute-message
-                  #(throw (Exception. "fail"))]
-      (is (thrown? Exception (h/save-hoks! hoks-data)))
-      (eq (h/get-hoks-by-id 1) {:aiemmin-hankitut-ammat-tutkinnon-osat []
-                                :aiemmin-hankitut-paikalliset-tutkinnon-osat []
-                                :hankittavat-paikalliset-tutkinnon-osat []
-                                :aiemmin-hankitut-yhteiset-tutkinnon-osat []
-                                :hankittavat-ammat-tutkinnon-osat []
-                                :opiskeluvalmiuksia-tukevat-opinnot []
-                                :hankittavat-yhteiset-tutkinnon-osat []
-                                :hankittavat-koulutuksen-osat []}))))
-
 (deftest set-tep-kasitelty-test
   (testing
    "If loppu is before today set tep_kasitelty to true"

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -459,6 +459,21 @@
             (ah/get-tarkentavat-tiedot-osaamisen-arvioija (:id tta)))
           (assoc data :aiemmin-hankitun-osaamisen-arvioijat [])))))
 
+(deftest get-hoks-test-send-msg-fail
+  (testing
+    (str "Save HOKS but fail in sending msg, "
+         "test that HOKS saving is not rolled back")
+    (with-redefs [oph.ehoks.external.aws-sqs/send-amis-palaute-message
+                  #(throw (Exception. "fail"))]
+      (eq (h/get-hoks-by-id 1) {:aiemmin-hankitut-ammat-tutkinnon-osat []
+                                :aiemmin-hankitut-paikalliset-tutkinnon-osat []
+                                :hankittavat-paikalliset-tutkinnon-osat []
+                                :aiemmin-hankitut-yhteiset-tutkinnon-osat []
+                                :hankittavat-ammat-tutkinnon-osat []
+                                :opiskeluvalmiuksia-tukevat-opinnot []
+                                :hankittavat-yhteiset-tutkinnon-osat []
+                                :hankittavat-koulutuksen-osat []}))))
+
 (deftest set-tep-kasitelty-test
   (testing
    "If loppu is before today set tep_kasitelty to true"


### PR DESCRIPTION
Lähetetään AMIS SQS-viestit futuressa sen jälkeen, kun Hoksin tallennustransaktio on valmistunut. Näin vältetään tilanne, jossa AMISHerateHandler ehtii hakemaan hoksia Ehoksista ennen transaktion valmistumista.