### PR TITLE
Always fetch alkamispäivä/arvioituPäättymispäivä from Koski for oht validation

### DIFF
--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -299,9 +299,9 @@
   ala ennen opiskeluoikeuden alkua eivätkä pääty opiskeluoikeuden
   suunnitellun loppumisajan jälkeen."
   [hoks]
-  (let [oo (oppijaindex/get-opiskeluoikeus-by-oid! (:opiskeluoikeus-oid hoks))
-        oo-alku (:alkamispaiva oo)
-        oo-loppu (:arvioitu-paattymispaiva oo)]
+  (let [oo (k/get-opiskeluoikeus-info (:opiskeluoikeus-oid hoks))
+        oo-alku (some-> (:alkamispäivä oo) (LocalDate/parse))
+        oo-loppu (some-> (:arvioituPäättymispäivä oo) (LocalDate/parse))]
     (if-not oo-alku
       (log/error "Opiskeluoikeus ei sisällä alkamispäivää:" oo)
       (doseq [oht (get-osaamisen-hankkimistavat hoks)]


### PR DESCRIPTION
## Kuvaus muutoksista

Vaikuttaa siltä, että koulutuksenjärjestäjät saattaa hyvinkin pidentää opiskeluoikeuden arvioitua päättymispäivää lyhyelläkin varoitusajalla ja lisätä sitten oppijalle uusia työpaikkajaksoja (koska kerran joku oli törmännyt tähän virheilmoitukseen).  Tätä varten ei käytetä indeksissä olevia alkamis- ja päättymispäivätietoja vaan haetaan aina Koskesta tuoreet tiedot (ne haetaan joka tapauksessa TUVA-tarkistusta varten).

Tämä tarkoittaa myös sitä, että indeksissä olevat pvm-tiedot ovat tällä hetkellä tarpeettomia.  En kuitenkaan ottaisi niitä välttämättä pois, koska hyvinkin voi jossain vaiheessa tulla esim. toive HOKS-listauksen rajauksesta niihin, joilla on voimassa oleva opiskeluoikeus tjsp.  Mutta voidaan myös tehdä joku siivous-PR jossa tehdään taas migraatio ettei noita juttuja olekaan indeksissä. :)

- alkuperäinen tiketti: https://jira.eduuni.fi/browse/OY-3945
- korjauksen syy: https://opetushallitus.slack.com/archives/C03KENM74EL/p1693562749873819

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
