### PR TITLE
Remove "Error caused by hoks-id ..." log print

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -312,7 +312,6 @@
         (let [db-hoks (db-handler (get-in request [:hoks :id]) hoks)]
           (assoc (response/no-content) :audit-data {:new hoks :old old-hoks}))
         (catch Exception e
-          (h/error-log-hoks-id (get-in request [:hoks :id]))
           (if (= (:error (ex-data e)) :disallowed-update)
             (response/bad-request! {:error (.getMessage e)})
             (throw e)))))))

--- a/src/oph/ehoks/hoks/hoks.clj
+++ b/src/oph/ehoks/hoks/hoks.clj
@@ -187,11 +187,6 @@
     hoks
     (rename-keys hoks {:deleted-at :poistettu})))
 
-(defn error-log-hoks-id
-  "Logittaa HOKSin ID:n virheenä."
-  [id]
-  (log/errorf "Error caused by hoks-id: %s" id))
-
 (defn- validate-tuva-hoks-type
   [hoks]
   (when-let [opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)]


### PR DESCRIPTION
## Kuvaus muutoksista

Tässä siis poistettu tuo otsikonmukainen lokitus `change-hoks!`-funktiosta. Lokitusta ei siis ole lisätty, toisin kuin tiketin EH-1377 kuvauksessa on ehdotettu. Tuo tiketti on muutenkin tosi vanha, ja aika paljon refaktorointia on ehtinyt tapahtua koodissa sen jälkeen. Tiketin otsikko on myös varsin lavea, tämä on tottakai moka jonka olen itse aikoinaan tehnyt. Tuon lokituksen poistaminen tuntui tässä tapauksessa sopivalta, koska käsittelemättömät poikkeukset lokitetaan joka tapauksessa `oph/ehoks/common/api.clj` poikkeuksen käsittelijässä `exception-handler`.

https://jira.eduuni.fi/browse/EH-1377

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
