### PR TITLE
Create indirection in oph.ehoks.ehoks-app so that routes can be hot reloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,28 +137,35 @@ Replissä `lein with-profiles +dev repl`:
 ``` repl
 user> (require 'oph.ehoks.dev-server)
 user> (def server (oph.ehoks.dev-server/start "ehoks-virkailija" nil))
+;; jos oot jo oikeassa nimiavaruudessa, kuten dev-profiili tekee
+oph.ehoks.dev-server=> (def server (start "ehoks-virkailija" nil))
 ```
 
 Tai omalla konfiguraatiolla:
 
 ``` repl
-user> (require 'oph.ehoks.dev-server)
-user> (def server (oph.ehoks.dev-server/start "ehoks-virkailija" "config/custom.edn"))
+oph.ehoks.dev-server=> (def server (start "both" "config/custom.edn"))
 ```
 
-Ajossa olevat kokonaisuudet näkee replissä
+Nimiavaruudessa `oph.ehoks.ehoks-app` ovat ne muuttujat (var), jotka
+`start` antaa run-jettylle käsittelemään kutsuja.  Siksi juuri tämän
+nimiavaruuden reload saa Jettyn käsittelemään tulevat kutsut päivitetyllä
+handlerilla jos esim. lähdekoodia on muutettu:
 
 ``` repl
-user> (System/getProperty “name”)
+oph.ehoks.dev-server=> (require 'oph.ehoks.ehoks-app :reload-all)
 ```
 
-Tämän voi vaihtaa ajamalla replissä
+Mikäli tämä ei auta (jos esim. kyse on varsinaisen handlerin
+ulkopuolella tehdyistä muutoksista), serverin voi myös uudelleenluoda
+(reload toki tarvitaan silti sille nimiavaruudelle, jota on muutettu):
 
 ``` repl
-user> (System/setProperty “name” “ehoks-virkailija”)
+oph.ehoks.dev-server=> (.stop server)
+[...]
+nil
+oph.ehoks.dev-server=> (def server (start "ehoks-oppija" nil))
 ```
-
-ja lataamalla tiedoston [ehoks_app.clj](src/oph/ehoks/ehoks_app.clj) uudelleen replissä.
 
 Ja ohjelman sammuttaminen:
 


### PR DESCRIPTION
## Kuvaus muutoksista

Muutetaan `oph.ehoks.ehoks-app/create-app`:n palauttamat app-funktiot var:eiksi.  Var toimii ihan kuin se funktio, jonka se sisältää (delegoi funktiokutsut sisällölleen), mutta jos uusi (def) muuttaa var:n sisällön, vaihtuu myös funktio, jolle delegoidaan.  Tämä tarkoittaa, että nimiavaruuden lataaminen uudelleen näkyy välittömästi siinä, miten käynnissä oleva jetty toimii, koska uusi app-funktio päätyy var:n kautta osaksi sitä tietorakennetta, joka on annettu run-jettylle.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
