### PR TITLE
EH-1467: korjataan tietoturva-aukko oppijat-endpointista

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ stamps/server-running: stamps/db-schema
 
 stamps/example-data: stamps/server-running
 	sh ./scripts/create-curl-session.sh
-	sh ./scripts/upload-hoks.sh
+	sh ./scripts/upload-hoks.sh resources/dev/demo-data/hoksit.json
 	touch $@
 
 tags::

--- a/resources/db/oppijat/select_oppilaitos_oppijat.sql
+++ b/resources/db/oppijat/select_oppilaitos_oppijat.sql
@@ -1,8 +1,6 @@
 SELECT o.oid,
        o.nimi,
        oo.oid AS opiskeluoikeus_oid,
-       oo.oppilaitos_oid,
-       oo.koulutustoimija_oid,
        oo.tutkinto_nimi,
        oo.osaamisala_nimi
 FROM oppijat AS o
@@ -10,12 +8,20 @@ FROM oppijat AS o
                        ON (o.oid = oo.oppija_oid)
        INNER JOIN hoksit AS h
                        ON (oo.oid = h.opiskeluoikeus_oid)
-WHERE ((oo.oppilaitos_oid IS NOT NULL AND oo.oppilaitos_oid LIKE ?) OR
-       (oo.koulutustoimija_oid IS NOT NULL AND oo.koulutustoimija_oid LIKE ?))
-  AND :nimi-filter
-      :tutkinto-filter
-      :osaamisala-filter
+WHERE oo.oppilaitos_oid = ?
+  AND (?::text[] IS NULL OR o.nimi ILIKE ALL (?::text[]))
+  AND (?::text IS NULL OR oo.tutkinto_nimi->>? ILIKE ?::text)
+  AND (?::text IS NULL OR oo.osaamisala_nimi->>? ILIKE ?::text)
   AND h.deleted_at IS NULL
-ORDER BY :order-by-column :desc
+ORDER BY CASE ?
+		WHEN 'nimi_asc' THEN o.nimi
+		WHEN 'tutkinto_asc' THEN oo.tutkinto_nimi->>?
+		WHEN 'osaamisala_asc' THEN oo.osaamisala_nimi->>?
+	END ASC,
+	CASE ?
+		WHEN 'nimi_desc' THEN o.nimi
+		WHEN 'tutkinto_desc' THEN oo.tutkinto_nimi->>?
+		WHEN 'osaamisala_desc' THEN oo.osaamisala_nimi->>?
+	END DESC
 LIMIT ?
 OFFSET ?

--- a/resources/db/oppijat/select_oppilaitos_oppijat_search_count.sql
+++ b/resources/db/oppijat/select_oppilaitos_oppijat_search_count.sql
@@ -1,13 +1,12 @@
 SELECT
-  COUNT(o.oid)
+  COUNT(oo.oid) AS count
 FROM oppijat AS o
-  LEFT OUTER JOIN opiskeluoikeudet AS oo
-    ON (o.oid = oo.oppija_oid)
-  INNER JOIN hoksit AS h
-    ON (oo.oid = h.opiskeluoikeus_oid)
-  WHERE
-    ((oo.oppilaitos_oid IS NOT NULL AND oo.oppilaitos_oid LIKE ?) OR
-     (oo.koulutustoimija_oid IS NOT NULL AND oo.koulutustoimija_oid LIKE ?)) AND
-    o.nimi ILIKE ?
-    :tutkinto-filter
-    :osaamisala-filter
+       LEFT OUTER JOIN opiskeluoikeudet AS oo
+                       ON (o.oid = oo.oppija_oid)
+       INNER JOIN hoksit AS h
+                       ON (oo.oid = h.opiskeluoikeus_oid)
+WHERE oo.oppilaitos_oid = ?
+  AND (?::text[] IS NULL OR o.nimi ILIKE ALL (?::text[]))
+  AND (?::text IS NULL OR oo.tutkinto_nimi->>? ILIKE ?::text)
+  AND (?::text IS NULL OR oo.osaamisala_nimi->>? ILIKE ?::text)
+  AND h.deleted_at IS NULL

--- a/scripts/upload-hoks.sh
+++ b/scripts/upload-hoks.sh
@@ -1,3 +1,4 @@
+test -z "$1" && echo "Usage: $0 <hoks-file.json>" 1>&2 && exit 1
 curl -i -b scripts/session-cookie.txt -H 'Content-type: application/json' \
- -H 'Caller-id: curl-poksutin' -d @resources/dev/demo-data/hoks_tuva.json \
+ -H 'Caller-id: curl-poksutin' -d "@$1" \
  http://localhost:3000/ehoks-virkailija-backend/api/v1/virkailija/oppijat/1.2.246.562.24.44651722625/hoksit 

--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -104,16 +104,10 @@
   ([queries arg & opts]
     (query queries (apply hash-map arg opts))))
 
-(defn convert-keys
+(defn map-keys
   "Apply a function to all keys in a map."
   [f m]
-  (rename-keys
-    m
-    (reduce
-      (fn [c n]
-        (assoc c n (f n)))
-      {}
-      (keys m))))
+  (zipmap (map f (keys m)) (vals m)))
 
 (defn remove-db-columns
   "Remove keys corresponding to columns used for internal purposes, keeping
@@ -127,12 +121,12 @@
 (defn to-underscore-keys
   "Convert dashes in keys to underscores."
   [m]
-  (convert-keys #(keyword (.replace (name %) \- \_)) m))
+  (map-keys #(keyword (.replace (name %) \- \_)) m))
 
 (defn to-dash-keys
   "Convert underscores in keys to dashes."
   [m]
-  (convert-keys #(keyword (.replace (name %) \_ \-)) m))
+  (map-keys #(keyword (.replace (name %) \_ \-)) m))
 
 (defn replace-in
   "Associate the value associated with sk with the new key or sequence of nested

--- a/src/oph/ehoks/db/db_operations/opiskeluoikeus.clj
+++ b/src/oph/ehoks/db/db_operations/opiskeluoikeus.clj
@@ -24,16 +24,6 @@
   [column params]
   (str (get translated-oppija-columns column) (get-locale params)))
 
-(defn- get-oppija-order-by-column
-  "Hakee sarakkeen, jolla tiedot järjestetään."
-  [params]
-  (let [column (:order-by-column params)]
-    (case column
-      :nimi "nimi"
-      :tutkinto (get-translated-oppija-column column params)
-      :osaamisala (get-translated-oppija-column column params)
-      "nimi")))
-
 (defn- get-translated-column-filter
   "Luo osan SQL-queryn WHERE-lauseesta, jolla tiedot suodatetaan."
   [column params]
@@ -43,24 +33,6 @@
     " ILIKE '"
     (get-like (column params))
     "'"))
-
-(defn set-oppijat-query
-  "Luo oppijat -queryn."
-  [params nimi-filter-count]
-  (-> queries/select-oppilaitos-oppijat
-      (cs/replace ":nimi-filter"
-                  (cs/join " AND " (repeat nimi-filter-count "o.nimi ILIKE ?")))
-      (cs/replace ":order-by-column"
-                  (get-oppija-order-by-column params))
-      (cs/replace ":desc" (if (:desc params) "DESC" "ASC"))
-      (cs/replace ":tutkinto-filter"
-                  (if (:tutkinto params)
-                    (get-translated-column-filter :tutkinto params)
-                    ""))
-      (cs/replace ":osaamisala-filter"
-                  (if (:osaamisala params)
-                    (get-translated-column-filter :osaamisala params)
-                    ""))))
 
 (defn set-oppijat-count-query
   "Luo oppijoiden määrä -queryn."

--- a/src/oph/ehoks/db/db_operations/opiskeluoikeus.clj
+++ b/src/oph/ehoks/db/db_operations/opiskeluoikeus.clj
@@ -3,50 +3,6 @@
             [oph.ehoks.db.db-operations.db-helpers :as db-ops]
             [clojure.string :as cs]))
 
-(defn get-like
-  "Luo LIKE-ekspression SQL:ää varten."
-  [v]
-  (format "%%%s%%" (or v "")))
-
-(def translated-oppija-columns
-  "Käännettyjen sarakkeiden pohjat."
-  {:tutkinto "tutkinto_nimi->>" :osaamisala "osaamisala_nimi->>"})
-
-(def default-locale "fi")
-
-(defn- get-locale
-  "Hakee nykyisen localen."
-  [params]
-  (str "'" (get params :locale default-locale) "'"))
-
-(defn- get-translated-oppija-column
-  "Hakee sarakkeen nimen, joka sisältää myös localen nimen."
-  [column params]
-  (str (get translated-oppija-columns column) (get-locale params)))
-
-(defn- get-translated-column-filter
-  "Luo osan SQL-queryn WHERE-lauseesta, jolla tiedot suodatetaan."
-  [column params]
-  (str
-    "AND oo."
-    (get-translated-oppija-column column params)
-    " ILIKE '"
-    (get-like (column params))
-    "'"))
-
-(defn set-oppijat-count-query
-  "Luo oppijoiden määrä -queryn."
-  [params]
-  (-> queries/select-oppilaitos-oppijat-search-count
-      (cs/replace ":tutkinto-filter"
-                  (if (:tutkinto params)
-                    (get-translated-column-filter :tutkinto params)
-                    ""))
-      (cs/replace ":osaamisala-filter"
-                  (if (:osaamisala params)
-                    (get-translated-column-filter :osaamisala params)
-                    ""))))
-
 (defn select-opiskeluoikeudet-without-tutkinto
   "Hakee tietokannasta opiskeluoikeudet, joissa ei ole tutkintoa."
   []

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -33,28 +33,28 @@
         osaamisala-ilike (field-matcher (:osaamisala params))
         lang (:locale params)
         order-by (str (:order-by-column params) "_"
-                      (if (:desc params) "desc" "asc"))]
-    (db-ops/query [queries/select-oppilaitos-oppijat
-                   (:oppilaitos-oid params)
-                   nimi-ilike nimi-ilike
-                   tutkinto-ilike lang tutkinto-ilike
-                   osaamisala-ilike lang osaamisala-ilike
-                   order-by lang lang
-                   order-by lang lang
-                   (:item-count params)
-                   (:offset params)]
-                  {:row-fn db-ops/from-sql})))
-
-(defn get-count
-  "Get total count of results"
-  [params]
-  (:count
-    (first
-      (db-ops/query
-        [(db-opiskeluoikeus/set-oppijat-count-query params)
-         (:oppilaitos-oid params)
-         (:koulutustoimija-oid params)
-         (db-opiskeluoikeus/get-like (:nimi params))]))))
+                      (if (:desc params) "desc" "asc"))
+        oppijat
+        (db-ops/query [queries/select-oppilaitos-oppijat
+                       (:oppilaitos-oid params)
+                       nimi-ilike nimi-ilike
+                       tutkinto-ilike lang tutkinto-ilike
+                       osaamisala-ilike lang osaamisala-ilike
+                       order-by lang lang
+                       order-by lang lang
+                       (:item-count params)
+                       (:offset params)]
+                      {:row-fn db-ops/from-sql})
+        total-count
+        (-> [queries/select-oppilaitos-oppijat-search-count
+             (:oppilaitos-oid params)
+             nimi-ilike nimi-ilike
+             tutkinto-ilike lang tutkinto-ilike
+             osaamisala-ilike lang osaamisala-ilike]
+            (db-ops/query)
+            (first)
+            :count)]
+    [oppijat total-count]))
 
 (defn get-amount-of-hoks
   "Get total amount of hokses now"

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -25,7 +25,7 @@
     (str "{" (cs/join "," (map field-matcher
                                (cs/split name-search #"[\s_%,]+"))) "}")))
 
-(defn search
+(defn search!
   "Search oppijat with given params"
   [params]
   (let [nimi-ilike (nimi-matcher (:nimi params))

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -44,7 +44,7 @@
     :return (restful/response
               [common-schema/OppijaSearchResult]
               :total-count s/Int)
-    :query-params [{order-by-column :- s/Keyword :nimi}
+    :query-params [{order-by-column :- s/Str "nimi"}
                    {desc :- s/Bool false}
                    {nimi :- s/Str nil}
                    {tutkinto :- s/Str nil}
@@ -76,26 +76,20 @@
            (str "User has insufficient privileges for "
                 "given organisation")}))
       (let [search-params
-            (cond->
-             {:desc desc
-              :item-count item-count
-              :order-by-column order-by-column
-              :offset (* page item-count)
-              :oppilaitos-oid oppilaitos-oid
-              :locale locale}
-              (some? nimi)
-              (assoc :nimi nimi)
-              (some? tutkinto)
-              (assoc :tutkinto tutkinto)
-              (some? osaamisala)
-              (assoc :osaamisala osaamisala))
-            oppijat (mapv
-                      #(dissoc
-                         % :oppilaitos-oid :koulutustoimija-oid)
-                      (op/search search-params))]
+            {:desc desc
+             :item-count item-count
+             :order-by-column order-by-column
+             :offset (* page item-count)
+             :oppilaitos-oid oppilaitos-oid
+             :locale locale
+             :nimi nimi
+             :tutkinto tutkinto
+             :osaamisala osaamisala}
+            oppijat (op/search search-params)
+            total-count (op/get-count search-params)]
         (restful/rest-ok
           oppijat
-          :total-count (op/get-count search-params))))))
+          :total-count total-count)))))
 
 (defn- check-opiskeluoikeus-match
   "Check that opiskeluoikeus OID from HOKS matches one held by student"

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -85,8 +85,7 @@
              :nimi nimi
              :tutkinto tutkinto
              :osaamisala osaamisala}
-            oppijat (op/search search-params)
-            total-count (op/get-count search-params)]
+            [oppijat total-count] (op/search search-params)]
         (restful/rest-ok
           oppijat
           :total-count total-count)))))

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -85,7 +85,7 @@
              :nimi nimi
              :tutkinto tutkinto
              :osaamisala osaamisala}
-            [oppijat total-count] (op/search search-params)]
+            [oppijat total-count] (op/search! search-params)]
         (restful/rest-ok
           oppijat
           :total-count total-count)))))

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -288,6 +288,15 @@
         (t/is (= (get-in body [:data 0 :oid])
                  "1.2.246.562.24.44000000003"))))))
 
+(t/deftest oppijat-sql-injection
+  (t/testing "oppijat endpoint doesn't have the SQL injection it used to"
+    (utils/with-db
+      (add-oppijat)
+      (add-hoksit)
+      (let [body (get-search {:tutkinto "';drop table hoksit;commit;--"})]
+        (t/is (= (count (:data body)) 0))
+        (t/is (= (get-in body [:meta :total-count]) 0))))))
+
 (t/deftest get-oppijat-filtered-with-swedish-locale
   (t/testing "GET virkailija oppijat filtered with swedish locale"
     (utils/with-db

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -231,12 +231,10 @@
       (let [body (get-search {})]
         (t/is (= (count (:data body)) 3))
         (t/is (= (get-in body [:meta :total-count]) 3))
-        (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000004"))
-        (t/is (= (get-in body [:data 1 :oid])
-                 "1.2.246.562.24.44000000003"))
-        (t/is (= (get-in body [:data 2 :oid])
-                 "1.2.246.562.24.44000000001"))))))
+        (t/is (= (set (map :oid (:data body)))
+                 #{"1.2.246.562.24.44000000004"
+                   "1.2.246.562.24.44000000003"
+                   "1.2.246.562.24.44000000001"}))))))
 
 (t/deftest get-oppijat-with-name-filter
   (t/testing "GET virkailija oppijat with name filtered"
@@ -255,7 +253,7 @@
       (add-oppijat)
       (add-hoksit)
       (let [body (get-search {:nimi "oppi"
-                              :order-by-column :nimi
+                              :order-by-column "nimi"
                               :desc true})]
         (t/is (= (count (:data body)) 2))
         (t/is (= (get-in body [:meta :total-count]) 2))
@@ -270,7 +268,7 @@
       (add-oppijat)
       (add-hoksit)
       (let [body (get-search {:nimi "oppi"
-                              :order-by-column :nimi})]
+                              :order-by-column "nimi"})]
         (t/is (= (count (:data body)) 2))
         (t/is (= (get-in body [:meta :total-count]) 2))
         (t/is (= (get-in body [:data 0 :oid])


### PR DESCRIPTION
## Kuvaus muutoksista

Muuttaa SQL-kyselyn sellaiseksi, että kaikki dynaamiset sisällöt tehdään parametreilla eikä rakennella dynaamisesti SQL-alilauseita.

https://jira.eduuni.fi/browse/EH-1467

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] Olemassa olevat testit menevät muutosten jälkeen läpi
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Koodimuutokset läpäisevät automaattisesti ajettavat linterit

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle

  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Tuotantoasennuksen ajankohdasta on sovittu
