### PR TITLE
Naming and making tickets into PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,17 @@
 ## Kuvaus muutoksista
 
-TODO
+TODO: kirjoita
 
-## PR:iin liittyvä Jira-tiketti (tunniste ja linkki)
-
-TODO
+TODO: PR:iin liittyvä Jira-tiketti (tunniste ja linkki)
 
 ## Muistilista PR:n tekijälle ja katselmoijille
 
 ### Ennen asettamista katselmointiin
+  - [ ] Build onnistuu ilman virheitä
   - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
-  - [ ] Olemassa olevat testit menevät muutosten jälkeen läpi
   - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
   - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
-  - [ ] Koodimuutokset läpäisevät automaattisesti ajettavat linterit
+  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin
 
 ❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**
 
@@ -22,4 +20,4 @@ TODO
     - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
   - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
   - [ ] Muutokset on testattu QA-ympäristössä
-  - [ ] Tuotantoasennuksen ajankohdasta on sovittu
+  - [ ] Yli jääneet kehityskohteet on tiketöity

--- a/doc/code-guidelines.md
+++ b/doc/code-guidelines.md
@@ -8,6 +8,24 @@ tyyliopasta](https://github.com/bbatsov/clojure-style-guide). Näihin
 käytänteisiin on kuitenkin sovittu kehittäjien kesken joitain poikkeuksia,
 jotka on tarkemmin kuvattuna alla.
 
+#### Funktioiden ja muuttujien nimeäminen
+
+Muuttujat nimetään sen mukaan, mitä ne sisältävät, yleensä
+mahdollisimman semanttisella tasolla.  Esimerkiksi hyvä nimi
+muuttujalle, jossa on lista HOKSeista, jotka ovat muuttuneet, on
+`changed-hoksit` mieluummin kuin `hoksit` mieluummin kuin `maps`
+mieluummin kuin `coll` mieluummin kuin `obj`.
+
+Funktiot nimetään sen mukaan, mitä ne palauttavat, esimerkiksi
+`oppija-contact-details`.  Joskus nimeen voi ottaa myös vihjeitä siitä,
+mitä ensimmäinen positionaalinen argumentti tekee, esimerkiksi
+`hoks-by-opiskeluoikeus-oid`.  Jos funktio muuttaa funktion ulkopuolista
+tilaa, funktion nimessä pitää kuvailla, mitä tilaa se muuttaa ja miten.
+Lisäksi funktio on tällöin huutomerkillinen, katso alla.
+
+Älä tee funktioita, jotka sekä muuttavat funktion ulkopuolista tilaa
+että palauttavat jotain (muuta kuin nil).
+
 #### Huutomerkin käyttö funktion nimessä
 
 Clojure-yhteisön tyylioppaasta poiketen, projektissa **epäpuhtaat funktiot


### PR DESCRIPTION
## Kuvaus muutoksista

Päivitin PR templatea:
- yhdistin testit ja linterit kohdaksi "build menee läpi"
- tein vaatimuksen nimeämisestä
- muistutus ylijääneiden hommien tiketöimisestä
- otin pois "tuotantoasennuksen ajankohta sovittu", eihän me tehdä niin, vai mitä?  Olisiko tarkoitus ettei saa mergetä ellei tiedetä milloin asennetaan?

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
