### PR TITLE
Fix päättökysely sending on HOKS replace

### DIFF
--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -536,13 +536,13 @@
   "Korvaa kokonaisen HOKSin (ml. tutkinnon osat) annetuilla arvoilla."
   [hoks-id new-values]
   (let [current-hoks (get-hoks-by-id hoks-id)
-        updated-hoks (assoc new-values :id hoks-id)
         amisherate-kasittelytila
         (db-hoks/get-or-create-amisherate-kasittelytila-by-hoks-id! hoks-id)
         h (jdbc/with-db-transaction
             [db-conn (db-ops/get-db-connection)]
             (replace-main-hoks! hoks-id new-values db-conn)
-            (replace-hoks-parts! updated-hoks db-conn))]
+            (replace-hoks-parts! (assoc new-values :id hoks-id) db-conn))
+        updated-hoks (get-hoks-by-id hoks-id)]
     (if (c/tuva-related-hoks? updated-hoks)
       (db-hoks/set-amisherate-kasittelytilat-to-true!
         amisherate-kasittelytila

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -883,7 +883,7 @@
          :types {:any s/Str}
          :description "HOKSin generoitu ulkoinen tunniste eHOKS-järjestelmässä"}
    :oppija-oid {:methods {:any :optional
-                          :post :required}
+                          :post :required} ; FIXME: should be required for :put
                 :types {:any Oid}
                 :description "Oppijan tunniste Opintopolku-ympäristössä"}
    :sahkoposti {:methods {:any :optional}
@@ -894,7 +894,7 @@
                    :description "Oppijan puhelinnumero, merkkijono."}
    :opiskeluoikeus-oid
    {:methods {:any :optional
-              :post :required}
+              :post :required} ; FIXME: should be required for :put
     :types {:any OpiskeluoikeusOid}
     :description (str "Opiskeluoikeuden oid-tunniste Koski-järjestelmässä "
                       "muotoa '1.2.246.562.15.00000000001'.")}


### PR DESCRIPTION
## Kuvaus muutoksista

Korjattu osana OY-4444 tapahtunut regressio, jossa päättökyselyiden lähetys epäonnistuu puuttuvien tietojen vuoksi. Haetaan ajantasaisimmat tiedot kannasta ja opiskelijapalautteiden lähetyksessä näitä.

https://jira.eduuni.fi/browse/EH-1567

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
