### PR TITLE
Validate osaamisenhankkimistapa dates again

### DIFF
--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -275,27 +275,30 @@
       (.isBefore (:loppu oht) (LocalDate/of 2021 7 1))
       (:oppisopimuksen-perusta-koodi-uri oht)))
 
+(defn- nonnegative-duration?
+  "Osaamisen hankkimistavat päiväykset ovat oikein päin"
+  [oht]
+  (not (.isBefore (:loppu oht) (:alku oht))))
+
 (s/defschema
   OsaamisenHankkimistapaLuontiJaMuokkaus
   "Schema osaamisen hankkimistavan luontiin ja muokkaukseen."
-  (s/constrained
-    (modify
-      OsaamisenHankkimistapa
-      "Osaamisen hankkimisen tavan luonti ja muokkaus (POST, PUT)"
-      {:removed [:module-id :id]})
-    oppisopimus-has-perusta?
-    "Tieto oppisopimuksen perustasta puuttuu."))
+  (-> OsaamisenHankkimistapa
+      (modify "Osaamisen hankkimisen tavan muokkaus (PATCH)"
+              {:removed [:module-id :id]})
+      (s/constrained oppisopimus-has-perusta?
+                     "Tieto oppisopimuksen perustasta puuttuu.")
+      (s/constrained nonnegative-duration? "Alku ennen loppua")))
 
 (s/defschema
   OsaamisenHankkimistapaPatch
   "Schema osaamisen hankkimistavan PATCH-päivitykseen."
-  (s/constrained
-    (modify
-      OsaamisenHankkimistapa
-      "Osaamisen hankkimisen tavan muokkaus (PATCH)"
-      {:removed [:module-id]})
-    oppisopimus-has-perusta?
-    "Tieto oppisopimuksen perustasta puuttuu."))
+  (-> OsaamisenHankkimistapa
+      (modify "Osaamisen hankkimisen tavan muokkaus (PATCH)"
+              {:removed [:module-id]})
+      (s/constrained oppisopimus-has-perusta?
+                     "Tieto oppisopimuksen perustasta puuttuu.")
+      (s/constrained nonnegative-duration? "Alku ennen loppua")))
 
 (s/defschema
   NaytonJarjestaja

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -244,6 +244,22 @@
       (is (= (utils/parse-body (:body put-response))
              {:error "Oppija-oid update not allowed!"})))))
 
+(deftest prevent-invalid-osaamisen-hankkimistapa
+  (testing "Start and end dates of OHT are checked"
+    (let [app (hoks-utils/create-app nil)
+          invalid-data
+          (assoc-in test-data/hoks-data
+                    [:hankittavat-yhteiset-tutkinnon-osat 0
+                     :osa-alueet 0 :osaamisen-hankkimistavat 0 :alku]
+                    "2020-10-02")
+          invalid-post-response
+          (hoks-utils/create-mock-post-request "" invalid-data app)]
+      (is (= (:status invalid-post-response) 400))
+      (is (-> (utils/parse-body (:body invalid-post-response))
+              (get-in [:errors :hankittavat-yhteiset-tutkinnon-osat 0
+                       :osa-alueet 0 :osaamisen-hankkimistavat 0])
+              (->> (re-find #"Alku ennen loppua")))))))
+
 (deftest prevent-osaamisen-saavuttaminen-out-of-range
   (testing "The allowed range of osaaminen-saavuttamisen-pvm is from 1.1.2018
            to two weeks in the future (from the time of saving the HOKS)."


### PR DESCRIPTION
OY-3494 oli peruttu järjestelmätoimittajan bugin vuoksi.  Tästä on yli vuosi, laitetaan taas päälle.