### PR TITLE
Revert "Make yksiloiva-tunniste mandatory in HOKS (not virkailija) endpoints"

### DIFF
--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -272,7 +272,7 @@
                :description (str "Tietorakenteen yksilöivä tunniste "
                                  "esimerkiksi tiedon jakamista varten")}
    :yksiloiva-tunniste
-   {:methods {:any :required
+   {:methods {:any :optional  ; TODO: change to :required
               :post-virkailija :optional
               :put-virkailija :optional
               :patch-virkailija :optional}

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -260,21 +260,6 @@
                        :osa-alueet 0 :osaamisen-hankkimistavat 0])
               (->> (re-find #"Alku ennen loppua")))))))
 
-(deftest require-yksiloiva-tunniste-in-oht
-  (testing "Osaamisen hankkimistavassa pitää olla yksilöivä tunniste."
-    (let [app (hoks-utils/create-app nil)
-          invalid-data
-          (update-in test-data/hoks-data
-                     [:hankittavat-ammat-tutkinnon-osat 0
-                      :osaamisen-hankkimistavat 0]
-                     dissoc :yksiloiva-tunniste)
-          invalid-post-response
-          (hoks-utils/create-mock-post-request "" invalid-data app)]
-      (is (= (:status invalid-post-response) 400))
-      (is (-> (utils/parse-body (:body invalid-post-response))
-              (get-in [:errors :hankittavat-ammat-tutkinnon-osat 0
-                       :osaamisen-hankkimistavat 0 :yksiloiva-tunniste]))))))
-
 (deftest prevent-osaamisen-saavuttaminen-out-of-range
   (testing "The allowed range of osaaminen-saavuttamisen-pvm is from 1.1.2018
            to two weeks in the future (from the time of saving the HOKS)."


### PR DESCRIPTION
This reverts commit c33e0c51722468b0aed04b1a4eddaccdff62eb3e.

It's because the change is wrong: the field should not be mandatory in all osaamisen hankkimistavat but only in työpaikkajaksot.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
