### PR TITLE
Parameterise HOKS schema to make yksiloiva tunniste mandatory for system transfer

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -101,14 +101,14 @@
     (c-api/GET "/:id" []
       :summary "Palauttaa HOKSin hankittavan yhteisen tutkinnon osan"
       :path-params [id :- s/Int]
-      :return (rest/response hoks-schema/HankittavaYTO)
+      :return (rest/response hoks-schema/HankittavaYhteinenTutkinnonOsa)
       (rest/rest-ok
         (dissoc (ha/get-hankittava-yhteinen-tutkinnon-osa id) :hoks-id)))
 
     (c-api/POST "/" [:as request]
       :summary
       "Luo (tai korvaa vanhan) hankittavan yhteisen tutkinnon osat HOKSiin"
-      :body [hyto partial-hoks-schema/HankittavaYTOLuonti]
+      :body [hyto partial-hoks-schema/HankittavaYhteinenTutkinnonOsaLuonti]
       :return (rest/response schema/POSTResponse :id s/Int)
       (let [hyto-response (ha/save-hankittava-yhteinen-tutkinnon-osa!
                             (get-in request [:hoks :id]) hyto)]
@@ -120,7 +120,7 @@
       :summary
       "Päivittää HOKSin hankittavan yhteisen tutkinnon osat arvoa tai arvoja"
       :path-params [id :- s/Int]
-      :body [values partial-hoks-schema/HankittavaYTOPaivitys]
+      :body [values partial-hoks-schema/HankittavaYhteinenTutkinnonOsaPaivitys]
       (let [hyto (pdb-ha/select-hankittava-yhteinen-tutkinnon-osa-by-id id)]
         (if (not-empty hyto)
           (do

--- a/src/oph/ehoks/hoks/partial_hoks_schema.clj
+++ b/src/oph/ehoks/hoks/partial_hoks_schema.clj
@@ -27,19 +27,19 @@
       :koulutuksen-jarjestaja-oid]}))
 
 (s/defschema
-  HankittavaYTOLuonti
+  HankittavaYhteinenTutkinnonOsaLuonti
   "Schema hankittavan yhteisen tutkinnon osan luontikyselyyn."
   (modify
-    hoks-schema/HankittavaYTOLuontiJaMuokkaus
+    hoks-schema/HankittavaYhteinenTutkinnonOsaLuontiJaMuokkaus
     (str "Hankittavan yhteinen tutkinnon osan tiedot uutta merkintää "
          "luotaessa (POST)")
     {:removed [:id :module-id]}))
 
 (s/defschema
-  HankittavaYTOPaivitys
+  HankittavaYhteinenTutkinnonOsaPaivitys
   "Schema hankittavan yhteisen tutkinnon osan päivityskyselyyn."
   (modify
-    hoks-schema/HankittavaYTOPatch
+    hoks-schema/HankittavaYhteinenTutkinnonOsaPatch
     (str "Hankittavan yhteinen tutkinnon osan tiedot kenttää tai kenttiä "
          "päivittäessä (PATCH)")
     {:removed [:module-id]

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -272,7 +272,7 @@
                :description (str "Tietorakenteen yksilöivä tunniste "
                                  "esimerkiksi tiedon jakamista varten")}
    :yksiloiva-tunniste
-   {:methods {:any :optional  ; TODO: change to :required
+   {:methods {:any :required
               :post-virkailija :optional
               :put-virkailija :optional
               :patch-virkailija :optional}

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -395,135 +395,140 @@
     [KoulutuksenJarjestajaArvioija]
     "Mikäli todennettu arvioijan kautta, annetaan arvioijien tiedot."))
 
-(s/defschema
-  OsaamisenOsoittaminen
-  "Osaamisen osoittamisen schema."
-  (describe
-    "Hankittavaan tutkinnon osaan tai yhteisen tutkinnon osan osa-alueeseen
-    sisältyvä osaamisen osoittaminen: näyttö tai muu osaamisen osoittaminen."
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    (s/optional-key :jarjestaja) NaytonJarjestaja
-    "Näytön tai osaamisen osoittamisen järjestäjä"
-    (s/optional-key :osa-alueet) [KoodistoKoodi]
-    (str "Suoritettavan tutkinnon osan näyttöön sisältyvän"
-         "yton osa-alueiden Koodisto-koodi-URIt
-         eperusteet-järjestelmässä muotoa ammatillisenoppiaineet_xxx"
-         "esim. ammatillisenoppiaineet_etk")
-    :nayttoymparisto Nayttoymparisto
-    "Organisaatio, jossa näyttö tai osaamisen osoittaminen annetaan"
-    :sisallon-kuvaus [s/Str]
-    (str "Tiivis kuvaus (esim. lista) työtilanteista ja työprosesseista, joiden
-    avulla ammattitaitovaatimusten tai osaamistavoitteiden mukainen osaaminen
-    osoitetaan. Vastaavat tiedot muusta osaamisen osoittamisesta siten, että
-    tieto kuvaa sovittuja tehtäviä ja toimia, joiden avulla osaaminen
-    osoitetaan.")
-    :alku LocalDate
-    "Näytön tai osaamisen osoittamisen alkupäivämäärä muodossa
-    YYYY-MM-DD"
-    :loppu LocalDate
-    "Näytön tai osaamisen osoittamisen loppupäivämäärä muodossa
-    YYYY-MM-DD"
-    (s/optional-key :koulutuksen-jarjestaja-osaamisen-arvioijat)
-    [KoulutuksenJarjestajaArvioija] "Näytön tai osaamisen osoittamisen
-    arvioijat"
-    (s/optional-key :tyoelama-osaamisen-arvioijat) [TyoelamaOsaamisenArvioija]
-    "Näytön tai osaamisen osoittamisen arvioijat"
-    (s/optional-key :vaatimuksista-tai-tavoitteista-poikkeaminen) s/Str
-    (str "Tutkinnon osan tai osa-alueen perusteisiin sisältyvät
-    ammattitaitovaatimukset tai osaamistavoitteet, joista opiskelijan kohdalla
-    poiketaan.")
-    (s/optional-key :yksilolliset-kriteerit) [s/Str]
-    (str "Ammattitaitovaatimus tai osaamistavoite, johon yksilölliset
-    arviointikriteerit kohdistuvat ja yksilölliset arviointikriteerit kyseiseen
-    ammattitaitovaatimukseen tai osaamistavoitteeseen.")))
+(def OsaamisenOsoittaminen-template
+  ^{:doc (str "Hankittavaan tutkinnon osaan tai yhteisen tutkinnon osan "
+              "osa-alueeseen sisältyvä osaamisen osoittaminen: "
+              "näyttö tai muu osaamisen osoittaminen.")
+    :type ::g/schema-template
+    :name "OsaamisenOsoittaminen"}
+  {:id {:methods {:any :excluded, :patch :optional, :get :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
+   :jarjestaja {:methods {:any :optional}
+                :types {:any NaytonJarjestaja}
+                :description "Näytön tai osaamisen osoittamisen järjestäjä"}
+   :osa-alueet
+   {:methods {:any :optional}
+    :types {:any [KoodistoKoodi]}
+    :description
+    (str "Suoritettavan tutkinnon osan näyttöön sisältyvän yton osa-alueiden "
+         "Koodisto-koodi-URIt eperusteet-järjestelmässä muotoa "
+         "ammatillisenoppiaineet_xxx, esim. ammatillisenoppiaineet_etk")}
+   :nayttoymparisto {:methods {:any :required}
+                     :types {:any Nayttoymparisto}
+                     :description (str "Organisaatio, jossa näyttö tai "
+                                       "osaamisen osoittaminen annetaan")}
+   :sisallon-kuvaus
+   {:methods {:any :required}
+    :types {:any [s/Str]}
+    :description
+    (str "Tiivis kuvaus (esim. lista) työtilanteista ja työprosesseista, "
+         "joiden avulla ammattitaitovaatimusten tai osaamistavoitteiden "
+         "mukainen osaaminen osoitetaan. Vastaavat tiedot muusta osaamisen "
+         "osoittamisesta siten, että tieto kuvaa sovittuja tehtäviä ja toimia, "
+         "joiden avulla osaaminen osoitetaan.")}
+   :alku {:methods {:any :required}
+          :types {:any LocalDate}
+          :description "Näytön tai osaamisen osoittamisen alkupäivämäärä"}
+   :loppu {:methods {:any :required}
+           :types {:any LocalDate}
+           :description "Näytön tai osaamisen osoittamisen loppupäivämäärä"}
+   :koulutuksen-jarjestaja-osaamisen-arvioijat
+   {:methods {:any :optional}
+    :types {:any [KoulutuksenJarjestajaArvioija]}
+    :description "Näytön tai osaamisen osoittamisen arvioijat"}
+   :tyoelama-osaamisen-arvioijat
+   {:methods {:any :optional}
+    :types {:any [TyoelamaOsaamisenArvioija]}
+    :description "Näytön tai osaamisen osoittamisen arvioijat"}
+   :vaatimuksista-tai-tavoitteista-poikkeaminen
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description (str "Tutkinnon osan tai osa-alueen perusteisiin sisältyvät "
+                      "ammattitaitovaatimukset tai osaamistavoitteet, joista "
+                      "opiskelijan kohdalla poiketaan.")}
+   :yksilolliset-kriteerit
+   {:methods {:any :optional}
+    :types {:any [s/Str]}
+    :description
+    (str "Ammattitaitovaatimus tai osaamistavoite, johon yksilölliset"
+         "arviointikriteerit kohdistuvat ja yksilölliset arviointikriteerit "
+         "kyseiseen ammattitaitovaatimukseen tai osaamistavoitteeseen.")}})
 
-(s/defschema
-  OsaamisenOsoittaminenLuontiJaMuokkaus
-  "Schema osaamisen osoittamisen luontiin ja muokkaukseen."
-  (modify
-    OsaamisenOsoittaminen
-    "Osaamisen hankkimisen tavan luonti ja muokkaus (POST, PUT)"
-    {:removed [:module-id :id]}))
+(s/defschema OsaamisenOsoittaminen
+             (g/generate OsaamisenOsoittaminen-template :get))
 
-(s/defschema
-  OsaamisenOsoittaminenPatch
-  "Schema osaamisen osoittamisen PATCH-päivitykseen."
-  (modify
-    OsaamisenOsoittaminen
-    "Osaamisen hankkimisen tavan luonti muokkaus (PATCH)"
-    {:removed [:module-id]}))
+(s/defschema OsaamisenOsoittaminenLuontiJaMuokkaus
+             (g/generate OsaamisenOsoittaminen-template :post))
 
-(s/defschema
-  YhteisenTutkinnonOsanOsaAlue
-  "Yhteisen tutkinnon osa osa-alueen schema."
-  (describe
-    "Hankittavan yhteinen tutkinnon osan (YTO) osa-alueen tiedot"
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    :osa-alue-koodi-uri OsaAlueKoodiUri
-    "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"
-    :osa-alue-koodi-versio s/Int
-    "Osa-alueen Koodisto-koodi-URIn versio (ammatillisenoppiaineet)"
-    (s/optional-key :osaamisen-hankkimistavat) [OsaamisenHankkimistapa]
-    "Osaamisen hankkimistavat"
-    (s/optional-key :vaatimuksista-tai-tavoitteista-poikkeaminen) s/Str
-    "vaatimuksista tai osaamistavoitteista poikkeaminen"
-    (s/optional-key :osaamisen-osoittaminen)
-    [OsaamisenOsoittaminen]
-    "Hankitun osaamisen osoittaminen: Näyttö tai muu osaamisen osoittaminen"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
-    (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
+(s/defschema OsaamisenOsoittaminenPatch
+             (g/generate OsaamisenOsoittaminen-template :patch))
+
+(def YhteisenTutkinnonOsanOsaAlue-template
+  ^{:doc "Hankittavan yhteinen tutkinnon osan (YTO) osa-alueen tiedot"
+    :type ::g/schema-template
+    :name "YhteisenTutkinnonOsanOsaAlue"}
+  {:id {:methods {:any :excluded, :get :optional, :patch :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
+   :osa-alue-koodi-uri
+   {:methods {:any :required}
+    :types {:any OsaAlueKoodiUri}
+    :description "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"}
+   :osa-alue-koodi-versio
+   {:methods {:any :required}
+    :types {:any s/Int}
+    :description "Osa-alueen Koodisto-koodi-URIn versio"}
+   :osaamisen-hankkimistavat {:methods {:any :optional}
+                              :types {:any [OsaamisenHankkimistapa-template]}
+                              :description "Osaamisen hankkimistavat"}
+   :vaatimuksista-tai-tavoitteista-poikkeaminen
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description "vaatimuksista tai osaamistavoitteista poikkeaminen"}
+   :osaamisen-osoittaminen
+   {:methods {:any :optional}
+    :types {:any [OsaamisenOsoittaminen-template]}
+    :description (str "Hankitun osaamisen osoittaminen: "
+                      "Näyttö tai muu osaamisen osoittaminen")}
+   :koulutuksen-jarjestaja-oid
+   {:methods {:any :optional}
+    :types {:any Oid}
+    :description
+    (str "Organisaation tunniste Opintopolku-palvelussa. Oid-numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
-         "koulutuksen järjestäjän oid.")
-    (s/optional-key :olennainen-seikka) s/Bool
+         "koulutuksen järjestäjän oid.")}
+   :olennainen-seikka
+   {:methods {:any :optional}
+    :types {:any s/Bool}
+    :description
     (str "Tieto sellaisen seikan olemassaolosta, jonka koulutuksen järjestäjä "
          "katsoo oleelliseksi tutkinnon osaan tai osa-alueeseen liittyvän "
-         "osaamisen hankkimisessa tai osoittamisessa.")
-    (s/optional-key :opetus-ja-ohjaus-maara)
-    (s/constrained s/Num
-                   #(not (neg? %))
-                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")
-    (str "Tutkinnon osan osa-alueeseen suunnitellun opetuksen ja ohjauksen "
-         "määrä tunteina.")))
+         "osaamisen hankkimisessa tai osoittamisessa.")}
+   :opetus-ja-ohjaus-maara
+   {:methods {:any :optional}
+    :types {:any (s/constrained
+                   s/Num #(not (neg? %))
+                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")}
+    :description (str "Tutkinnon osan osa-alueeseen suunnitellun opetuksen "
+                      "ja ohjauksen määrä tunteina.")}})
 
-(s/defschema
-  YhteisenTutkinnonOsanOsaAlueLuontiJaMuokkaus
-  "Schema hankittavan yhteisen tutkinnon osan osa-alueen luontiin ja
-  muokkaukseen."
-  (modify
-    YhteisenTutkinnonOsanOsaAlue
-    "Hankittavan yhteinen tutkinnon osan (YTO) osa-alueen tiedot (POST, PUT)"
-    {:removed [:module-id :osaamisen-osoittaminen :osaamisen-hankkimistavat :id]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaLuontiJaMuokkaus] "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenLuontiJaMuokkaus]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema YhteisenTutkinnonOsanOsaAlue
+             (g/generate YhteisenTutkinnonOsanOsaAlue-template :get))
 
-(s/defschema
-  YhteisenTutkinnonOsanOsaAluePatch
-  "Schema hankittavan yhteisen tutkinnon osan osa-alueen PATCH-päivitykseen."
-  (modify
-    YhteisenTutkinnonOsanOsaAlue
-    "Hankittavan yhteinen tutkinnon osan (YTO) osa-alueen tiedot (PATCH)"
-    {:removed [:module-id :osaamisen-osoittaminen :osaamisen-hankkimistavat]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaPatch]
-       "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenPatch]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema YhteisenTutkinnonOsanOsaAlueLuontiJaMuokkaus
+             (g/generate YhteisenTutkinnonOsanOsaAlue-template :post))
+
+(s/defschema YhteisenTutkinnonOsanOsaAluePatch
+             (g/generate YhteisenTutkinnonOsanOsaAlue-template :patch))
 
 (s/defschema
   AiemminHankitunYTOOsaAlue

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -605,11 +605,10 @@
   {:id {:methods {:any :excluded, :patch :optional, :get :optional}
         :types {:any s/Int}
         :description "Tunniste eHOKS-järjestelmässä"}
-   :module-id
-   {:methods {:any :excluded, :get :required}
-    :types {:any UUID}
-    :description (str "Tietorakenteen yksilöivä tunniste "
-                      "esimerkiksi tiedon jakamista varten")}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
    :osa-alueet {:methods {:any :required}
                 :types {:any [YhteisenTutkinnonOsanOsaAlue-template]}
                 :description "yhteisen tutkinnon osan osa-alueet"}
@@ -652,144 +651,140 @@
     :alku LocalDate "Opintojen alkupäivämäärä muodossa YYYY-MM-DD"
     :loppu LocalDate "Opintojen loppupäivämäärä muodossa YYYY-MM-DD"))
 
-(s/defschema
-  HankittavaAmmatillinenTutkinnonOsa
-  "Hankittavan ammatillisen tutkinnon osan schema."
-  (describe
-    "Hankittavan ammatillisen osaamisen tiedot (GET)"
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    :tutkinnon-osa-koodi-uri TutkinnonOsaKoodiUri
-    "Tutkinnon osan Koodisto-koodi-URI (tutkinnonosat)"
-    :tutkinnon-osa-koodi-versio s/Int
-    "Tutkinnon osan Koodisto-koodi-URIn versio ePerusteet-palvelussa
-     (tutkinnonosat)"
-    (s/optional-key :vaatimuksista-tai-tavoitteista-poikkeaminen) s/Str
-    (str "Tekstimuotoinen selite ammattitaitovaatimuksista tai "
-         "osaamistavoitteista poikkeamiseen")
-    (s/optional-key :osaamisen-osoittaminen) [OsaamisenOsoittaminen]
-    "Hankitun osaamisen osoittaminen: Näyttö tai muu osaamisen osoittaminen"
-    (s/optional-key :osaamisen-hankkimistavat) [OsaamisenHankkimistapa]
-    "Osaamisen hankkimistavat"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+(def HankittavaAmmatillinenTutkinnonOsa-template
+  ^{:doc "Hankittavan ammatillisen tutkinnon osan schema."
+    :type ::g/schema-template
+    :name "HankittavaAmmatillinenTutkinnonOsa"}
+  {:id {:methods {:any :excluded, :patch :optional, :get :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
+   :tutkinnon-osa-koodi-uri
+   {:methods {:any :required}
+    :types {:any TutkinnonOsaKoodiUri}
+    :description (str "Tutkinnon osan Koodisto-koodi-URI ePerusteet-palvelussa "
+                      "(tutkinnonosat) muotoa tutkinnonosat_xxxxxx eli esim. "
+                      "tutkinnonosat_100002")}
+   :tutkinnon-osa-koodi-versio
+   {:methods {:any :required}
+    :types {:any s/Int}
+    :description (str "Tutkinnon osan Koodisto-koodi-URIn versio "
+                      "ePerusteet-palvelussa (tutkinnonosat)")}
+   :vaatimuksista-tai-tavoitteista-poikkeaminen
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description (str "Tekstimuotoinen selite ammattitaitovaatimuksista tai "
+                      "osaamistavoitteista poikkeamiseen")}
+   :osaamisen-osoittaminen
+   {:methods {:any :optional}
+    :types {:any [OsaamisenOsoittaminen-template]}
+    :description (str "Hankitun osaamisen osoittaminen: "
+                      "Näyttö tai muu osaamisen osoittaminen")}
+   :osaamisen-hankkimistavat {:methods {:any :optional}
+                              :types {:any [OsaamisenHankkimistapa-template]}
+                              :description "Osaamisen hankkimistavat"}
+   :koulutuksen-jarjestaja-oid
+   {:methods {:any :optional}
+    :types {:any Oid}
+    :description
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
-         "koulutuksen järjestäjän oid.")
-    (s/optional-key :olennainen-seikka) s/Bool
+         "koulutuksen järjestäjän oid.")}
+   :olennainen-seikka
+   {:methods {:any :optional}
+    :types {:any s/Bool}
+    :description
     (str "Tieto sellaisen seikan olemassaolosta, jonka koulutuksen järjestäjä "
          "katsoo oleelliseksi tutkinnon osaan tai osa-alueeseen liittyvän "
-         "osaamisen hankkimisessa tai osoittamisessa.")
-    (s/optional-key :opetus-ja-ohjaus-maara)
-    (s/constrained s/Num
-                   #(not (neg? %))
-                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")
-    "Tutkinnon osaan suunnitellun opetuksen ja ohjauksen määrä tunteina."))
+         "osaamisen hankkimisessa tai osoittamisessa.")}
+   :opetus-ja-ohjaus-maara
+   {:methods {:any :optional}
+    :types {:any (s/constrained
+                   s/Num #(not (neg? %))
+                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")}
+    :description (str "Tutkinnon osan osa-alueeseen suunnitellun opetuksen "
+                      "ja ohjauksen määrä tunteina.")}})
 
-(s/defschema
-  HankittavaAmmatillinenTutkinnonOsaLuontiJaMuokkaus
-  "Schema hankittavan ammatillisen tutkinnon osan luontiin ja muokkaukseen."
-  (modify
-    HankittavaAmmatillinenTutkinnonOsa
-    "Hankittavan ammatillisen osaamisen tiedot (POST, PUT)"
-    {:removed [:module-id :osaamisen-hankkimistavat :osaamisen-osoittaminen :id]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaLuontiJaMuokkaus] "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenLuontiJaMuokkaus]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaAmmatillinenTutkinnonOsa
+             (g/generate HankittavaAmmatillinenTutkinnonOsa-template :get))
 
-(s/defschema
-  HankittavaAmmatillinenTutkinnonOsaPatch
-  "Schema hankittavan ammatillisen tutkinnon osan PATCH-päivitykseen."
-  (modify
-    HankittavaAmmatillinenTutkinnonOsa
-    "Hankittavan ammatillisen osaamisen tiedot (PATCH)"
-    {:removed [:module-id :osaamisen-hankkimistavat :osaamisen-osoittaminen]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaPatch]
-       "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenPatch]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaAmmatillinenTutkinnonOsaLuontiJaMuokkaus
+             (g/generate HankittavaAmmatillinenTutkinnonOsa-template :post))
 
-(s/defschema
-  HankittavaPaikallinenTutkinnonOsa
-  "Hankittavan paikallisen tutkinnon osan schema."
-  (describe
-    "Hankittava paikallinen tutkinnon osa"
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    (s/optional-key :amosaa-tunniste) s/Str
-    "Tunniste ePerusteet AMOSAA -palvelussa"
-    (s/optional-key :nimi) s/Str "Tutkinnon osan nimi"
-    (s/optional-key :laajuus) s/Int "Tutkinnon osan laajuus"
-    (s/optional-key :tavoitteet-ja-sisallot) s/Str
-    (str "Paikallisen tutkinnon osan ammattitaitovaatimukset tai"
-         "osaamistavoitteet")
-    (s/optional-key :vaatimuksista-tai-tavoitteista-poikkeaminen) s/Str
-    "vaatimuksista tai osaamistavoitteista poikkeaminen"
-    (s/optional-key :osaamisen-hankkimistavat) [OsaamisenHankkimistapa]
-    "Osaamisen hankkimistavat"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+(s/defschema HankittavaAmmatillinenTutkinnonOsaPatch
+             (g/generate HankittavaAmmatillinenTutkinnonOsa-template :patch))
+
+(def HankittavaPaikallinenTutkinnonOsa-template
+  ^{:doc "Hankittavan paikallisen tutkinnon osan schema."
+    :type ::g/schema-template
+    :name "HankittavaPaikallinenTutkinnonOsa"}
+  {:id {:methods {:any :excluded, :patch :optional, :get :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
+   :amosaa-tunniste {:methods {:any :optional}
+                     :types {:any s/Str}
+                     :description "Tunniste ePerusteet AMOSAA -palvelussa"}
+   :nimi {:methods {:any :optional}
+          :types {:any s/Str}
+          :description "Tutkinnon osan nimi"}
+   :laajuus {:methods {:any :optional}
+             :types {:any s/Int}
+             :description "Tutkinnon osan laajuus"}
+   :tavoitteet-ja-sisallot
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description
+    "Paikallisen tutkinnon osan ammattitaitovaatimukset tai osaamistavoitteet"}
+   :vaatimuksista-tai-tavoitteista-poikkeaminen
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description (str "Tekstimuotoinen selite ammattitaitovaatimuksista tai "
+                      "osaamistavoitteista poikkeamiseen")}
+   :osaamisen-osoittaminen
+   {:methods {:any :optional}
+    :types {:any [OsaamisenOsoittaminen-template]}
+    :description (str "Hankitun osaamisen osoittaminen: "
+                      "Näyttö tai muu osaamisen osoittaminen")}
+   :osaamisen-hankkimistavat {:methods {:any :optional}
+                              :types {:any [OsaamisenHankkimistapa-template]}
+                              :description "Osaamisen hankkimistavat"}
+   :koulutuksen-jarjestaja-oid
+   {:methods {:any :optional}
+    :types {:any Oid}
+    :description
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
-         "koulutuksen järjestäjän oid.")
-    (s/optional-key :osaamisen-osoittaminen) [OsaamisenOsoittaminen]
-    "Hankitun osaamisen osoittaminen: Näyttö tai muu osaamisen osoittaminen"
-    (s/optional-key :olennainen-seikka) s/Bool
+         "koulutuksen järjestäjän oid.")}
+   :olennainen-seikka
+   {:methods {:any :optional}
+    :types {:any s/Bool}
+    :description
     (str "Tieto sellaisen seikan olemassaolosta, jonka koulutuksen järjestäjä "
          "katsoo oleelliseksi tutkinnon osaan tai osa-alueeseen liittyvän "
-         "osaamisen hankkimisessa tai osoittamisessa.")
-    (s/optional-key :opetus-ja-ohjaus-maara)
-    (s/constrained s/Num
-                   #(not (neg? %))
-                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")
-    "Tutkinnon osaan suunnitellun opetuksen ja ohjauksen määrä tunteina."))
+         "osaamisen hankkimisessa tai osoittamisessa.")}
+   :opetus-ja-ohjaus-maara
+   {:methods {:any :optional}
+    :types {:any (s/constrained
+                   s/Num #(not (neg? %))
+                   "Opetuksen ja ohjauksen määrä ei saa olla negatiivinen.")}
+    :description (str "Tutkinnon osan osa-alueeseen suunnitellun opetuksen "
+                      "ja ohjauksen määrä tunteina.")}})
 
-(s/defschema
-  HankittavaPaikallinenTutkinnonOsaLuontiJaMuokkaus
-  "Schema hankittavan paikallisen tutkinnon osan luontiin ja muokkaukseen."
-  (modify
-    HankittavaPaikallinenTutkinnonOsa
-    "Hankittavan paikallisen osaamisen tiedot (POST, PUT)"
-    {:removed [:module-id :osaamisen-hankkimistavat :osaamisen-osoittaminen :id]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaLuontiJaMuokkaus] "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenLuontiJaMuokkaus]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaPaikallinenTutkinnonOsa
+             (g/generate HankittavaPaikallinenTutkinnonOsa-template :get))
 
-(s/defschema
-  HankittavaPaikallinenTutkinnonOsaPatch
-  "Schema hankittavan paikallisen tutkinnon osan PATCH-päivitykseen."
-  (modify
-    HankittavaPaikallinenTutkinnonOsa
-    "Hankittavan paikallisen osaamisen tiedot (PATCH)"
-    {:removed [:module-id :osaamisen-hankkimistavat :osaamisen-osoittaminen]
-     :added
-     (describe
-       ""
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaPatch]
-       "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenPatch]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaPaikallinenTutkinnonOsaLuontiJaMuokkaus
+             (g/generate HankittavaPaikallinenTutkinnonOsa-template :post))
+
+(s/defschema HankittavaPaikallinenTutkinnonOsaPatch
+             (g/generate HankittavaPaikallinenTutkinnonOsa-template :patch))
 
 (s/defschema
   AiemminHankittuPaikallinenTutkinnonOsa

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -793,7 +793,8 @@
   (let [prosessi-mode (if (some #{:prosessi-required} flags)
                         :required :optional)]
     (-> schema
-        (dissoc :osaamisen-hankkimistavat :osaamisen-osoittaminen :osa-alueet)
+        (dissoc :osaamisen-hankkimistavat :osaamisen-osoittaminen :osa-alueet
+                :opetus-ja-ohjaus-maara)
         (assoc :valittu-todentamisen-prosessi-koodi-uri
                {:methods {:any prosessi-mode}
                 :types {:any TodentamisenProsessiKoodiUri}

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -530,150 +530,116 @@
 (s/defschema YhteisenTutkinnonOsanOsaAluePatch
              (g/generate YhteisenTutkinnonOsanOsaAlue-template :patch))
 
-(s/defschema
-  AiemminHankitunYTOOsaAlue
-  "Aiemmin hankitun yhteisen tutkinnon osan osa-alueen schema."
-  (describe
-    "AiemminHankitun YTOn osa-alueen tiedot"
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    :osa-alue-koodi-uri OsaAlueKoodiUri
-    "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"
-    :osa-alue-koodi-versio s/Int
-    "Osa-alueen Koodisto-koodi-URIn versio (ammatillisenoppiaineet)"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+(def AiemminHankitunYTOOsaAlue-template
+  ^{:doc "Aiemmin hankitun yhteisen tutkinnon osan osa-alueen schema."
+    :type ::g/schema-template
+    :name "AiemminHankitunYTOOsaAlue"}
+  {:id {:methods {:any :excluded, :get :optional, :patch :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id {:methods {:any :excluded, :get :required}
+               :types {:any UUID}
+               :description (str "Tietorakenteen yksilöivä tunniste "
+                                 "esimerkiksi tiedon jakamista varten")}
+   :osa-alue-koodi-uri
+   {:methods {:any :required}
+    :types {:any OsaAlueKoodiUri}
+    :description "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"}
+   :osa-alue-koodi-versio
+   {:methods {:any :required}
+    :types {:any s/Int}
+    :description "Osa-alueen Koodisto-koodi-URIn versio"}
+   :koulutuksen-jarjestaja-oid
+   {:methods {:any :optional}
+    :types {:any Oid}
+    :description
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
-         "koulutuksen järjestäjän oid.")
-    (s/optional-key :vaatimuksista-tai-tavoitteista-poikkeaminen) s/Str
-    "vaatimuksista tai osaamistavoitteista poikkeaminen"
-    :valittu-todentamisen-prosessi-koodi-uri TodentamisenProsessiKoodiUri
-    "Todentamisen prosessin kuvauksen (suoraan/arvioijien kautta/näyttö)
-    koodi-uri. Koodisto Osaamisen todentamisen prosessi, eli muotoa
-    osaamisentodentamisenprosessi_xxxx"
-    :valittu-todentamisen-prosessi-koodi-versio s/Int
-    "Todentamisen prosessin kuvauksen Koodisto-koodi-URIn versio
-    (Osaamisen todentamisen prosessi)"
-    (s/optional-key :tarkentavat-tiedot-naytto) [OsaamisenOsoittaminen]
-    "Mikäli valittu näytön kautta, tuodaan myös näytön tiedot."
-    (s/optional-key :olennainen-seikka) s/Bool
-    (str "Tieto sellaisen seikan
-    olemassaolosta, jonka koulutuksen järjestäjä katsoo oleelliseksi tutkinnon
-    osaan tai osa-alueeseen liittyvän osaamisen hankkimisessa tai
-    osoittamisessa.")
-    (s/optional-key :tarkentavat-tiedot-osaamisen-arvioija)
-    TodennettuArviointiLisatiedot
-    "Mikäli arvioijan kautta todennettu, annetaan myös arvioijan lisätiedot"))
+         "koulutuksen järjestäjän oid.")}
+   :vaatimuksista-tai-tavoitteista-poikkeaminen
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description "vaatimuksista tai osaamistavoitteista poikkeaminen"}
+   :valittu-todentamisen-prosessi-koodi-uri
+   {:methods {:any :required}
+    :types {:any TodentamisenProsessiKoodiUri}
+    :description
+    (str "Todentamisen prosessin kuvauksen (suoraan/arvioijien kautta/näyttö)"
+         "koodi-uri. Koodisto Osaamisen todentamisen prosessi, eli muotoa"
+         "osaamisentodentamisenprosessi_xxxx")}
+   :valittu-todentamisen-prosessi-koodi-versio
+   {:methods {:any :required}
+    :types {:any s/Int}
+    :description (str "Todentamisen prosessin kuvauksen Koodisto-koodi-URIn "
+                      "versio (Osaamisen todentamisen prosessi)")}
+   :tarkentavat-tiedot-naytto
+   {:methods {:any :optional}
+    :types {:any [OsaamisenOsoittaminen-template]}
+    :description "Mikäli valittu näytön kautta, tuodaan myös näytön tiedot."}
+   :olennainen-seikka
+   {:methods {:any :optional}
+    :types {:any s/Bool}
+    :description
+    (str "Tieto sellaisen seikan olemassaolosta, jonka koulutuksen järjestäjä "
+         "katsoo oleelliseksi tutkinnon osaan tai osa-alueeseen liittyvän "
+         "osaamisen hankkimisessa tai osoittamisessa.")}
+   :tarkentavat-tiedot-osaamisen-arvioija
+   {:methods {:any :optional}
+    :types {:any TodennettuArviointiLisatiedot}
+    :description (str "Mikäli arvioijan kautta todennettu, annetaan myös "
+                      "arvioijan lisätiedot")}})
 
-(s/defschema
-  AiemminHankitunYTOOsaAlueLuontiJaMuokkaus
-  "Schema aiemmin hankitun yhteisen tutkinnon osan osa-alueen luontiin ja
-  muokkaukseen."
-  (modify
-    AiemminHankitunYTOOsaAlue
-    "AiemminHankitun YTOn osa-alueen tiedot (POST, PUT)"
-    {:removed [:module-id :tarkentavat-tiedot-naytto :id]
-     :added
-     (describe
-       ""
-       (s/optional-key :tarkentavat-tiedot-naytto)
-       [OsaamisenOsoittaminenLuontiJaMuokkaus]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema AiemminHankitunYTOOsaAlue
+             (g/generate AiemminHankitunYTOOsaAlue-template :get))
 
-(s/defschema
-  AiemminHankitunYTOOsaAluePatch
-  "Schema aiemmin hankitun yhteisen tutkinnon osan osa-alueen
-  PATCH-päivitykseen."
-  (modify
-    AiemminHankitunYTOOsaAlue
-    "AiemminHankitun YTOn osa-alueen tiedot (PATCH)"
-    {:removed [:module-id :tarkentavat-tiedot-naytto]
-     :added
-     (describe
-       ""
-       (s/optional-key :tarkentavat-tiedot-naytto)
-       [OsaamisenOsoittaminenPatch]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema AiemminHankitunYTOOsaAlueLuontiJaMuokkaus
+             (g/generate AiemminHankitunYTOOsaAlue-template :post))
 
-(s/defschema
-  YhteinenTutkinnonOsa
-  "Yhteisen tutkinnon osan schema."
-  (describe
-    "Yhteinen Tutkinnon osa (YTO)"
-    (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    :module-id UUID (str "Tietorakenteen yksilöivä tunniste "
-                         "esimerkiksi tiedon jakamista varten")
-    :osa-alueet [YhteisenTutkinnonOsanOsaAlue] "YTO osa-alueet"
-    :tutkinnon-osa-koodi-uri TutkinnonOsaKoodiUri
-    "Tutkinnon osan Koodisto-koodi-URI ePerusteet-palvelussa
-    (tutkinnonosat) eli muotoa  tutkinnonosat_xxxxxx eli esim.
-    tutkinnonosat_100002"
-    :tutkinnon-osa-koodi-versio s/Int
-    "Tutkinnon osan Koodisto-koodi-URIn versio ePerusteet-palvelussa
-     (tutkinnonosat)"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+(s/defschema AiemminHankitunYTOOsaAluePatch
+             (g/generate AiemminHankitunYTOOsaAlue-template :patch))
+
+(def YhteinenTutkinnonOsa-template
+  ^{:doc "Hankittava Yhteinen Tutkinnon osa (YTO)"
+    :type ::g/schema-template
+    :name "YhteinenTutkinnonOsa"}
+  {:id {:methods {:any :excluded, :patch :optional, :get :optional}
+        :types {:any s/Int}
+        :description "Tunniste eHOKS-järjestelmässä"}
+   :module-id
+   {:methods {:any :excluded, :get :required}
+    :types {:any UUID}
+    :description (str "Tietorakenteen yksilöivä tunniste "
+                      "esimerkiksi tiedon jakamista varten")}
+   :osa-alueet {:methods {:any :required}
+                :types {:any [YhteisenTutkinnonOsanOsaAlue-template]}
+                :description "yhteisen tutkinnon osan osa-alueet"}
+   :tutkinnon-osa-koodi-uri
+   {:methods {:any :required}
+    :types {:any TutkinnonOsaKoodiUri}
+    :description (str "Tutkinnon osan Koodisto-koodi-URI ePerusteet-palvelussa "
+                      "(tutkinnonosat) muotoa tutkinnonosat_xxxxxx eli esim. "
+                      "tutkinnonosat_100002")}
+   :tutkinnon-osa-koodi-versio
+   {:methods {:any :required}
+    :types {:any s/Int}
+    :description (str "Tutkinnon osan Koodisto-koodi-URIn versio "
+                      "ePerusteet-palvelussa (tutkinnonosat)")}
+   :koulutuksen-jarjestaja-oid
+   {:methods {:any :optional}
+    :types {:any Oid}
+    :description
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
-         "koulutuksen järjestäjän oid.")))
+         "koulutuksen järjestäjän oid.")}})
 
-(s/defschema
-  HankittavaYTO
-  "Hankittavan yhteisen tutkinnon osan schema."
-  (modify
-    YhteinenTutkinnonOsa
-    "Hankittavan yhteinen tutkinnon osan (YTO) tiedot"
-    {:removed [:vaatimuksista-tai-tavoitteista-poikkeaminen]}))
+(s/defschema HankittavaYTO
+             (g/generate YhteinenTutkinnonOsa-template :get))
 
-(s/defschema
-  HankittavaYTOLuontiJaMuokkaus
-  "Schema hankittavan yhteisen tutkinnon osan luontiin ja muokkaukseen."
-  (modify
-    HankittavaYTO
-    "Hankittavan yhteisen tutkinnnon osan (POST, PUT)"
-    {:removed
-     [:module-id
-      :osaamisen-hankkimistavat
-      :osaamisen-osoittaminen
-      :osa-alueet
-      :id]
-     :added
-     (describe
-       ""
-       :osa-alueet [YhteisenTutkinnonOsanOsaAlueLuontiJaMuokkaus]
-       "YTO osa-alueet"
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaLuontiJaMuokkaus] "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenLuontiJaMuokkaus]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaYTOLuontiJaMuokkaus
+             (g/generate YhteinenTutkinnonOsa-template :post))
 
-(s/defschema
-  HankittavaYTOPatch
-  "Schema hankittavan yhteisen tutkinnon osan PATCH-päivitykseen."
-  (modify
-    HankittavaYTO
-    "Hankittavan yhteisen tutkinnnon osan (PATCH)"
-    {:removed
-     [:module-id
-      :osaamisen-hankkimistavat
-      :osaamisen-osoittaminen
-      :osa-alueet]
-     :added
-     (describe
-       ""
-       :osa-alueet [YhteisenTutkinnonOsanOsaAluePatch]
-       "YTO osa-alueet"
-       (s/optional-key :osaamisen-hankkimistavat)
-       [OsaamisenHankkimistapaPatch]
-       "Osaamisen hankkimistavat"
-       (s/optional-key :osaamisen-osoittaminen)
-       [OsaamisenOsoittaminenPatch]
-       (str "Hankitun osaamisen osoittaminen: "
-            "Näyttö tai muu osaamisen osoittaminen"))}))
+(s/defschema HankittavaYTOPatch
+             (g/generate YhteinenTutkinnonOsa-template :patch))
 
 (s/defschema
   OpiskeluvalmiuksiaTukevatOpinnot
@@ -880,7 +846,7 @@
   AiemminHankittuYhteinenTutkinnonOsa
   "Aiemmin hankitun yhteisen tutkinnon osan schema."
   (modify
-    YhteinenTutkinnonOsa
+    HankittavaYTO
     "Aiemmin hankittu yhteinen tutkinnon osa"
     {:removed [:osa-alueet]
      :added

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -1164,22 +1164,17 @@
 
 (def HOKSPaivitys
   "HOKSin päivitysschema."
-  (generate-hoks-schema "HOKSPaivitys"
-                        :patch
-                        "HOKS-dokumentin osittainen päivittäminen (PATCH)"))
+  (generate-hoks-schema
+    "HOKSPaivitys" :patch "HOKS-dokumentin osittainen päivittäminen (PATCH)"))
 
 (def HOKSKorvaus
   "HOKSin korvausschema."
-  (generate-hoks-schema "HOKSKorvaus"
-                        :put
-                        "HOKS-dokumentin ylikirjoitus (PUT)"))
+  (generate-hoks-schema
+    "HOKSKorvaus" :put "HOKS-dokumentin ylikirjoitus (PUT)"))
 
 (def HOKSLuonti
   "HOKSin luontischema."
-  (generate-hoks-schema "HOKSLuonti"
-                        :post
-                        (str "HOKS-dokumentin arvot uutta merkintää luotaessa "
-                             "(POST)")))
+  (generate-hoks-schema "HOKSLuonti" :post "HOKS-dokumentin luominen (POST)"))
 
 (s/defschema
   kyselylinkki

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -333,12 +333,6 @@
 (s/defschema OsaamisenHankkimistapa
              (g/generate OsaamisenHankkimistapa-template :get))
 
-(s/defschema OsaamisenHankkimistapaLuontiJaMuokkaus
-             (g/generate OsaamisenHankkimistapa-template :post))
-
-(s/defschema OsaamisenHankkimistapaPatch
-             (g/generate OsaamisenHankkimistapa-template :patch))
-
 (s/defschema
   NaytonJarjestaja
   "Näytön järjestäjän schema."
@@ -462,12 +456,6 @@
 (s/defschema OsaamisenOsoittaminen
              (g/generate OsaamisenOsoittaminen-template :get))
 
-(s/defschema OsaamisenOsoittaminenLuontiJaMuokkaus
-             (g/generate OsaamisenOsoittaminen-template :post))
-
-(s/defschema OsaamisenOsoittaminenPatch
-             (g/generate OsaamisenOsoittaminen-template :patch))
-
 (defn hankittava->aiemmin-hankittu
   "Muuttaa hankittavan tutkinnon osan skeema-mallineen aiemmin hankitun
   tutkinnon osan skeema-mallineeksi."
@@ -558,12 +546,6 @@
 (s/defschema HankittavanYTOnOsaAlue
              (g/generate HankittavanYTOnOsaAlue-template :get))
 
-(s/defschema HankittavanYTOnOsaAlueLuontiJaMuokkaus
-             (g/generate HankittavanYTOnOsaAlue-template :post))
-
-(s/defschema HankittavanYTOnOsaAluePatch
-             (g/generate HankittavanYTOnOsaAlue-template :patch))
-
 (def AiemminHankitunYTOnOsaAlue-template
   (with-meta
     (hankittava->aiemmin-hankittu
@@ -575,12 +557,6 @@
 
 (s/defschema AiemminHankitunYTOnOsaAlue
              (g/generate AiemminHankitunYTOnOsaAlue-template :get))
-
-(s/defschema AiemminHankitunYTOnOsaAlueLuontiJaMuokkaus
-             (g/generate AiemminHankitunYTOnOsaAlue-template :post))
-
-(s/defschema AiemminHankitunYTOnOsaAluePatch
-             (g/generate AiemminHankitunYTOnOsaAlue-template :patch))
 
 (def HankittavaYhteinenTutkinnonOsa-template
   ^{:doc "Hankittava Yhteinen Tutkinnon osa (YTO)"
@@ -857,73 +833,11 @@
     "Osaaminen voidaan merkitä saavutetuksi enintään kaksi viikkoa
     tulevaisuuteen ja vähintään vuodelle 2018."))
 
-(def ^:private ahato-part-of-hoks
-  "Aiemmin hankitun ammatillisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [AiemminHankittuAmmatillinenTutkinnonOsa]
-           :post [AiemminHankittuAmmatillinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [AiemminHankittuAmmatillinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description (str "Aiemmin hankittu ammatillinen osaaminen. Ei sallittu "
-                     "TUVA-HOKSilla.")})
-
-(def ^:private ahyto-part-of-hoks
-  "Aiemmin hankitun yhteisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [AiemminHankittuYhteinenTutkinnonOsa]
-           :post [AiemminHankittuYhteinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [AiemminHankittuYhteinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description (str "Aiemmin hankitut yhteiset tutkinnon osat (YTO). Ei "
-                     "sallittu TUVA-HOKSilla.")})
-
-(def ^:private ahpto-part-of-hoks
-  "Aiemmin hankitun paikallisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [AiemminHankittuPaikallinenTutkinnonOsa]
-           :post [AiemminHankittuPaikallinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [AiemminHankittuPaikallinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description (str "Aiemmin hankittu paikallinen tutkinnon osa. Ei sallittu "
-                     "TUVA-HOKSilla.")})
-
 (def ^:private oto-part-of-hoks
   "Opiskeluvalmiuksia tukevien opintojen HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
+  {:methods {:any :optional :patch :excluded}
    :types {:any [OpiskeluvalmiuksiaTukevatOpinnot]}
    :description (str "Opiskeluvalmiuksia tukevat opinnot. Ei sallittu "
-                     "TUVA-HOKSilla.")})
-
-(def ^:private hato-part-of-hoks
-  "Hankittavan ammatillisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [HankittavaAmmatillinenTutkinnonOsa]
-           :post [HankittavaAmmatillinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [HankittavaAmmatillinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description
-   (str "Hankittavan ammatillisen osaamisen hankkimisen tiedot. Ei sallittu "
-        "TUVA-HOKSilla.")})
-
-(def ^:private hyto-part-of-hoks
-  "Hankittavan yhteisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [HankittavaYhteinenTutkinnonOsa]
-           :post [HankittavaYhteinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [HankittavaYhteinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description (str "Hankittavan yhteisen tutkinnon osan hankkimisen tiedot. "
-                     "Ei sallittu TUVA-HOKSilla.")})
-
-(def ^:private hpto-part-of-hoks
-  "Hankittavan paikallisen tutkinnon osan HOKS-osa schemana."
-  {:methods {:any :optional
-             :patch :excluded}
-   :types {:any [HankittavaPaikallinenTutkinnonOsa]
-           :post [HankittavaPaikallinenTutkinnonOsaLuontiJaMuokkaus]
-           :put [HankittavaPaikallinenTutkinnonOsaLuontiJaMuokkaus]}
-   :description (str "Hankittavat paikallisen tutkinnon osat. Ei sallittu "
                      "TUVA-HOKSilla.")})
 
 (def ^:private hankittava-koulutuksen-osa
@@ -1013,13 +927,39 @@
                               :get :optional}
                     :types {:any s/Bool}
                     :description "Tieto, onko HOKS tuotu manuaalisyötön kautta"}
-   :aiemmin-hankitut-ammat-tutkinnon-osat ahato-part-of-hoks
-   :aiemmin-hankitut-yhteiset-tutkinnon-osat ahyto-part-of-hoks
-   :aiemmin-hankitut-paikalliset-tutkinnon-osat ahpto-part-of-hoks
+   :aiemmin-hankitut-ammat-tutkinnon-osat
+   {:methods {:any :optional :patch :excluded}
+    :types {:any [AiemminHankittuAmmatillinenTutkinnonOsa-template]}
+    :description (str "Aiemmin hankittu ammatillinen osaaminen. Ei sallittu "
+                      "TUVA-HOKSilla.")}
+   :aiemmin-hankitut-yhteiset-tutkinnon-osat
+   {:methods {:any :optional :patch :excluded}
+    :types {:any [AiemminHankittuYhteinenTutkinnonOsa-template]}
+    :description (str "Aiemmin hankitut yhteiset tutkinnon osat (YTO). Ei "
+                      "sallittu TUVA-HOKSilla.")}
+   :aiemmin-hankitut-paikalliset-tutkinnon-osat
+   {:methods {:any :optional :patch :excluded}
+    :types {:any [AiemminHankittuPaikallinenTutkinnonOsa-template]}
+    :description (str "Aiemmin hankittu paikallinen tutkinnon osa. Ei sallittu "
+                      "TUVA-HOKSilla.")}
    :opiskeluvalmiuksia-tukevat-opinnot oto-part-of-hoks
-   :hankittavat-ammat-tutkinnon-osat hato-part-of-hoks
-   :hankittavat-yhteiset-tutkinnon-osat hyto-part-of-hoks
-   :hankittavat-paikalliset-tutkinnon-osat hpto-part-of-hoks
+   :hankittavat-ammat-tutkinnon-osat
+   {:methods {:any :optional :patch :excluded}
+    :types {:any [HankittavaAmmatillinenTutkinnonOsa-template]}
+    :description (str "Hankittavan ammatillisen osaamisen hankkimisen "
+                      "tiedot. Ei sallittu TUVA-HOKSilla.")}
+   :hankittavat-yhteiset-tutkinnon-osat
+   {:methods {:any :optional
+              :patch :excluded}
+    :types {:any [HankittavaYhteinenTutkinnonOsa-template]}
+    :description (str "Hankittavan yhteisen tutkinnon osan hankkimisen tiedot. "
+                      "Ei sallittu TUVA-HOKSilla.")}
+   :hankittavat-paikalliset-tutkinnon-osat
+   {:methods {:any :optional
+              :patch :excluded}
+    :types {:any [HankittavaPaikallinenTutkinnonOsa-template]}
+    :description (str "Hankittavat paikallisen tutkinnon osat. Ei sallittu "
+                      "TUVA-HOKSilla.")}
    :hankittavat-koulutuksen-osat hankittava-koulutuksen-osa})
 
 (defn generate-hoks-schema [schema-name method doc]

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -1067,6 +1067,7 @@
 (def HOKSModel
   "HOKS-schema."
   ^{:doc "Henkilökohtainen osaamisen kehittämissuunnitelmadokumentti"
+    :type ::g/schema-template
     :restful true
     :name "HOKSModel"}
   {:id {:methods {:post :excluded}
@@ -1152,15 +1153,13 @@
    :hankittavat-paikalliset-tutkinnon-osat hpto-part-of-hoks
    :hankittavat-koulutuksen-osat hankittava-koulutuksen-osa})
 
-(def HOKS
-  "HOKSin schema."
-  (with-meta
-    (g/generate HOKSModel :get)
-    {:doc "Henkilökohtainen osaamisen kehittämissuunnitelmadokumentti (GET)"
-     :name "HOKS"}))
-
 (defn generate-hoks-schema [schema-name method doc]
   (with-meta (g/generate HOKSModel method) {:doc doc :name schema-name}))
+
+(def HOKS
+  "HOKSin schema."
+  (generate-hoks-schema
+    "HOKS" :get "Henkilökohtainen osaamisen kehittämissuunnitelmadokumentti"))
 
 (def HOKSPaivitys
   "HOKSin päivitysschema."

--- a/src/oph/ehoks/hoks/vipunen_schema.clj
+++ b/src/oph/ehoks/hoks/vipunen_schema.clj
@@ -831,6 +831,7 @@
   "HOKSin schema (vipunen)."
   ^{:doc "Henkilökohtainen osaamisen kehittämissuunnitelmadokumentti
      Vipusta varten, ei sisällä henkilöiden nimiä tai sähköpostiosoitteita"
+    :type ::g/schema-template
     :restful true
     :name "HOKSModelVipunen"}
   {:id {:methods {:post :excluded}

--- a/src/oph/ehoks/schema/generator.clj
+++ b/src/oph/ehoks/schema/generator.clj
@@ -2,15 +2,25 @@
   (:require [schema.core :as s]
             [ring.swagger.json-schema :as rsjs]))
 
+(def method-fallbacks
+  {:post-virkailija :post,
+   :put-virkailija :put,
+   :patch-virkailija :patch})
+
 (defn get-access
   "Get access type for method"
   [v method]
-  (or (get-in v [:methods method]) (get-in v [:methods :any]) :required))
+  (or (get-in v [:methods method])
+      (get-in v [:methods (method-fallbacks method)])
+      (get-in v [:methods :any])
+      :required))
 
 (defn get-type
   "Get value type for method"
   [v method]
-  (or (get-in v [:types method]) (get-in v [:types :any])))
+  (or (get-in v [:types method])
+      (get-in v [:types (method-fallbacks method)])
+      (get-in v [:types :any])))
 
 (s/defschema
   ModelValue
@@ -19,12 +29,18 @@
              (s/optional-key :get) s/Keyword
              (s/optional-key :post) s/Keyword
              (s/optional-key :put) s/Keyword
-             (s/optional-key :patch) s/Keyword}
+             (s/optional-key :patch) s/Keyword
+             (s/optional-key :post-virkailija) s/Keyword
+             (s/optional-key :put-virkailija) s/Keyword
+             (s/optional-key :patch-virkailija) s/Keyword}
    :types {(s/optional-key :any) s/Any
            (s/optional-key :get) s/Any
            (s/optional-key :post) s/Any
            (s/optional-key :put) s/Any
-           (s/optional-key :patch) s/Any}
+           (s/optional-key :patch) s/Any
+           (s/optional-key :post-virkailija) s/Any
+           (s/optional-key :put-virkailija) s/Any
+           (s/optional-key :patch-virkailija) s/Any}
    :description s/Str})
 
 (defn generate

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -632,7 +632,9 @@
                     (c-api/POST "/" [:as request]
                       :summary (str "Luo uuden HOKSin. "
                                     "Vaatii manuaalisyöttäjän oikeudet")
-                      :body [hoks hoks-schema/HOKSLuonti]
+                      :body [hoks (hoks-schema/generate-hoks-schema
+                                    "HOKSLuonti-virkailija" :post-virkailija
+                                    "HOKS-dokumentin luonti")]
                       :return (restful/response schema/POSTResponse :id s/Int)
                       (post-oppija hoks request))
 
@@ -744,12 +746,18 @@
                             :summary
                             "Ylikirjoittaa olemassa olevan HOKSin arvon tai
                              arvot"
-                            :body [hoks-values hoks-schema/HOKSKorvaus]
+                            :body [hoks-values
+                                   (hoks-schema/generate-hoks-schema
+                                     "HOKSKorvaus-virkailija" :put-virkailija
+                                     "HOKS-dokumentin korvaus")]
                             (put-hoks (h/add-missing-oht-yksiloiva-tunniste
                                         hoks-values) hoks-id))
 
                           (c-api/PATCH "/" request
-                            :body [hoks-values hoks-schema/HOKSPaivitys]
+                            :body [hoks-values
+                                   (hoks-schema/generate-hoks-schema
+                                     "HOKSPaivitys-virkailija" :patch-virkailija
+                                     "HOKS-dokumentin päivitys")]
                             :summary "Oppijan hoksin päätason arvojen päivitys"
                             (patch-hoks hoks-values hoks-id))))
 

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -260,6 +260,21 @@
                        :osa-alueet 0 :osaamisen-hankkimistavat 0])
               (->> (re-find #"Alku ennen loppua")))))))
 
+(deftest require-yksiloiva-tunniste-in-oht
+  (testing "Osaamisen hankkimistavassa pitää olla yksilöivä tunniste."
+    (let [app (hoks-utils/create-app nil)
+          invalid-data
+          (update-in test-data/hoks-data
+                     [:hankittavat-ammat-tutkinnon-osat 0
+                      :osaamisen-hankkimistavat 0]
+                     dissoc :yksiloiva-tunniste)
+          invalid-post-response
+          (hoks-utils/create-mock-post-request "" invalid-data app)]
+      (is (= (:status invalid-post-response) 400))
+      (is (-> (utils/parse-body (:body invalid-post-response))
+              (get-in [:errors :hankittavat-ammat-tutkinnon-osat 0
+                       :osaamisen-hankkimistavat 0 :yksiloiva-tunniste]))))))
+
 (deftest prevent-osaamisen-saavuttaminen-out-of-range
   (testing "The allowed range of osaaminen-saavuttamisen-pvm is from 1.1.2018
            to two weeks in the future (from the time of saving the HOKS)."

--- a/test/oph/ehoks/schema/generator_test.clj
+++ b/test/oph/ehoks/schema/generator_test.clj
@@ -6,6 +6,7 @@
             [oph.ehoks.utils :refer [eq]]))
 
 (def example
+  ^{:type ::g/schema-template}
   {:id {:methods {:any :required
                   :post :excluded}
         :description "Hello ID"


### PR DESCRIPTION
## Kuvaus muutoksista

- Tehdään mekanismi, jolla skeemoista voidaan generoida erilaisia POST-, PUT- ja PATCH-skeemoja virkailijan ja järjestelmätunnuksen endpointeille
- Luodaan infra sille, että skeemat luodaan rekursiivisesti käyttötarkoituksen perusteella yhdestä templatesta
- Päivitetään kaikki skeemat sellaisiksi, että ne käyttävät rekursiivista infraa
- Ja vihdoin: asetetaan `yksiloiva-tunniste` pakolliseksi kentäksi HOKSin skeemassa, mutta ei virkailija-endpointeissa.
- Oheisena: korjattu se, että POST-, PUT- ja PATCH-skeemoissa yhteiselle tutkinnon osalle oli unohtunut skeemaan että se voisi sisältää osaamisen hankkimistapoja tai osoittamisia.  Näille ei ollut oikeasti tukea tietokantakoodissa, joten jos HOKS oikeasti sisälsi niitä, siitä tuli 500-virheitä.  (YTO:n osa-alueet voivat sisältää näitä ja se toimii oikein, mutta YTO:n päätasolla ne olivat ilmeisesti moka.)
- Oheisena: korjattu se, että aiemmin hankittu paikallisen tutkinnon osa sisälsi `opetus-ja-ohjaus-maara` -kentän, vaikka tälle ei ollut tietokantatukea ja kentän lisääminen aiheutti 500-virheen.
- Avoin kysymys on se, kuuluuko AHATOssa (aiemmin hankittu ammatillisen tutkinnon osa) olla `vaatimuksista-tai-tavoitteista-poikkeaminen` -kenttä.  Vanhastaan ei ollut, mutta muissa aiemmin hankituissa oli. 

https://jira.eduuni.fi/browse/EH-1473

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
