### PR TITLE
EH-1518: Käsittele 404-virhetilanne Service Ticketiä haettaessa

### DIFF
--- a/src/oph/ehoks/common/api.clj
+++ b/src/oph/ehoks/common/api.clj
@@ -14,6 +14,11 @@
   [_ __ ___]
   (response/not-found {:reason "Route not found"}))
 
+(defn unauthorized-handler
+  "Käsittelee tapauksen, jossa ei (ole/saada tarkistettua) käyttöoikeuksia."
+  [_ __ ___]
+  (response/unauthorized {:reason "Unable to check access rights"}))
+
 (defn log-exception
   "Logittaa virheen."
   [ex data]
@@ -41,6 +46,7 @@
    ::c-ex/response-validation (c-ex/with-logging
                                 c-ex/http-response-handler :error)
    :not-found not-found-handler
+   :unauthorized unauthorized-handler
    ::c-ex/default exception-handler})
 
 (defn create-app


### PR DESCRIPTION
## Kuvaus muutoksista

Käsitellään tilanne/tilanteet, jossa CAS palauttaa 404 haettaessa uutta Service Ticketiä. Näitä tapahtunee useimmiten sen jälkeen, kun CAS-palvelu on käynnistetty uudelleen.

https://jira.eduuni.fi/browse/EH-1518

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
