### PR TITLE
Add hoks-id filter parameter and hoks-id result field in oppijat search endpoint

### DIFF
--- a/resources/db/oppijat/select_oppilaitos_oppijat.sql
+++ b/resources/db/oppijat/select_oppilaitos_oppijat.sql
@@ -2,7 +2,8 @@ SELECT o.oid,
        o.nimi,
        oo.oid AS opiskeluoikeus_oid,
        oo.tutkinto_nimi,
-       oo.osaamisala_nimi
+       oo.osaamisala_nimi,
+       h.id AS hoks_id
 FROM oppijat AS o
        LEFT OUTER JOIN opiskeluoikeudet AS oo
                        ON (o.oid = oo.oppija_oid)
@@ -12,6 +13,7 @@ WHERE oo.oppilaitos_oid = ?
   AND (?::text[] IS NULL OR o.nimi ILIKE ALL (?::text[]))
   AND (?::text IS NULL OR oo.tutkinto_nimi->>? ILIKE ?::text)
   AND (?::text IS NULL OR oo.osaamisala_nimi->>? ILIKE ?::text)
+  AND (?::int IS NULL OR h.id = ?::int)
   AND h.deleted_at IS NULL
 ORDER BY CASE ?
 		WHEN 'nimi_asc' THEN o.nimi

--- a/resources/db/oppijat/select_oppilaitos_oppijat_search_count.sql
+++ b/resources/db/oppijat/select_oppilaitos_oppijat_search_count.sql
@@ -9,4 +9,5 @@ WHERE oo.oppilaitos_oid = ?
   AND (?::text[] IS NULL OR o.nimi ILIKE ALL (?::text[]))
   AND (?::text IS NULL OR oo.tutkinto_nimi->>? ILIKE ?::text)
   AND (?::text IS NULL OR oo.osaamisala_nimi->>? ILIKE ?::text)
+  AND (?::int IS NULL OR h.id = ?::int)
   AND h.deleted_at IS NULL

--- a/src/oph/ehoks/common/schema.clj
+++ b/src/oph/ehoks/common/schema.clj
@@ -37,6 +37,7 @@
   {:oid s/Str
    :nimi s/Str
    :opiskeluoikeus-oid s/Str
+   (s/optional-key :hoks-id) s/Int
    (s/optional-key :tutkinto-nimi) {(s/optional-key :fi) s/Str
                                     (s/optional-key :en) s/Str
                                     (s/optional-key :sv) s/Str}

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -31,6 +31,7 @@
   (let [nimi-ilike (nimi-matcher (:nimi params))
         tutkinto-ilike (field-matcher (:tutkinto params))
         osaamisala-ilike (field-matcher (:osaamisala params))
+        hoks-id (:hoks-id params)
         lang (:locale params)
         order-by (str (:order-by-column params) "_"
                       (if (:desc params) "desc" "asc"))
@@ -40,6 +41,7 @@
                        nimi-ilike nimi-ilike
                        tutkinto-ilike lang tutkinto-ilike
                        osaamisala-ilike lang osaamisala-ilike
+                       hoks-id hoks-id
                        order-by lang lang
                        order-by lang lang
                        (:item-count params)
@@ -50,7 +52,8 @@
              (:oppilaitos-oid params)
              nimi-ilike nimi-ilike
              tutkinto-ilike lang tutkinto-ilike
-             osaamisala-ilike lang osaamisala-ilike]
+             osaamisala-ilike lang osaamisala-ilike
+             hoks-id hoks-id]
             (db-ops/query)
             (first)
             :count)]

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -49,13 +49,14 @@
                    {nimi :- s/Str nil}
                    {tutkinto :- s/Str nil}
                    {osaamisala :- s/Str nil}
+                   {hoks-id :- s/Int nil}
                    {item-count :- s/Int 10}
                    {page :- s/Int 0}
                    oppilaitos-oid :- s/Str
                    {locale :- s/Str "fi"}]
-    :summary "Listaa virkailijan oppilaitoksen oppijat, joilla on
-                       HOKS luotuna. Käyttäjällä pitää olla READ käyttöoikeus
-                       annettuun organisaatioon eHOKS-palvelussa."
+    :summary "Listaa virkailijan oppilaitoksen oppijoiden opiskeluoikeudet,
+             joilla on HOKS luotuna. Käyttäjällä pitää olla READ-käyttöoikeus
+             annettuun organisaatioon eHOKS-palvelussa."
 
     (if-not (contains?
               (user/get-organisation-privileges
@@ -84,7 +85,8 @@
              :locale locale
              :nimi nimi
              :tutkinto tutkinto
-             :osaamisala osaamisala}
+             :osaamisala osaamisala
+             :hoks-id hoks-id}
             [oppijat total-count] (op/search! search-params)]
         (restful/rest-ok
           oppijat

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -231,6 +231,8 @@
       (let [body (get-search {})]
         (t/is (= (count (:data body)) 3))
         (t/is (= (get-in body [:meta :total-count]) 3))
+        (t/is (= (set (map :hoks-id (:data body)))
+                 #{1 3 4}))
         (t/is (= (set (map :oid (:data body)))
                  #{"1.2.246.562.24.44000000004"
                    "1.2.246.562.24.44000000003"
@@ -244,8 +246,23 @@
       (let [body (get-search {:nimi "teu"})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:meta :total-count]) 1))
+        (t/is (= (get-in body [:data 0 :hoks-id]) 1))
         (t/is (= (get-in body [:data 0 :oid])
                  "1.2.246.562.24.44000000001"))))))
+
+(t/deftest get-oppijat-with-hoks-id
+  (t/testing "oppijat endpoint returns correct result by exact hoks-id"
+    (utils/with-db
+      (add-oppijat)
+      (add-hoksit)
+      (let [body (get-search {:hoks-id 3})]
+        (t/is (= (count (:data body)) 1))
+        (t/is (= (:total-count (:meta body)) 1))
+        (t/is (= (get-in body [:data 0 :oid]) "1.2.246.562.24.44000000003"))
+        (t/is (= (get-in body [:data 0 :hoks-id]) 3)))
+      (let [body (get-search {:hoks-id 30033})]
+        (t/is (= (count (:data body)) 0))
+        (t/is (= (:total-count (:meta body)) 0))))))
 
 (t/deftest get-oppijat-with-name-filter-and-order-desc
   (t/testing "GET virkailija oppijat ordered descending and filtered with name"


### PR DESCRIPTION
## Kuvaus muutoksista

PR lisää mahdollisuuden hakea opiskeluoikeuksia HOKS-id:n perusteella ja näyttää HOKS-id hakutuloksissa.

https://jira.eduuni.fi/browse/OY-4182

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] Olemassa olevat testit menevät muutosten jälkeen läpi
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Koodimuutokset läpäisevät automaattisesti ajettavat linterit

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Tuotantoasennuksen ajankohdasta on sovittu
