### PR TITLE
OY-4444: Yhtenäistetään opiskelijapalatteiden muodostuskriteerit

### DIFF
--- a/resources/db/hoksit/select_non_tuva_hoksit_created_between.sql
+++ b/resources/db/hoksit/select_non_tuva_hoksit_created_between.sql
@@ -1,0 +1,8 @@
+SELECT * FROM hoksit h
+    WHERE h.created_at >= ?
+    AND h.created_at <= ?
+    AND h.deleted_at IS NULL
+    AND h.tuva_opiskeluoikeus_oid IS NULL
+    AND NOT EXISTS (SELECT 1 FROM hankittavat_koulutuksen_osat hko
+                        WHERE hko.deleted_at IS NULL
+                        AND hko.hoks_id = h.id)

--- a/resources/db/hoksit/select_non_tuva_hoksit_finished_between.sql
+++ b/resources/db/hoksit/select_non_tuva_hoksit_finished_between.sql
@@ -1,0 +1,8 @@
+SELECT * FROM hoksit h
+    WHERE h.osaamisen_saavuttamisen_pvm >= ?
+    AND h.osaamisen_saavuttamisen_pvm <= ?
+    AND h.deleted_at IS NULL
+    AND h.tuva_opiskeluoikeus_oid IS NULL
+    AND NOT EXISTS (SELECT 1 FROM hankittavat_koulutuksen_osat hko
+                        WHERE hko.deleted_at IS NULL
+                        AND hko.hoks_id = h.id)

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -426,6 +426,24 @@
     [queries/select-hoksit-finished-between from to]
     {:row-fn hoks-from-sql}))
 
+(defn select-non-tuva-hoksit-created-between
+  "Hakee tietokannasta ne HOKSit, jotka on luotu annettujen ajankohtien
+  välillä ja jotka eivät ole TUVA-HOKSeja tai TUVA-HOKSien kanssa
+  rinnakkaisia ammatillisia HOKSeja."
+  [from to]
+  (db-ops/query
+    [queries/select-non-tuva-hoksit-created-between from to]
+    {:row-fn hoks-from-sql}))
+
+(defn select-non-tuva-hoksit-finished-between
+  "Hakee tietokannasta ne HOKSit, jotka on merkattu valmiiksi annettujen
+  ajankohtien välillä ja jotka eivät ole TUVA-HOKSeja tai TUVA-HOKSien kanssa
+  rinnakkaisia ammatillisia HOKSeja."
+  [from to]
+  (db-ops/query
+    [queries/select-non-tuva-hoksit-finished-between from to]
+    {:row-fn hoks-from-sql}))
+
 (defn- generate-unique-eid
   "Luo EID, jota ei ole vielä käytössä missään tietokannassa olevassa HOKSissa."
   []

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -640,6 +640,21 @@
                     (db-ops/to-sql (dissoc tilat :id))
                     ["id = ?" (:id tilat)] db-conn)))
 
+(defn set-amisherate-kasittelytilat-to-true!
+  "Set both `aloitusherate_kasitelty` and `paattoherate_kasitelty` to `true` if
+  both or either one had previsouly value `false`. For log printing purposes,
+  `reason-msg` should tell why kasittelytilat will be set to `true`."
+  [kasittelytilat reason-msg]
+  ; Only set kasittelytilat if either kasittelytila is `false`.
+  (when-not (and (:aloitusherate_kasitelty kasittelytilat)
+                 (:paattoherate_kasitelty kasittelytilat))
+    (log/info "Setting `aloitusherate_kasitelty` and `paattoherate_kasitelty`"
+              "to `true`. Reason: " reason-msg)
+    (update-amisherate-kasittelytilat!
+      {:id (:id kasittelytilat)
+       :aloitusherate_kasitelty true
+       :paattoherate_kasitelty true})))
+
 (defn select-hoksit-with-kasittelemattomat-aloitusheratteet
   "Hakee tietokannasta HOKSit, joissa on käsittelemättömiä aloitusherätteitä."
   [start end limit]

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -60,6 +60,10 @@
 (defq select-hoksit-created-between "hoksit/select_hoksit_created_between.sql")
 (defq select-hoksit-finished-between
       "hoksit/select_hoksit_finished_between.sql")
+(defq select-non-tuva-hoksit-created-between
+      "hoksit/select_non_tuva_hoksit_created_between.sql")
+(defq select-non-tuva-hoksit-finished-between
+      "hoksit/select_non_tuva_hoksit_finished_between.sql")
 (defq select-hoks-oppijat-without-index
       "hoksit/select_oppija_oids_without_info.sql")
 (defq select-hoks-oppijat-without-index-count

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -116,11 +116,10 @@
                                           (.queueUrl queue-url)
                                           (.messageBody (json/write-str msg))
                                           (.build)))]
-    (when-not (some? (.messageId resp))
-      (log/error "Failed to send message " msg)
-      (throw (ex-info
-               "Failed to send SQS message"
-               {:error :sqs-error})))))
+    (if (some? (.messageId resp))
+      true
+      (do (log/error "Failed to send message " msg)
+          (throw (ex-info "Failed to send SQS message" {:error :sqs-error}))))))
 
 (defn send-amis-palaute-message
   "Lähettää AMIS-palauteviestin."

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -60,8 +60,9 @@
 
 (defn build-hoks-hyvaksytty-msg
   "Luo HOKS hyväksytty -viestin."
-  [id hoks]
-  {:ehoks-id id
+  [hoks]
+  {:pre [(:id hoks)]}
+  {:ehoks-id (:id hoks)
    :kyselytyyppi "aloittaneet"
    :opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
    :oppija-oid (:oppija-oid hoks)
@@ -71,9 +72,9 @@
 
 (defn build-hoks-osaaminen-saavutettu-msg
   "Luo HOKS osaamisen saavutettu -viestin."
-  [id hoks kyselytyyppi]
-  {:pre [(:osaamisen-saavuttamisen-pvm hoks)]}
-  {:ehoks-id id
+  [hoks kyselytyyppi]
+  {:pre [(:id hoks) (:osaamisen-saavuttamisen-pvm hoks)]}
+  {:ehoks-id (:id hoks)
    :kyselytyyppi kyselytyyppi
    :opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
    :oppija-oid (:oppija-oid hoks)

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -36,7 +36,7 @@
   [queue-name]
   (try
     (get-queue-url queue-name)
-    (catch QueueDoesNotExistException e
+    (catch QueueDoesNotExistException _
       (log/error (str queue-name " does not exist")))))
 
 (def ^:private herate-queue-url

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -71,14 +71,15 @@
 
 (defn build-hoks-osaaminen-saavutettu-msg
   "Luo HOKS osaamisen saavutettu -viestin."
-  [id saavuttamisen-pvm hoks kyselytyyppi]
+  [id hoks kyselytyyppi]
+  {:pre [(:osaamisen-saavuttamisen-pvm hoks)]}
   {:ehoks-id id
    :kyselytyyppi kyselytyyppi
    :opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
    :oppija-oid (:oppija-oid hoks)
    :sahkoposti (:sahkoposti hoks)
    :puhelinnumero (:puhelinnumero hoks)
-   :alkupvm (str saavuttamisen-pvm)})
+   :alkupvm (str (:osaamisen-saavuttamisen-pvm hoks))})
 
 (defn build-tyoelamapalaute-msg
   "Luo työelämäpalauteviestin."

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -65,7 +65,7 @@
         :query-params [from :- LocalDate
                        to :- LocalDate]
         :return {:count s/Int}
-        (let [hoksit (db-hoks/select-hoksit-created-between from to)
+        (let [hoksit (db-hoks/select-non-tuva-hoksit-created-between from to)
               count  (op/send-every-needed! :aloituskysely hoksit)]
           (restful/rest-ok {:count count})))
 
@@ -75,7 +75,7 @@
         :query-params [from :- LocalDate
                        to :- LocalDate]
         :return {:count s/Int}
-        (let [hoksit (db-hoks/select-hoksit-finished-between from to)
+        (let [hoksit (db-hoks/select-non-tuva-hoksit-finished-between from to)
               count  (op/send-every-needed! :paattokysely hoksit)]
           (restful/rest-ok {:count count})))
 

--- a/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
@@ -91,7 +91,7 @@
   "Resend aloituskyselyt for given time period."
   [from to]
   (send-kyselyt-for-hoksit (db-hoks/select-hoksit-created-between from to)
-                           #(sqs/build-hoks-hyvaksytty-msg (:id %) %)))
+                           #(sqs/build-hoks-hyvaksytty-msg %)))
 
 (defn paatto-build-msg
   "Build päättökysely message."
@@ -99,10 +99,7 @@
   (when-let [opiskeluoikeus (k/get-opiskeluoikeus-info
                               (:opiskeluoikeus-oid hoks))]
     (when-let [kyselytyyppi (op/get-kysely-type opiskeluoikeus)]
-      (sqs/build-hoks-osaaminen-saavutettu-msg
-        (:id hoks)
-        hoks
-        kyselytyyppi))))
+      (sqs/build-hoks-osaaminen-saavutettu-msg hoks kyselytyyppi))))
 
 (defn resend-paattokyselyherate-between
   "Resend päättökyselyt for given time period."
@@ -127,8 +124,7 @@
     (log/infof
       "Sending %d (limit %d) hoksit between %s and %s"
       (count hoksit) (* 2 limit) start end)
-    (send-kyselyt-for-hoksit aloittaneet
-                             #(sqs/build-hoks-hyvaksytty-msg (:id %) %))
+    (send-kyselyt-for-hoksit aloittaneet #(sqs/build-hoks-hyvaksytty-msg %))
     (send-kyselyt-for-hoksit paattyneet paatto-build-msg)
     hoksit))
 

--- a/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
@@ -100,11 +100,7 @@
   (if-let [opiskeluoikeus (k/get-opiskeluoikeus-info
                             (:opiskeluoikeus-oid hoks))]
     (if-let [kyselytyyppi (h/get-kysely-type opiskeluoikeus)]
-      (sqs/build-hoks-osaaminen-saavutettu-msg
-        (:id hoks)
-        (:osaamisen-saavuttamisen-pvm hoks)
-        hoks
-        kyselytyyppi))))
+      (sqs/build-hoks-osaaminen-saavutettu-msg (:id hoks) hoks kyselytyyppi))))
 
 (defn resend-paattokyselyherate-between
   "Resend päättökyselyt for given time period."

--- a/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu/heratepalvelu.clj
@@ -1,7 +1,5 @@
 (ns oph.ehoks.heratepalvelu.heratepalvelu
-  (:require [clj-time.core :as t]
-            [clj-time.format :as f]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.external.aws-sqs :as sqs]
@@ -82,7 +80,7 @@
          c 0]
     (if (:osaamisen-hankkimisen-tarve hoks)
       (do
-        (if-let [msg (build-msg hoks)]
+        (when-let [msg (build-msg hoks)]
           (sqs/send-amis-palaute-message msg))
         (recur (first r) (rest r) (inc c)))
       (if (not-empty r)
@@ -98,9 +96,9 @@
 (defn paatto-build-msg
   "Build päättökysely message."
   [hoks]
-  (if-let [opiskeluoikeus (k/get-opiskeluoikeus-info
-                            (:opiskeluoikeus-oid hoks))]
-    (if-let [kyselytyyppi (op/get-kysely-type opiskeluoikeus)]
+  (when-let [opiskeluoikeus (k/get-opiskeluoikeus-info
+                              (:opiskeluoikeus-oid hoks))]
+    (when-let [kyselytyyppi (op/get-kysely-type opiskeluoikeus)]
       (sqs/build-hoks-osaaminen-saavutettu-msg
         (:id hoks)
         hoks

--- a/src/oph/ehoks/hoks/common.clj
+++ b/src/oph/ehoks/hoks/common.clj
@@ -56,6 +56,11 @@
           naytto (:osa-alueet n) conn)
         naytto))))
 
+(defn tuva-related-hoks?
+  [hoks]
+  (or (some? (seq (:hankittavat-koulutuksen-osat hoks)))
+      (some? (:tuva-opiskeluoikeus-oid hoks))))
+
 (defn get-map
   "Get-funktion erikoisversio. Jos avain on sekvenssi, hakee sen jokaisen
   jäsenen coll:ista ja laittaa ne uuteen vectoriin vastaavassa järjestyksessä.

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -523,6 +523,9 @@
                   (:aiemmin-hankitut-yhteiset-tutkinnon-osat hoks)
                   conn))
 
+(def ^:private tuva-hoks-msg-template
+  "HOKS `%s` is a TUVA-HOKS or rinnakkainen ammatillinen HOKS.")
+
 (defn replace-hoks!
   "Korvaa kokonaisen HOKSin (ml. tutkinnon osat) annetuilla arvoilla."
   [hoks-id new-values]
@@ -535,10 +538,9 @@
             (replace-main-hoks! hoks-id new-values db-conn)
             (replace-hoks-parts! updated-hoks db-conn))]
     (if (c/tuva-related-hoks? updated-hoks)
-      (db-hoks/update-amisherate-kasittelytilat!
-        {:id (:id amisherate-kasittelytila)
-         :aloitusherate_kasitelty true
-         :paattoherate_kasitelty true})
+      (db-hoks/set-amisherate-kasittelytilat-to-true!
+        amisherate-kasittelytila
+        (format tuva-hoks-msg-template (:id updated-hoks)))
       (do
         (when (op/send? :aloituskysely current-hoks updated-hoks)
           (db-hoks/update-amisherate-kasittelytilat!
@@ -563,10 +565,9 @@
       (db-hoks/update-hoks-by-id! hoks-id new-values db-conn)
       (let [updated-hoks (merge current-hoks new-values)]
         (if (c/tuva-related-hoks? updated-hoks)
-          (db-hoks/update-amisherate-kasittelytilat!
-            {:id (:id amisherate-kasittelytila)
-             :aloitusherate_kasitelty true
-             :paattoherate_kasitelty true})
+          (db-hoks/set-amisherate-kasittelytilat-to-true!
+            amisherate-kasittelytila
+            (format tuva-hoks-msg-template (:id updated-hoks)))
           (do
             (when (op/send? :aloituskysely current-hoks updated-hoks)
               (db-hoks/update-amisherate-kasittelytilat!

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -298,10 +298,8 @@
                    (:id hoks) tuva-hoks conn)
                  (save-hoks-parts! hoks conn)))]
     (future
-      (when (op/send? :aloituskysely hoks)
-        (op/send-aloituskysely! hoks))
-      (when (op/send? :paattokysely hoks)
-        (op/send-paattokysely! hoks)))
+      (op/send-if-needed! :aloituskysely hoks)
+      (op/send-if-needed! :paattokysely hoks))
     hoks))
 
 (defn check-and-save-hoks!
@@ -546,12 +544,12 @@
           (db-hoks/update-amisherate-kasittelytilat!
             {:id (:id amisherate-kasittelytila)
              :aloitusherate_kasitelty false})
-          (op/send-aloituskysely! updated-hoks))
+          (op/send! :aloituskysely updated-hoks))
         (when (op/send? :paattokysely current-hoks updated-hoks)
           (db-hoks/update-amisherate-kasittelytilat!
             {:id (:id amisherate-kasittelytila)
              :paattoherate_kasitelty false})
-          (op/send-paattokysely! updated-hoks))))
+          (op/send! :paattokysely updated-hoks))))
     h))
 
 (defn update-hoks!
@@ -574,12 +572,12 @@
               (db-hoks/update-amisherate-kasittelytilat!
                 {:id (:id amisherate-kasittelytila)
                  :aloitusherate_kasitelty false})
-              (op/send-aloituskysely! updated-hoks))
+              (op/send! :aloituskysely updated-hoks))
             (when (op/send? :paattokysely current-hoks updated-hoks)
               (db-hoks/update-amisherate-kasittelytilat!
                 {:id (:id amisherate-kasittelytila)
                  :paattoherate_kasitelty false})
-              (op/send-paattokysely! updated-hoks))))
+              (op/send! :paattokysely updated-hoks))))
         updated-hoks))))
 
 (defn insert-kyselylinkki!

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -140,6 +140,12 @@
   [id]
   (get-hoks-values (db-hoks/select-hoks-by-id id)))
 
+(defn get-hoks-with-hankittavat-koulutuksen-osat!
+  [hoks-id]
+  (assoc (db-hoks/select-hoks-by-id hoks-id)
+         :hankittavat-koulutuksen-osat
+         (ha/get-hankittavat-koulutuksen-osat hoks-id)))
+
 (defn filter-for-vipunen
   "Trimmaa kaikki HOKSin tutkinnon osat paitsi hankittavat paikalliset tutkinnon
   osat vipusta varten."

--- a/src/oph/ehoks/opiskelijapalaute.clj
+++ b/src/oph/ehoks/opiskelijapalaute.clj
@@ -1,8 +1,8 @@
 (ns oph.ehoks.opiskelijapalaute
-  (:require
-    [clojure.tools.logging :as log]
-    [oph.ehoks.external.aws-sqs :as sqs]
-    [oph.ehoks.external.koski :as k]))
+  (:require [clojure.tools.logging :as log]
+            [oph.ehoks.external.aws-sqs :as sqs]
+            [oph.ehoks.external.koski :as k]
+            [oph.ehoks.hoks.common :as c]))
 
 (defn- ammatillinen-suoritus?
   "Tarkistaa, onko suorituksen tyyppi ammatillinen suoritus tai osittainen
@@ -58,3 +58,53 @@
                     (:id hoks)
                     (:osaamisen-saavuttamisen-pvm hoks)
                     (:opiskeluoikeus-oid hoks)))))
+
+(defn- added?
+  [key* current-hoks updated-hoks]
+  (and (some? (get updated-hoks key*)) (nil? (get current-hoks key*))))
+
+(defn send?
+  "Checks if aloituskysely or päättökysely should be sent. The function has two
+  arities, one for HOKS creation and the other for HOKS update. On HOKS creation
+  log printings will occur when kysely won't be sent and on HOKS update the
+  other way around."
+  ([kysely hoks] ; on HOKS creation
+    {:pre [(#{:aloituskysely :paattokysely} kysely)]}
+    (let [msg (format "Not sending %s for HOKS `%s`. "
+                      (name kysely) (:id hoks))]
+      (cond
+        (not (:osaamisen-hankkimisen-tarve hoks))
+        (log/info msg "`osaamisen-hankkimisen-tarve` is not set to `true` "
+                  "for given HOKS.")
+        (c/tuva-related-hoks? hoks)
+        (log/info msg "HOKS is either TUVA-HOKS or \"ammatillisen "
+                  "koulutuksen HOKS\" related to TUVA-HOKS.")
+        (and (= kysely :paattokysely)
+             (nil? (:osaamisen-saavuttamisen-pvm hoks)))
+        (log/info msg "`osaamisen-saavuttamisen-pvm` has not yet been set "
+                  "for given HOKS.")
+        :else true)))
+  ([kysely current-hoks updated-hoks] ; on HOKS update
+    {:pre [(#{:aloituskysely :paattokysely} kysely)]}
+    (let [msg (format "Sending %s for HOKS `%s`. "
+                      (name kysely) (:id updated-hoks))]
+      (and (:osaamisen-hankkimisen-tarve updated-hoks)
+           (not (c/tuva-related-hoks? updated-hoks))
+           (not ; In case of log prints `nil` is returned, convert to `true`.
+             (cond
+               (and (= kysely :aloituskysely)
+                    (not (:osaamisen-hankkimisen-tarve current-hoks)))
+               (log/info msg "`osaamisen-hankkimisen-tarve` updated from "
+                         "`false` to `true`.")
+               (and (= kysely :aloituskysely)
+                    (added? :sahkoposti current-hoks updated-hoks))
+               (log/info msg "`sahkoposti` has been added.")
+               (and (= kysely :aloituskysely)
+                    (added? :puhelinnumero current-hoks updated-hoks))
+               (log/info msg "`puhelinnumero` has been added.")
+               (and (= kysely :paattokysely)
+                    (added? :osaamisen-saavuttamisen-pvm
+                            current-hoks
+                            updated-hoks))
+               (log/info msg "`osaamisen-saavuttamisen-pvm` has been added.")
+               :else true)))))) ; will be converted to `false`.

--- a/src/oph/ehoks/opiskelijapalaute.clj
+++ b/src/oph/ehoks/opiskelijapalaute.clj
@@ -32,31 +32,29 @@
 
 (defn send-aloituskysely!
   "Lähettää AMIS aloituskyselyn herätepalveluun."
-  [hoks-id hoks]
+  [hoks]
+  {:pre [(:id hoks)]}
   (try
-    (sqs/send-amis-palaute-message
-      (sqs/build-hoks-hyvaksytty-msg
-        hoks-id hoks))
+    (sqs/send-amis-palaute-message (sqs/build-hoks-hyvaksytty-msg hoks))
     (catch Exception e
       (log/warn e)
-      (log/warnf "Error in sending aloituskysely for hoks id %s." hoks-id))))
+      (log/warnf "Error in sending aloituskysely for hoks id %s." (:id hoks)))))
 
 (defn send-paattokysely!
   "Lähettää AMIS-päättöpalautekyselyn herätepalveluun."
-  [hoks-id hoks]
-  {:pre [(:osaamisen-saavuttamisen-pvm hoks)]}
+  [hoks]
+  {:pre [(:id hoks) (:osaamisen-saavuttamisen-pvm hoks)]}
   (try (let [opiskeluoikeus (k/get-opiskeluoikeus-info
                               (:opiskeluoikeus-oid hoks))
              kyselytyyppi (get-kysely-type opiskeluoikeus)]
          (when (and (some? opiskeluoikeus) (some? kyselytyyppi))
            (sqs/send-amis-palaute-message
-             (sqs/build-hoks-osaaminen-saavutettu-msg
-               hoks-id hoks kyselytyyppi))))
+             (sqs/build-hoks-osaaminen-saavutettu-msg hoks kyselytyyppi))))
        (catch Exception e
          (log/warn e)
          (log/warnf (str "Error in sending päättökysely for hoks id %s. "
                          "osaamisen-saavuttamisen-pvm %s. "
                          "opiskeluoikeus-oid %s.")
-                    hoks-id
+                    (:id hoks)
                     (:osaamisen-saavuttamisen-pvm hoks)
                     (:opiskeluoikeus-oid hoks)))))

--- a/src/oph/ehoks/opiskelijapalaute.clj
+++ b/src/oph/ehoks/opiskelijapalaute.clj
@@ -1,0 +1,62 @@
+(ns oph.ehoks.opiskelijapalaute
+  (:require
+    [clojure.tools.logging :as log]
+    [oph.ehoks.external.aws-sqs :as sqs]
+    [oph.ehoks.external.koski :as k]))
+
+(defn- ammatillinen-suoritus?
+  "Tarkistaa, onko suorituksen tyyppi ammatillinen suoritus tai osittainen
+  ammatillinen suoritus."
+  [suoritus]
+  (or (= (:koodiarvo (:tyyppi suoritus)) "ammatillinentutkinto")
+      (= (:koodiarvo (:tyyppi suoritus)) "ammatillinentutkintoosittainen")))
+
+(defn- get-suoritus
+  "Hakee opiskeluoikeudesta ensimmäisen suorituksen, jonka tyyppi on
+  ammatillinen suoritus tai osittainen ammatillinen suoritus."
+  [opiskeluoikeus]
+  (some #(when (ammatillinen-suoritus? %) %) (:suoritukset opiskeluoikeus)))
+
+(defn get-kysely-type
+  "Muuttaa opiskeluoikeuden suorituksen tyypin sellaiseksi, minkä herätepalvelu
+  voi hyväksyä."
+  [opiskeluoikeus]
+  (let [tyyppi (get-in
+                 (get-suoritus opiskeluoikeus)
+                 [:tyyppi :koodiarvo])]
+    (cond
+      (= tyyppi "ammatillinentutkinto")
+      "tutkinnon_suorittaneet"
+      (= tyyppi "ammatillinentutkintoosittainen")
+      "tutkinnon_osia_suorittaneet")))
+
+(defn send-aloituskysely!
+  "Lähettää AMIS aloituskyselyn herätepalveluun."
+  [hoks-id hoks]
+  (try
+    (sqs/send-amis-palaute-message
+      (sqs/build-hoks-hyvaksytty-msg
+        hoks-id hoks))
+    (catch Exception e
+      (log/warn e)
+      (log/warnf "Error in sending aloituskysely for hoks id %s." hoks-id))))
+
+(defn send-paattokysely!
+  "Lähettää AMIS-päättöpalautekyselyn herätepalveluun."
+  [hoks-id hoks]
+  {:pre [(:osaamisen-saavuttamisen-pvm hoks)]}
+  (try (let [opiskeluoikeus (k/get-opiskeluoikeus-info
+                              (:opiskeluoikeus-oid hoks))
+             kyselytyyppi (get-kysely-type opiskeluoikeus)]
+         (when (and (some? opiskeluoikeus) (some? kyselytyyppi))
+           (sqs/send-amis-palaute-message
+             (sqs/build-hoks-osaaminen-saavutettu-msg
+               hoks-id hoks kyselytyyppi))))
+       (catch Exception e
+         (log/warn e)
+         (log/warnf (str "Error in sending päättökysely for hoks id %s. "
+                         "osaamisen-saavuttamisen-pvm %s. "
+                         "opiskeluoikeus-oid %s.")
+                    hoks-id
+                    (:osaamisen-saavuttamisen-pvm hoks)
+                    (:opiskeluoikeus-oid hoks)))))

--- a/src/oph/ehoks/user.clj
+++ b/src/oph/ehoks/user.clj
@@ -1,7 +1,7 @@
 (ns oph.ehoks.user
   (:require [clojure.string :as str]
             [oph.ehoks.external.organisaatio :as o]
-            [oph.ehoks.oppijaindex :as op]))
+            [oph.ehoks.oppijaindex :as oi]))
 
 (defn resolve-privilege
   "Resolves OPH privilege to keyword sets"
@@ -50,8 +50,8 @@
    :roles              (get-service-roles (:kayttooikeudet organisation))
    :child-organisations (if (= (:organisaatioOid organisation)
                                "1.2.246.562.10.00000000001")
-                          (op/get-oppilaitos-oids-cached)
-                          (op/get-oppilaitos-oids-by-koulutustoimija-oid
+                          (oi/get-oppilaitos-oids-cached)
+                          (oi/get-oppilaitos-oids-by-koulutustoimija-oid
                             (:organisaatioOid organisation)))})
 
 (defn get-auth-info

--- a/src/oph/ehoks/virkailija/middleware.clj
+++ b/src/oph/ehoks/virkailija/middleware.clj
@@ -1,7 +1,7 @@
 (ns oph.ehoks.virkailija.middleware
   (:require [ring.util.http-response :as response]
             [oph.ehoks.user :as user]
-            [oph.ehoks.oppijaindex :as op]
+            [oph.ehoks.oppijaindex :as oi]
             [clojure.tools.logging :as log]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]))
 
@@ -65,12 +65,12 @@
              ticket-user (:oppilaitos-oid opiskeluoikeus))
            privilege)
           opiskeluoikeus))
-      (op/get-oppija-opiskeluoikeudet oppija-oid))))
+      (oi/get-oppija-opiskeluoikeudet oppija-oid))))
 
 (defn virkailija-has-privilege-in-opiskeluoikeus?
   "Check if user has access privileges to opiskeluoikeus"
   [ticket-user opiskeluoikeus-oid privilege]
-  (let [opiskeluoikeus (op/get-opiskeluoikeus-by-oid! opiskeluoikeus-oid)]
+  (let [opiskeluoikeus (oi/get-opiskeluoikeus-by-oid! opiskeluoikeus-oid)]
     (and (some? opiskeluoikeus)
          (contains?
            (user/get-organisation-privileges

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -197,11 +197,9 @@
       (if-let [hoks (h/get-hoks-with-hankittavat-koulutuksen-osat! hoks-id)]
         (if (op/send-if-needed! :aloituskysely hoks)
           (response/no-content)
-          (do (log/info (str "Did not resend aloitusheräte "
-                             "(osaamisen-hankkimisen-tarve=false) for hoks-id "
-                             hoks-id))
-              (response/bad-request
-                {:error "Osaamisen hankkimisen tarve false"})))
+          (response/bad-request
+            {:error (str "Either `osaamisen-hankkimisen-tarve` is `false` or "
+                         "HOKS is TUVA related.")}))
         (do (log/warn "No HOKS found with given hoks-id " hoks-id)
             (response/not-found {:error "No HOKS found with given hoks-id"}))))
 
@@ -212,16 +210,10 @@
       (if-let [hoks (h/get-hoks-with-hankittavat-koulutuksen-osat! hoks-id)]
         (if (op/send-if-needed! :paattokysely hoks)
           (response/no-content)
-          (do (log/info (str "Did not resend päättöheräte "
-                             "(osaamisen-saavuttamisen-pvm="
-                             (:osaamisen-saavuttamisen-pvm hoks)
-                             ", osaamisen-hankkimisen-tarve="
-                             (:osaamisen-hankkimisen-tarve hoks)
-                             ") for hoks-id "
-                             hoks-id))
-              (response/bad-request
-                {:error (str "No osaamisen saavuttamisen pvm or osaamisen "
-                             "hankkimisen tarve is false")})))
+          (response/bad-request
+            {:error (str "Either `osaamisen-hankkimisen-tarve` is `false`, "
+                         "`osaamisen-hankkimisen-pvm` has not been set or "
+                         "HOKS is TUVA related.")}))
         (do (log/warn "No HOKS found with given hoks-id:" hoks-id)
             (response/not-found {:error "No HOKS found with given hoks-id"}))))
 

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -198,7 +198,7 @@
         (if hoks
           (if (:osaamisen-hankkimisen-tarve hoks)
             (do
-              (op/send-aloituskysely! hoks-id hoks)
+              (op/send-aloituskysely! hoks)
               (response/no-content))
             (do
               (log/info (str "Did not resend aloitusheräte "

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -196,7 +196,7 @@
       :path-params [hoks-id :- s/Int]
       (let [hoks (db-hoks/select-hoks-by-id hoks-id)]
         (if hoks
-          (if (:osaamisen-hankkimisen-tarve hoks)
+          (if (op/send? :aloituskysely hoks)
             (do
               (op/send-aloituskysely! hoks)
               (response/no-content))
@@ -218,8 +218,7 @@
       :path-params [hoks-id :- s/Int]
       (let [hoks (db-hoks/select-hoks-by-id hoks-id)]
         (if hoks
-          (if (and (:osaamisen-hankkimisen-tarve hoks)
-                   (:osaamisen-saavuttamisen-pvm hoks))
+          (if (op/send? :paattokysely hoks)
             (do
               (sqs/send-amis-palaute-message (hp/paatto-build-msg hoks))
               (response/no-content))

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -7,7 +7,6 @@
             [oph.ehoks.external.cache :as c]
             [oph.ehoks.oppijaindex :as oi]
             [oph.ehoks.heratepalvelu.heratepalvelu :as hp]
-            [oph.ehoks.hoks.hoks :as h]
             [oph.ehoks.opiskelijapalaute :as op]
             [clojure.core.async :as a]
             [ring.util.http-response :as response]

--- a/test/oph/ehoks/opiskelijapalaute_test.clj
+++ b/test/oph/ehoks/opiskelijapalaute_test.clj
@@ -1,0 +1,152 @@
+(ns oph.ehoks.opiskelijapalaute-test
+  (:require [clojure.test :refer [are deftest is testing]]
+            [oph.ehoks.opiskelijapalaute :as op]
+            [oph.ehoks.utils :refer [assoc-if-some]]))
+
+(def hoksit
+  (for [tarve  [true false nil]
+        pvm    ["2023-09-01" nil]
+        sposti ["testi.testaaja@testidomain.testi" nil]
+        puh    ["0123456789" nil]]
+    (assoc-if-some {}
+                   :osaamisen-hankkimisen-tarve tarve
+                   :osaamisen-saavuttamisen-pvm pvm
+                   :sahkoposti sposti
+                   :puhelinnumero puh)))
+
+(def tuva-hoksit
+  (for [tarve  [true false nil]
+        pvm    ["2023-09-01" nil]
+        sposti ["testi.testaaja@testidomain.testi" nil]
+        puh    ["0123456789" nil]]
+    (assoc-if-some {}
+                   :osaamisen-hankkimisen-tarve tarve
+                   :osaamisen-saavuttamisen-pvm pvm
+                   :sahkoposti sposti
+                   :puhelinnumero puh
+                   :hankittavat-koulutuksen-osat ["koulutuksen-osa"])))
+
+(def tuva-rinnakkaiset-ammat-hoksit
+  (for [tarve  [true false nil]
+        pvm    ["2023-09-01" nil]
+        sposti ["testi.testaaja@testidomain.testi" nil]
+        puh    ["0123456789" nil]]
+    (assoc-if-some {}
+                   :osaamisen-hankkimisen-tarve tarve
+                   :osaamisen-saavuttamisen-pvm pvm
+                   :sahkoposti sposti
+                   :puhelinnumero puh
+                   :tuva-opiskeluoikeus-oid "1.2.246.562.15.88406700034")))
+
+(deftest test-send?
+  (testing "On HOKS creation or update"
+    (testing "don't send kysely if"
+      (testing "`osaamisen-hankkimisen-tarve` is missing or is `false`."
+        (doseq [hoks (filter #(not (:osaamisen-hankkimisen-tarve %)) hoksit)]
+          (is (not (op/send? :aloituskysely hoks)))
+          (is (not (op/send? :paattokysely  hoks))))
+        (doseq [current-hoks hoksit
+                updated-hoks (filter #(not (:osaamisen-hankkimisen-tarve %))
+                                     hoksit)]
+          (is (not (op/send? :aloituskysely current-hoks updated-hoks)))
+          (is (not (op/send? :paattokysely  current-hoks updated-hoks)))))
+
+      (testing "HOKS is a TUVA-HOKS or a HOKS related to TUVA-HOKS."
+        (doseq [hoks (concat tuva-hoksit tuva-rinnakkaiset-ammat-hoksit)]
+          (is (not (op/send? :aloituskysely hoks)))
+          (is (not (op/send? :paattokysely  hoks))))
+        (doseq [current-hoks hoksit
+                updated-hoks (concat tuva-hoksit
+                                     tuva-rinnakkaiset-ammat-hoksit)]
+          (is (not (op/send? :aloituskysely current-hoks updated-hoks)))
+          (is (not (op/send? :paattokysely  current-hoks updated-hoks)))))
+
+      (testing
+       "don't send päättökysely if `osaamisen-saavuttamisen-pvm` is missing."
+        (doseq [hoks (filter #(not (:osaamisen-saavuttamisen-pvm %)) hoksit)]
+          (is (not (op/send? :paattokysely  hoks))))
+        (doseq [current-hoks hoksit
+                updated-hoks (filter #(not (:osaamisen-saavuttamisen-pvm %))
+                                     hoksit)]
+          (is (not (op/send? :paattokysely current-hoks updated-hoks)))))))
+
+  (testing "On HOKS creation"
+    (testing "send aloituskysely if `osaamisen-hankkimisen-tarve` is `true`."
+      (doseq [hoks (filter :osaamisen-hankkimisen-tarve hoksit)]
+        (is (op/send? :aloituskysely hoks))))
+
+    (testing (str "send paattokysely if `osaamisen-hankkimisen-tarve` is "
+                  "`true` and `osaamisen-saavuttamisen-pvm` is not missing.")
+      (doseq [hoks (filter #(and (:osaamisen-hankkimisen-tarve %)
+                                 (:osaamisen-saavuttamisen-pvm %))
+                           hoksit)]
+        (is (op/send? :paattokysely hoks)))))
+
+  (testing "On HOKS update"
+    (testing
+     "send aloituskysely if `osaamisen-hankkimisen-tarve` is added to HOKS."
+      (doseq [current-hoks (filter #(not (:osaamisen-hankkimisen-tarve %))
+                                   hoksit)
+              updated-hoks (filter :osaamisen-hankkimisen-tarve hoksit)]
+        (is (op/send? :aloituskysely current-hoks updated-hoks))))
+
+    (testing (str "send aloituskysely if `sahkoposti` is added to HOKS and "
+                  "`osaamisen-hankkimisen-tarve` is `true`.")
+      (doseq [current-hoks (filter #(not (:sahkoposti %)) hoksit)
+              updated-hoks (filter #(and (:sahkoposti %)
+                                         (:osaamisen-hankkimisen-tarve %))
+                                   hoksit)]
+        (is (op/send? :aloituskysely current-hoks updated-hoks))))
+
+    (testing (str "send aloituskysely if `puhelinnumero` is added to HOKS and "
+                  "`osaamisen-hankkimisen-tarve` is `true`.")
+      (doseq [current-hoks (filter #(not (:puhelinnumero %)) hoksit)
+              updated-hoks (filter #(and (:puhelinnumero %)
+                                         (:osaamisen-hankkimisen-tarve %))
+                                   hoksit)]
+        (is (op/send? :aloituskysely current-hoks updated-hoks))))
+
+    (testing
+     "send päättökysely if `osaamisen-saavuttamisen-pvm` is added to HOKS."
+      (doseq [current-hoks (filter #(and (:osaamisen-hankkimisen-tarve %)
+                                         (not (:osaamisen-saavuttamisen-pvm %)))
+                                   hoksit)
+              updated-hoks (filter #(and (:osaamisen-hankkimisen-tarve %)
+                                         (:osaamisen-saavuttamisen-pvm %))
+                                   hoksit)]
+        (is (op/send? :paattokysely current-hoks updated-hoks))))
+
+    (testing "don't send aloituskysely if"
+      (testing "`sahkoposti` stays unchanged, is changed or is removed."
+        (are [old-val new-val]
+             (not (op/send?
+                    :aloituskysely
+                    {:osaamisen-hankkimisen-tarve true :sahkoposti old-val}
+                    {:osaamisen-hankkimisen-tarve true :sahkoposti new-val}))
+          "testi.testaaja@testidomain.testi" "testi.testaaja@testidomain.testi"
+          "testi.testaaja@testidomain.testi" "testi.testinen@testi.domain"
+          "testi.testaaja@testidomain.testi" nil))
+
+      (testing "`puhelinnumero` stays unchanged, is changed or is removed."
+        (are [old-val new-val]
+             (not (op/send?
+                    :aloituskysely
+                    {:osaamisen-hankkimisen-tarve true
+                     :puhelinnumero old-val}
+                    {:osaamisen-hankkimisen-tarve true
+                     :puhelinnumero new-val}))
+          "0123456789" "0123456789"
+          "0123456789" "0011223344"
+          "0123456789" nil)))
+
+    (testing (str "don't send päättökysely if `osaamisen-saavuttamisen-pvm` "
+                  "stays unchanged, is changed or is removed.")
+      (are [old-val new-val]
+           (not (op/send? :paattokysely
+                          {:osaamisen-hankkimisen-tarve true
+                           :osaamisen-saavuttamisen-pvm old-val}
+                          {:osaamisen-hankkimisen-tarve true
+                           :osaamisen-saavuttamisen-pvm new-val}))
+        "2023-09-01" "2023-09-01"
+        "2023-09-01" "2023-09-02"
+        "2023-09-01" nil))))

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -314,3 +314,11 @@
 (defn mock-get-opiskeluoikeus-info
   [_]
   {:tyyppi {:koodiarvo "ammatillinenkoulutus"}})
+
+(defn assoc-if-some
+  "Like `assoc`, but doesn't add key-value-pair to map if value is `nil`."
+  [m & kvs]
+  (->> (partition 2 kvs)
+       (filter (comp some? second))
+       (map vec)
+       (into m)))


### PR DESCRIPTION
## Kuvaus muutoksista

Korjattu bugi, jonka seurauksena opiskelijapalautekyselylinkkejä muodostuu TUVA-hokseille sekä TUVA-hoksien kanssa rinnakkaisille ammatillisille hokseille. Tehty refaktorointia ja lisätty testejä, joilla on yritetty yhtenäistää ja selkeyttää opiskelijapalauteen muodostuksen logikkaa.

https://jira.eduuni.fi/browse/OY-4444

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
