### PR TITLE
Compose both-app so that both apps have their own swagger

### DIFF
--- a/src/oph/ehoks/ehoks_app.clj
+++ b/src/oph/ehoks/ehoks_app.clj
@@ -7,27 +7,59 @@
             [oph.ehoks.db.session-store :as session-store]
             [oph.ehoks.oppija.handler :as oppija-handler]
             [oph.ehoks.virkailija.handler :as virkailija-handler]
+            [clojure.java.io]
             [clojure.string :refer [lower-case]]
             [environ.core :refer [env]]))
 
+(defn real-response? [response]
+  (and (map? response) (not= 404 (:status response))))
+
+(defn request-with-new-body [request body]
+  (assoc request :body (clojure.java.io/input-stream body)))
+
+(defn app-union
+  "Combines apps by trying the same request with all of them,
+  until one of them returns something else than not-found.
+  Basically the same as compojure.core/routes,
+  but not handling a request can be signalled by a not-found response
+  in addition to nil."
+  [first-app & apps]
+  (if (empty? apps)
+    first-app
+    (let [rest-app (apply app-union apps)]
+      (fn
+        ([request]
+          (let [body-bytes (-> request :body (slurp) (.getBytes))
+                response (first-app (request-with-new-body request body-bytes))]
+            (if (real-response? response)
+              response
+              (rest-app (request-with-new-body request body-bytes)))))
+        ([request respond raise]
+          (let [body-bytes (-> request :body (slurp) (.getBytes))]
+            (first-app (request-with-new-body request body-bytes)
+                       (fn [response]
+                         (if (real-response? response)
+                           (respond response)
+                           (rest-app (request-with-new-body request body-bytes)
+                                     respond
+                                     raise)))
+                       (fn [exception]
+                         (if (real-response? (:response (ex-data exception)))
+                           (raise exception)
+                           (rest-app (request-with-new-body request body-bytes)
+                                     respond
+                                     raise))))))))))
+
 (def both-app
   "App with both oppija and virkailija routes initialized."
-  (c-api/api
-    {:swagger
-     {:ui "/ehoks-backend/doc"
-      :spec "/ehoks-backend/doc/swagger.json"
-      :data {:info {:title "eHOKS backend"
-                    :description "Oppija for eHOKS"}
-             :tags [{:name "api", :description ""}]}}
-     :exceptions
-     {:handlers common-api/handlers}}
-
-    oppija-handler/routes
-    virkailija-handler/routes
-
-    (c-api/undocumented
-      (compojure-route/not-found
-        (response/not-found {:reason "Route not found"})))))
+  (app-union
+    oppija-handler/app-routes
+    virkailija-handler/app-routes
+    (compojure-route/not-found
+      (-> (str "{\"reason\": \"Use APIs under /ehoks-virkailija-backend "
+               "or /ehoks-oppija-backend\"}")
+          (response/not-found)
+          (response/content-type "application/json")))))
 
 (defn create-app
   "Create ehoks web app of given name. Name will decide if system has oppija


### PR DESCRIPTION
This fixes the problem that swagger is in the wrong place when running both-app, causing ehoks-ui LuoHOKS and MuokkaaHOKS components to break.