### PR TITLE
Require yksilöivä tunniste only in työpaikkajakso only for system transfer

### DIFF
--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -263,14 +263,14 @@
     :type ::g/schema-template
     :constraints
     [{:check osa-aikaisuustieto-valid?
-      :description "Osa-aikaisuustieto ei ole välillä 1-100."}
+      :description "Lisää osa-aikaisuustieto, joka on välillä 1-100."}
      {:check tyopaikkajakso-has-yksiloiva-tunniste?
       :except-methods #{:put-virkailija :post-virkailija :patch-virkailija}
-      :description "Työpaikkajaksossa on yksilöivä tunniste."}
+      :description "Lisää työpaikkajaksoon yksilöivä tunniste."}
      {:check oppisopimus-has-perusta?
-      :description "Tieto oppisopimuksen perustasta puuttuu."}
+      :description "Lisää jaksoon oppisopimuksen perustan koodi-uri."}
      {:check nonnegative-duration?
-      :description "Jakson alku on ennen loppua"}]
+      :description "Korjaa alku- ja loppupäivämäärä oikein päin."}]
     :name "OsaamisenHankkimistapa"}
   {:id {:methods {:any :excluded, :patch :optional, :get :optional}
         :types {:any s/Int}

--- a/src/oph/ehoks/schema/generator.clj
+++ b/src/oph/ehoks/schema/generator.clj
@@ -44,6 +44,11 @@
            (s/optional-key :patch-virkailija) s/Any}
    :description s/Str})
 
+(defn applicable-constraints
+  "Given a :constraints definition, give all that apply to the given method."
+  [constraints method]
+  (remove #(contains? (:except-methods %) method) constraints))
+
 (defn schema-template->schema
   "Generate schema for given HTTP method from template m.  If m is not
   a template, just return it as is."
@@ -66,10 +71,10 @@
                   :required [k value-described])))
             schema)
       (into {} schema)
-      (reduce (fn [schema [constraint description]]
-                (s/constrained schema constraint description))
+      (reduce (fn [schema {:keys [check description]}]
+                (s/constrained schema check description))
               schema
-              (:constraints (meta m)))
+              (applicable-constraints (:constraints (meta m)) method))
       (with-meta schema
                  {:name (str (:name (meta m)) "-" (name method))
                   :doc (:doc (meta m))}))))

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -219,7 +219,7 @@
           (eq (:errors body)
               {:hankittavat-ammat-tutkinnon-osat
                [{:osaamisen-hankkimistavat
-                 [(str "(not (\"Osa-aikaisuustieto ei ole välillä "
+                 [(str "(not (\"Lisää osa-aikaisuustieto, joka on välillä "
                        "1-100.\" a-clojure.lang.PersistentArrayMap))")]}]}))))))
 
 (deftest osaamisen-hankkimistavat-isnt-mandatory

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -258,7 +258,7 @@
       (is (-> (utils/parse-body (:body invalid-post-response))
               (get-in [:errors :hankittavat-yhteiset-tutkinnon-osat 0
                        :osa-alueet 0 :osaamisen-hankkimistavat 0])
-              (->> (re-find #"alku on ennen loppua")))))))
+              (->> (re-find #"Korjaa alku- ja loppupäivä")))))))
 
 (deftest require-yksiloiva-tunniste-in-oht
   (testing "Osaamisen hankkimistavassa pitää olla yksilöivä tunniste."


### PR DESCRIPTION
## Kuvaus muutoksista

Nyt on toteutettu tää niin kuin se oli määriteltykin eli yksilöiviä tunnisteita ei edellytetä muilta osaamisen hankkimistavoilta kuin työpaikkajaksoilta.

https://jira.eduuni.fi/browse/EH-1473

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
