### PR TITLE
Don't autogenerate yksiloiva tunniste in DB

### DIFF
--- a/src/db/migration/V1_1687861485788__No_autogeneration_of_yksiloiva_tunniste.sql
+++ b/src/db/migration/V1_1687861485788__No_autogeneration_of_yksiloiva_tunniste.sql
@@ -1,0 +1,2 @@
+ALTER TABLE osaamisen_hankkimistavat
+	ALTER yksiloiva_tunniste SET DEFAULT NULL;

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -234,7 +234,7 @@
     (add-opiskeluoikeus hoks)
     (add-hankintakoulutukset-to-index hoks opiskeluoikeudet))
   (check-virkailija-privileges hoks request)
-  (save-hoks hoks request))
+  (save-hoks (h/add-missing-oht-yksiloiva-tunniste hoks) request))
 
 (defn- get-hoks-perustiedot
   "Get basic information from HOKS"
@@ -730,7 +730,8 @@
                             "Ylikirjoittaa olemassa olevan HOKSin arvon tai
                              arvot"
                             :body [hoks-values hoks-schema/HOKSKorvaus]
-                            (put-hoks hoks-values hoks-id))
+                            (put-hoks (h/add-missing-oht-yksiloiva-tunniste
+                                        hoks-values) hoks-id))
 
                           (c-api/PATCH "/" request
                             :body [hoks-values hoks-schema/HOKSPaivitys]

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -350,7 +350,8 @@
         (is (= (:status post-response) 200))
         (is (= (:status put-response) 204))
         (is (= (:status get-response) 200))
-        (eq (:opiskeluvalmiuksia-tukevat-opinnot test-data/hoks-data)
+        (eq (utils/dissoc-module-ids
+              (:opiskeluvalmiuksia-tukevat-opinnot test-data/hoks-data))
             (utils/dissoc-module-ids
               (:opiskeluvalmiuksia-tukevat-opinnot get-response-data)))))))
 

--- a/test/oph/ehoks/hoks/hoks_parts/hankittavat_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_parts/hankittavat_handler_test.clj
@@ -32,7 +32,7 @@
             (utils/dissoc-module-ids
               (:data (utils/parse-body (:body ppto-new))))
             (assoc
-              parts-test-data/hpto-data
+              (utils/dissoc-module-ids parts-test-data/hpto-data)
               :id 1)))))))
 
 (deftest patch-all-hankittavat-paikalliset-tutkinnon-osat
@@ -69,7 +69,7 @@
                              :data)]
         (is (= (:status patch-response) 204))
         (eq (utils/dissoc-module-ids get-response)
-            (assoc parts-test-data/hpto-data
+            (assoc (utils/dissoc-module-ids parts-test-data/hpto-data)
                    :id 1
                    :nimi "2223"))))))
 
@@ -83,10 +83,9 @@
             (hoks-utils/create-mock-hoks-osa-get-request hyto-path app hoks)]
         (hoks-utils/assert-post-response-is-ok hyto-path post-response)
         (is (= (:status get-response) 200))
-        (eq (utils/dissoc-module-ids
-              (utils/parse-body
-                (:body get-response)))
-            {:meta {} :data (assoc parts-test-data/hyto-data :id 1)})))))
+        (eq (utils/dissoc-module-ids (utils/parse-body (:body get-response)))
+            {:meta {} :data (assoc (utils/dissoc-module-ids
+                                     parts-test-data/hyto-data) :id 1)})))))
 
 (def ^:private one-value-of-hyto-patched
   {:koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000012"})
@@ -125,7 +124,8 @@
             get-response-data (:data (utils/parse-body (:body get-response)))]
         (is (= (:status patch-response) 204))
         (eq (utils/dissoc-module-ids (:osa-alueet get-response-data))
-            (:osa-alueet parts-test-data/multiple-hyto-values-patched))))))
+            (utils/dissoc-module-ids
+              (:osa-alueet parts-test-data/multiple-hyto-values-patched)))))))
 
 (def hyto-sub-entity-patched
   {:osa-alueet parts-test-data/osa-alueet-of-hyto})
@@ -143,7 +143,7 @@
             get-response-data (:data (utils/parse-body (:body get-response)))]
         (is (= (:status patch-response) 204))
         (eq (utils/dissoc-module-ids (:osa-alueet get-response-data))
-            (:osa-alueet hyto-sub-entity-patched))))))
+            (utils/dissoc-module-ids (:osa-alueet hyto-sub-entity-patched)))))))
 
 (deftest post-and-get-hankittava-ammatillinen-osaaminen
   (testing "POST hankittava ammatillinen osaaminen and then get created hao"
@@ -164,10 +164,9 @@
                 "%s/1/hankittava-ammat-tutkinnon-osa/1"
                 hoks-utils/base-url)}})
         (is (= (:status get-response) 200))
-        (eq (utils/dissoc-module-ids
-              (utils/parse-body
-                (:body get-response)))
-            {:meta {} :data (assoc parts-test-data/hao-data :id 1)})))))
+        (eq (utils/dissoc-module-ids (utils/parse-body (:body get-response)))
+            {:meta {} :data (assoc (utils/dissoc-module-ids
+                                     parts-test-data/hao-data) :id 1)})))))
 
 (deftest patch-all-hankittava-ammatillinen-osaaminen
   (testing "PATCH ALL hankittava ammat osaaminen"
@@ -183,11 +182,10 @@
             get-response
             (hoks-utils/create-mock-hoks-osa-get-request hao-path app hoks)]
         (is (= (:status patch-response) 204))
-        (eq (utils/dissoc-module-ids
-              (utils/parse-body
-                (:body get-response)))
+        (eq (utils/dissoc-module-ids (utils/parse-body (:body get-response)))
             {:meta {} :data
-             (assoc parts-test-data/patch-all-hao-data :id 1)})))))
+             (assoc (utils/dissoc-module-ids parts-test-data/patch-all-hao-data)
+                    :id 1)})))))
 
 (deftest patch-one-hankittava-ammatilinen-osaaminen
   (testing "PATCH one value hankittava ammatillinen osaaminen"

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -346,7 +346,7 @@
         (utils/dissoc-module-ids
           (ah/get-aiemmin-hankitut-ammat-tutkinnon-osat
             (:id hoks)))
-        ahato-data))))
+        (utils/dissoc-module-ids ahato-data)))))
 
 (deftest get-aiemmin-hankitut-paikalliset-tutkinnon-osat-test
   (testing "Get HOKS aiemmin hankitut paikalliset tutkinnon osat"
@@ -356,7 +356,7 @@
       (eq
         (utils/dissoc-module-ids
           (ah/get-aiemmin-hankitut-paikalliset-tutkinnon-osat (:id hoks)))
-        ahpto-data))))
+        (utils/dissoc-module-ids ahpto-data)))))
 
 (deftest get-hankittava-ammat-tutkinnon-osa-test
   (testing "Get HOKS hankittava ammatillinen osaaminen"
@@ -365,7 +365,7 @@
       (eq
         (utils/dissoc-module-ids
           (ha/get-hankittavat-ammat-tutkinnon-osat (:id hoks)))
-        hao-data))))
+        (utils/dissoc-module-ids hao-data)))))
 
 (deftest get-opiskeluvalmiuksia-tukevat-opinnot-test
   (testing "Get HOKS opiskeluvalmiuksia tukevat opinnot"
@@ -374,7 +374,7 @@
       (eq
         (utils/dissoc-module-ids
           (ot/get-opiskeluvalmiuksia-tukevat-opinnot (:id hoks)))
-        oto-data))))
+        (utils/dissoc-module-ids oto-data)))))
 
 (deftest get-aiemmin-hankitut-yhteiset-tutkinnon-osat-test
   (testing "Get HOKS aiemmin hankitut yhteiset tutkinnon osat"
@@ -383,7 +383,7 @@
       (eq
         (utils/dissoc-module-ids
           (ah/get-aiemmin-hankitut-yhteiset-tutkinnon-osat (:id hoks)))
-        ahyto-data))))
+        (utils/dissoc-module-ids ahyto-data)))))
 
 (deftest get-hankittavat-paikalliset-tutkinnon-osat-test
   (testing "Set HOKS hankittavat paikalliset tutkinnon osat"
@@ -394,7 +394,7 @@
       (eq
         (utils/dissoc-module-ids
           (ha/get-hankittavat-paikalliset-tutkinnon-osat (:id hoks)))
-        hpto-data))))
+        (utils/dissoc-module-ids hpto-data)))))
 
 (deftest get-hankittavat-yhteiset-tutkinnon-osat-test
   (testing "Get HOKS hankittavat yhteiset tutkinnon osat"
@@ -403,7 +403,7 @@
       (eq
         (utils/dissoc-module-ids
           (ha/get-hankittavat-yhteiset-tutkinnon-osat (:id hoks)))
-        hyto-data))))
+        (utils/dissoc-module-ids hyto-data)))))
 
 (deftest get-hankittavat-koulutuksen-osat
   (testing "GET TUVA hankittavat koulutuksen osat"
@@ -421,7 +421,7 @@
       (eq
         (utils/dissoc-module-ids (h/get-hoks-by-id (:id hoks)))
         (assoc
-          hoks-data
+          (utils/dissoc-module-ids hoks-data)
           :id 1
           :eid (:eid hoks)
           :manuaalisyotto false)))))

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -98,9 +98,8 @@
     (is (= (:status post-response) 200))
     (is (= (:status put-response) 204))
     (is (= (:status get-response) 200))
-    (eq (utils/dissoc-module-ids
-          (hoks-part get-response-data))
-        (hoks-part updated-hoks))))
+    (eq (utils/dissoc-module-ids (hoks-part get-response-data))
+        (utils/dissoc-module-ids (hoks-part updated-hoks)))))
 
 (defn assert-post-response-is-ok [post-path post-response]
   (is (= (:status post-response) 200))

--- a/test/oph/ehoks/oppija/handler_test.clj
+++ b/test/oph/ehoks/oppija/handler_test.clj
@@ -55,12 +55,13 @@
           body (utils/parse-body (:body get-response))]
       (is (= (:status post-response) 200))
       (is (= (:status get-response) 200))
-      (eq
-        (utils/dissoc-module-ids (:data body))
-        [(dates-to-str
-           (assoc test-data/hoks-data
-                  :eid (get-in body [:data 0 :eid])
-                  :manuaalisyotto false))]))))
+      (-> test-data/hoks-data
+          (utils/dissoc-module-ids)
+          (assoc :eid (get-in body [:data 0 :eid])
+                 :manuaalisyotto false)
+          (dates-to-str)
+          (vector)
+          (eq (utils/dissoc-module-ids (:data body)))))))
 
 (defn- mock-authenticated [request]
   (let [store (atom {})

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -277,7 +277,7 @@
       (reduce (fn [res val]
                 (conj res [(first val) (dissoc-module-ids (second val))]))
               {}
-              (dissoc data :module-id))
+              (dissoc data :module-id :yksiloiva-tunniste))
       (map #(dissoc-module-ids %) data))
     data))
 


### PR DESCRIPTION
Instead, generate it in the API endpoint for manually creating a HOKS (POST .../api/v1/virkailija/hoksit).

## Kuvaus muutoksista

Tää PR ei (vielä) estä HOKSien tallentamista ilman osaamisenhankkimistapojen yksilöiviä tunnisteita, mutta muuttaa toimintaa siten, että yksilöivät tunnisteet muodostetaan automaattisesti vain niille OHT:ille, jotka ovat uudessa, manuaalisyötetyssä HOKSissa.

https://jira.eduuni.fi/browse/EH-1472

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
