### PR TITLE
OY-4272: HOKSin muutokset tallentumaan auditlokiin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [org.clojure/data.json "0.2.6"]
                  [environ "1.1.0"]
                  [software.amazon.awssdk/sqs "2.5.37"]
-                 [fi.vm.sade/auditlogger "9.2.2-20231108.123740-2"]
+                 [fi.vm.sade/auditlogger "9.2.2-20231114.085926-4"]
                  [com.rpl/specter "1.1.3"]
                  [org.clojure/core.memoize "1.0.250"]]
   :managed-dependencies [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [org.clojure/data.json "0.2.6"]
                  [environ "1.1.0"]
                  [software.amazon.awssdk/sqs "2.5.37"]
-                 [fi.vm.sade/auditlogger "8.3.0-20190605.103856-7"]
+                 [fi.vm.sade/auditlogger "9.2.2-20231108.123740-2"]
                  [com.rpl/specter "1.1.3"]
                  [org.clojure/core.memoize "1.0.250"]]
   :managed-dependencies [[org.clojure/clojure "1.10.1"]
@@ -60,7 +60,8 @@
                          [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
                          [com.fasterxml.jackson.core/jackson-datatype-jsr310 "2.9.8"]
                          [org.clojure/data.json "0.2.6"]
-                         [com.google.code.gson/gson "2.8.0"]
+                         [com.google.code.gson/gson "2.10.1"]
+                         [com.tananaev/json-patch "1.2"]
 
                          ;; XML
                          [org.clojure/data.xml "0.0.8"]

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -93,6 +93,7 @@
         :header-params [caller-id :- s/Str]
         :query-params [oid :- s/Str]
         (hp/handle-onrmodified oid)
+        ; TODO refaktoroi onr-käsittelyä auditlokitusystävällisemmäksi (OY-4523)
         (response/no-content))
 
       (c-api/GET "/tyoelamajaksot-active-between" []
@@ -112,6 +113,7 @@
         :return {:hankkimistapa-ids [s/Int]}
         (let [hankkimistavat
               []] ;(db-hoks/delete-tyopaikkaohjaajan-yhteystiedot!)]
+          ; TODO lisää auditlog entry, kun siivous enabloidaan
           (restful/rest-ok {:hankkimistapa-ids hankkimistavat})))
 
       (c-api/DELETE "/opiskelijan-yhteystiedot" []
@@ -122,4 +124,5 @@
         :header-params [caller-id :- s/Str]
         :return {:hoks-ids [s/Int]}
         (let [hoks-ids []] ;(db-hoks/delete-opiskelijan-yhteystiedot!)]
+          ; TODO lisää auditlog entry, kun siivous enabloidaan
           (restful/rest-ok {:hoks-ids hoks-ids}))))))

--- a/src/oph/ehoks/logging/audit.clj
+++ b/src/oph/ehoks/logging/audit.clj
@@ -12,6 +12,7 @@
                                 Operation
                                 Target$Builder
                                 Changes)
+           (java.time ZonedDateTime ZoneOffset)
            (java.net InetAddress)
            (org.ietf.jgss Oid)))
 
@@ -90,6 +91,9 @@
     (or (number? obj) (string? obj) (boolean? obj) (nil? obj)) obj
     (map? obj) (zipmap (keys obj) (map with-only-json-types (vals obj)))
     (coll? obj) (map with-only-json-types obj)
+    (instance? java.util.Date obj) (-> (.toInstant obj)
+                                       (.atZone (ZoneOffset/UTC))
+                                       (str))
     :else (str obj)))
 
 (defn- build-changes

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -981,13 +981,14 @@
                 virkailija-for-test)
               body (utils/parse-body (:body response))
               hoks-url (get-in body [:data :uri])
-              put-response-just-date
+              put-response-just-dates
               (with-test-virkailija
                 (mock/json-body
                   (mock/request :put hoks-url)
                   (assoc hoks-data
                          :id (get-in body [:meta :id])
-                         :ensikertainen-hyvaksyminen "2018-12-17"))
+                         :ensikertainen-hyvaksyminen "2018-12-17"
+                         :paivitetty "2019-01-02T10:20:30.000Z"))
                 virkailija-for-test)
               put-response
               (with-test-virkailija
@@ -996,6 +997,8 @@
                   (assoc
                     hoks-data
                     :id (get-in body [:meta :id])
+                    :ensikertainen-hyvaksyminen "2018-12-17"
+                    :paivitetty "2019-01-02T10:20:30.001Z"
                     :hankittavat-ammat-tutkinnon-osat
                     hato-data))
                 virkailija-for-test)
@@ -1018,9 +1021,11 @@
             (utils/eq (utils/dissoc-module-ids
                         (get-in body [:data :hankittavat-ammat-tutkinnon-osat]))
                       (utils/dissoc-module-ids hato-data)))
-          (t/is (= (:status put-response-just-date) 204))
+          (t/is (= (:status put-response-just-dates) 204))
           (t/is (logtest/logged? "audit" :info #"overwrite.*2018-12-17")
                 (str "log entries:" (logtest/the-log)))
+          (t/is (logtest/logged?
+                  "audit" :info #"overwrite.*2019-01-02T10:20:30Z"))
           (t/is (= (:status put-response) 204))
           (t/is (logtest/logged? "audit" :info #"overwrite.*Tanelin Paja")))))))
 


### PR DESCRIPTION
## Kuvaus muutoksista

Korjataan toiminnallisuus niin, että HOKSiin tallennettavat muutokset tallentuvat auditlokiin.

Riippuu auditloggerin [muutoksesta](https://github.com/Opetushallitus/auditlogger/pull/24).

https://jira.eduuni.fi/browse/OY-4272

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
