### PR TITLE
Add response schemata to most virkailija endpoints

### DIFF
--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -28,6 +28,7 @@
         :query-params [start :- LocalDate
                        end :- LocalDate
                        limit :- (s/maybe s/Int)]
+        :return s/Int
         (let [l (or limit 10)
               periods (hp/process-finished-workplace-periods start end l)]
           (restful/rest-ok (count periods))))
@@ -37,6 +38,7 @@
         :query-params [start :- LocalDate
                        end :- LocalDate
                        limit :- (s/maybe s/Int)]
+        :return s/Int
         (let [l (or limit 10)
               hoksit (hp/process-hoksit-without-kyselylinkit start end l)]
           (restful/rest-ok (count hoksit))))
@@ -61,6 +63,7 @@
         :header-params [caller-id :- s/Str]
         :query-params [from :- LocalDate
                        to :- LocalDate]
+        :return {:count s/Int}
         (let [count (hp/resend-aloituskyselyherate-between from to)]
           (restful/rest-ok {:count count})))
 
@@ -69,6 +72,7 @@
         :header-params [caller-id :- s/Str]
         :query-params [from :- LocalDate
                        to :- LocalDate]
+        :return {:count s/Int}
         (let [count (hp/resend-paattokyselyherate-between from to)]
           (restful/rest-ok {:count count})))
 
@@ -102,7 +106,7 @@
             kerrallaan. Palauttaa kyseisten jaksojen id:t (hankkimistapa-id)
             herätepalvelua varten. POISTETTU KÄYTÖSTÄ TILAPÄISESTI."
         :header-params [caller-id :- s/Str]
-
+        :return {:hankkimistapa-ids [s/Int]}
         (let [hankkimistavat
               []] ;(db-hoks/delete-tyopaikkaohjaajan-yhteystiedot!)]
           (restful/rest-ok {:hankkimistapa-ids hankkimistavat})))
@@ -113,5 +117,6 @@
             tiedot kerrallaan. Palauttaa kyseisten tapausten hoks id:t
             herätepalvelua varten. POISTETTU KÄYTÖSTÄ TILAPÄISESTI."
         :header-params [caller-id :- s/Str]
+        :return {:hoks-ids [s/Int]}
         (let [hoks-ids []] ;(db-hoks/delete-opiskelijan-yhteystiedot!)]
           (restful/rest-ok {:hoks-ids hoks-ids}))))))

--- a/src/oph/ehoks/virkailija/external_handler.clj
+++ b/src/oph/ehoks/virkailija/external_handler.clj
@@ -122,7 +122,7 @@
       (c-api/GET "/koulutuksenOsa/:koodi-uri" [:as request]
         :summary "Hakee koulutuksenOsan ePerusteet-palvelusta"
         :path-params [koodi-uri :- s/Str]
-        :return (restful/response  [s/Any])
+        :return (restful/response [s/Any])
         (restful/with-not-found-handling
           (eperusteet/get-koulutuksenOsa-by-koodiUri koodi-uri))))
 

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -430,6 +430,9 @@
                                end :- LocalDate
                                {pagesize :- s/Int 25}
                                {pageindex :- s/Int 0}]
+                :return {:count s/Int
+                         :pagecount s/Int
+                         :result [s/Any]}
                 (cond (and oppilaitos
                            (contains?
                              (user/get-organisation-privileges
@@ -475,6 +478,7 @@
                 :summary "Vastaajatunnuksen tiedot"
                 :header-params [caller-id :- s/Str]
                 :path-params [tunnus :- s/Str]
+                :return s/Any
                 (get-vastaajatunnus-info tunnus))
 
               (c-api/DELETE "/vastaajatunnus/:tunnus" []
@@ -490,6 +494,9 @@
                 :path-params [oppilaitosoid :- s/Str]
                 :query-params [{pagesize :- s/Int 25}
                                {pageindex :- s/Int 0}]
+                :return {:count s/Int
+                         :pagecount s/Int
+                         :result [s/Any]}
                 (if (contains? (user/get-organisation-privileges
                                  (get-in request [:session :virkailija-user])
                                  oppilaitosoid)
@@ -523,6 +530,11 @@
                                {alkupvm-loppu :- LocalDate (LocalDate/now)}
                                {limit :- s/Int 2000}
                                {from-id :- s/Int 0}]
+                :return {:last-id s/Int
+                         :paattokysely-total-count s/Int
+                         :o-s-pvm-ilman-vahvistuspvm-count s/Int
+                         :vahvistuspvm-ilman-o-s-pvm-count s/Int
+                         :vahvistuspvm-ja-o-s-pvm s/Int}
                 (let [data (db-hoks/select-kyselylinkit-by-date-and-type-temp
                              alkupvm alkupvm-loppu from-id limit)
                       last-id (:hoks-id (last data))]
@@ -575,6 +587,9 @@
                 true."
                 :query-params [{limit :- s/Int 2000}
                                {from-id :- s/Int 0}]
+                :return {:count s/Int
+                         :ids [s/Int]
+                         :last-id s/Int}
                 (let [hoksit (db-hoks/select-hokses-greater-than-id
                                from-id
                                limit
@@ -672,6 +687,7 @@
                         :path-params [hoks-id :- s/Int]
                         :summary "Hoksin tiedot.
                                 Vaatii manuaalisyöttäjän oikeudet"
+                        :return hoks-schema/HOKS
                         (get-hoks hoks-id request))
 
                       (c-api/POST "/:hoks-id/resend-palaute" request
@@ -679,6 +695,7 @@
                                   uudelleen lähetykselle"
                         :path-params [hoks-id :- s/Int]
                         :body [data hoks-schema/palaute-resend]
+                        :return {:sahkoposti s/Str}
                         (let [kyselylinkit
                               (heratepalvelu/get-oppija-kyselylinkit
                                 oppija-oid)
@@ -705,6 +722,7 @@
                         :summary "Palauttaa tietoja oppijan aktiivisista
                                   kyselylinkeistä (ilman kyselytunnuksia)"
                         :path-params [hoks-id :- s/Int]
+                        :return [s/Any]
                         (let [kyselylinkit
                               (heratepalvelu/get-oppija-kyselylinkit
                                 oppija-oid)
@@ -745,6 +763,7 @@
                           :summary "Asettaa HOKSin
                               poistetuksi(shallow delete) id:n perusteella."
                           :body [data hoks-schema/shallow-delete-hoks]
+                          :return {:success s/Int}
                           (let [hoks (h/get-hoks-by-id hoks-id)
                                 oppilaitos-oid (if (seq (:oppilaitos-oid data))
                                                  (:oppilaitos-oid data)
@@ -801,6 +820,7 @@
                         (c-api/GET "/" []
                           :summary "Kaikki hoksit (perustiedot).
                         Tarvitsee OPH-pääkäyttäjän oikeudet"
+                          :return [s/Any]
                           (restful/rest-ok (db-hoks/select-hoksit))))))
 
                   (route-middleware

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -625,10 +625,8 @@
                   :path-params [oppija-oid :- s/Str]
 
                   (c-api/POST "/index" []
-                    :summary
-                    "Indeksoi oppijan tiedot, jos on tarpeen. DEPRECATED"
-                    (a/go
-                      (response/ok {:message "Route is deprected."})))
+                    :summary "Indeksoi oppijan tiedot. DEPRECATED"
+                    (response/gone {:message "Route is deprected."}))
 
                   (c-api/context "/hoksit" []
                     (c-api/POST "/" [:as request]
@@ -648,8 +646,7 @@
                       (c-api/GET "/oppilaitos/:oppilaitos-oid" request
                         :path-params [oppilaitos-oid :- s/Str]
                         :return (restful/response [hoks-schema/HOKS])
-                        :summary "Oppijan hoksit (perustiedot,
-                                                  rajoitettu uusi versio)"
+                        :summary "Oppijan hoksit (rajoitettu uusi versio)"
                         (if (contains?
                               (user/get-organisation-privileges
                                 (get-in

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -156,8 +156,7 @@
           (restful/rest-ok {:opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
                             :oppija-oid (:oppija-oid hoks)})
           (do
-            (log/warn "No HOKS found with given hoks-id "
-                      hoks-id)
+            (log/warn "No HOKS found with given hoks-id" hoks-id)
             (response/not-found
               {:error "No HOKS found with given hoks-id"})))))
 

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -244,6 +244,7 @@
       :header-params [caller-id :- s/Str]
       :query-params [from :- LocalDate
                      to :- LocalDate]
+      :return {:count s/Int}
       (let [count (hp/resend-aloituskyselyherate-between from to)]
         (restful/rest-ok {:count count})))
 
@@ -252,5 +253,6 @@
       :header-params [caller-id :- s/Str]
       :query-params [from :- LocalDate
                      to :- LocalDate]
+      :return {:count s/Int}
       (let [count (hp/resend-paattokyselyherate-between from to)]
         (restful/rest-ok {:count count})))))


### PR DESCRIPTION
## Kuvaus muutoksista

Aiemmin hoksien GET-endpointissa ei voinut olla skeemaa, jottei response menisi hajalle validoinnissa vanhan väärän datan vuoksi.  Nyt kuitenkin ei-validitkin vastaukset päästetään läpi, joten skeeman voi hyvin lisätä dokumentaatioksi.  Lisätään samalla muihinkin skeemoihin, joista puuttuu.

Osa lisätyistä skeemoista on tosi epämääräisiä (turvautuu nopeasti s/Anyyn), koska varsinaisen skeeman selvittäminen tämän PR:n osana ei oo kohtuullinen työmäärä.  Voidaan tehdä niistä erillisiä PR:ia.

https://jira.eduuni.fi/browse/EH-1452

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
