### PR TITLE
OY-4557: Ohitetaan osaamisen hankkimistavan päivämäärävalidointi eronneeksi katsotun oppijan HOKSille

### DIFF
--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -148,7 +148,14 @@
 (deftest create-hoks-without-osa-aikaisuustieto
   (testing "Create HOKS without osa-aikaisuustieto"
     (with-redefs [oph.ehoks.external.koski/get-opiskeluoikeus-info
-                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}})]
+                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+                           :tila {:opiskeluoikeusjaksot
+                                  [{:alku "2023-07-03"
+                                    :tila {:koodiarvo "lasna"
+                                           :nimi {:fi "Läsnä"}
+                                           :koodistoUri
+                                           "koskiopiskeluoikeudentila"
+                                           :koodistoVersio 1}}]}})]
       (let [hoks-data test-data/hoks-data-without-osa-aikaisuus
             response
             (hoks-utils/mock-st-post
@@ -197,7 +204,14 @@
 (deftest create-new-hoks-with-valid-osa-aikaisuus
   (testing "Create new hoks with valid osa-aikaisuustieto"
     (with-redefs [oph.ehoks.external.koski/get-opiskeluoikeus-info
-                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}})]
+                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+                           :tila {:opiskeluoikeusjaksot
+                                  [{:alku "2023-07-03"
+                                    :tila {:koodiarvo "lasna"
+                                           :nimi {:fi "Läsnä"}
+                                           :koodistoUri
+                                           "koskiopiskeluoikeudentila"
+                                           :koodistoVersio 1}}]}})]
       (let [hoks-data test-data/new-hoks-with-valid-osa-aikaisuus
             response
             (hoks-utils/mock-st-post
@@ -226,6 +240,13 @@
   (testing "Create new hoks without osa-aikaisuustieto"
     (with-redefs [oph.ehoks.external.koski/get-opiskeluoikeus-info
                   (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+                           :tila {:opiskeluoikeusjaksot
+                                  [{:alku "2023-07-03"
+                                    :tila {:koodiarvo "lasna"
+                                           :nimi {:fi "Läsnä"}
+                                           :koodistoUri
+                                           "koskiopiskeluoikeudentila"
+                                           :koodistoVersio 1}}]}
                            :suoritukset [{:tyyppi {:koodiarvo "telma"}}]})]
       (let [hoks-data test-data/new-hoks-without-osa-aikaisuus
             response
@@ -373,7 +394,14 @@
 (deftest hoks-put-adds-non-existing-part
   (testing "If HOKS part doesn't currently exist, PUT creates it"
     (with-redefs [oph.ehoks.external.koski/get-opiskeluoikeus-info
-                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}})]
+                  (fn [_] {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+                           :tila {:opiskeluoikeusjaksot
+                                  [{:alku "2023-07-03"
+                                    :tila {:koodiarvo "lasna"
+                                           :nimi {:fi "Läsnä"}
+                                           :koodistoUri
+                                           "koskiopiskeluoikeudentila"
+                                           :koodistoVersio 1}}]}})]
       (let [app (hoks-utils/create-app nil)
             post-response
             (hoks-utils/create-mock-post-request

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -918,3 +918,14 @@
       (is (= (:status response) 401))
       (is (= (utils/parse-body (:body response))
              {:reason "Unable to check access rights"})))))
+
+(deftest test-bypasses-oht-date-checks-when-eronnut
+  (testing "Bypasses OHT date check when opiskeluoikeus tila is eronnut"
+    (let [app (hoks-utils/create-app nil)
+          data
+          (assoc test-data/hoks-data
+                 :opiskeluoikeus-oid
+                 "1.2.246.562.15.00000000006")
+          post-response
+          (hoks-utils/create-mock-post-request "" data app)]
+      (is (= (:status post-response) 200)))))

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -531,6 +531,13 @@
 (defn mock-get-opiskeluoikeus
   [_]
   {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
+   :tila {:opiskeluoikeusjaksot
+          [{:alku "2020-07-03"
+            :tila {:koodiarvo "lasna"
+                   :nimi {:fi "Läsnä"}
+                   :koodistoUri
+                   "koskiopiskeluoikeudentila"
+                   :koodistoVersio 1}}]}
    :tyyppi {:koodiarvo "ammatillinenkoulutus"}})
 
 (def hoks-osaaminen-saavutettu

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -15,6 +15,12 @@
 
 (def opiskeluoikeus-data
   {:oppilaitos {:oid "1.2.246.562.10.222222222222"}
+   :tila {:opiskeluoikeusjaksot
+          [{:alku "2023-07-03"
+            :tila {:koodiarvo "lasna"
+                   :nimi {:fi "Läsnä"}
+                   :koodistoUri "koskiopiskeluoikeudentila"
+                   :koodistoVersio 1}}]}
    :suoritukset
    [{:koulutusmoduuli
      {:tunniste

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -166,6 +166,12 @@
                 url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000001")
               {:status 200
                :body {:oid "1.2.246.562.15.00000000001"
+                      :tila {:opiskeluoikeusjaksot
+                             [{:alku "2010-01-01"
+                               :tila {:koodiarvo "lasna"
+                                      :nimi {:fi "Läsnä"}
+                                      :koodistoUri "koskiopiskeluoikeudentila"
+                                      :koodistoVersio 1}}]}
                       :oppilaitos {:oid (or oppilaitos-oid
                                             "1.2.246.562.10.12944436166")}
                       :suoritukset
@@ -191,6 +197,12 @@
                 url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000004")
               {:status 200
                :body {:oid "1.2.246.562.15.00000000004"
+                      :tila {:opiskeluoikeusjaksot
+                             [{:alku "2023-10-01"
+                               :tila {:koodiarvo "lasna"
+                                      :nimi {:fi "Läsnä"}
+                                      :koodistoUri "koskiopiskeluoikeudentila"
+                                      :koodistoVersio 1}}]}
                       :oppilaitos {:oid (or oppilaitos-oid
                                             "1.2.246.562.10.12944436166")}
                       :alkamispäivä "2023-10-01"
@@ -201,6 +213,29 @@
                 url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000005")
               {:status 200
                :body {:oid "1.2.246.562.15.00000000005"
+                      :tila {:opiskeluoikeusjaksot
+                             [{:alku "2010-10-01"
+                               :tila {:koodiarvo "lasna"
+                                      :nimi {:fi "Läsnä"}
+                                      :koodistoUri "koskiopiskeluoikeudentila"
+                                      :koodistoVersio 1}}]}
+                      :oppilaitos {:oid (or oppilaitos-oid
+                                            "1.2.246.562.10.12944436166")}
+                      :alkamispäivä "2010-10-01"
+                      :arvioituPäättymispäivä "2010-12-01"
+                      :suoritukset
+                      [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
+                      :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
+              (.endsWith
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000006")
+              {:status 200
+               :body {:oid "1.2.246.562.15.00000000006"
+                      :tila {:opiskeluoikeusjaksot
+                             [{:alku "2010-12-01"
+                               :tila {:koodiarvo "eronnut"
+                                      :nimi {:fi "Eronnut"}
+                                      :koodistoUri "koskiopiskeluoikeudentila"
+                                      :koodistoVersio 1}}]}
                       :oppilaitos {:oid (or oppilaitos-oid
                                             "1.2.246.562.10.12944436166")}
                       :alkamispäivä "2010-10-01"

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -85,6 +85,13 @@
            {:status 200
             :body {:oid "1.2.246.562.15.760000000010"
                    :oppilaitos {:oid "1.2.246.562.10.1200000000010"}
+                   :tila {:opiskeluoikeusjaksot
+                          [{:alku "2023-07-03"
+                            :tila {:koodiarvo "lasna"
+                                   :nimi {:fi "Läsnä"}
+                                   :koodistoUri
+                                   "koskiopiskeluoikeudentila"
+                                   :koodistoVersio 1}}]}
                    :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
            (.endsWith
              url "/koski/api/opiskeluoikeus/1.2.246.562.15.760000000011")


### PR DESCRIPTION
## Kuvaus muutoksista

Ohitetaan osaamisen hankkimistavan päivämäärävalidointi eronneeksi katsotun (opiskeluoikeuden tila not in (valmistunut, läsnä, väliaikaisesti keskeytynyt)) oppijan HOKSille. Eli mahdollistaa tällaisen HOKSin tietojen päivittämisen ilman että työpaikkajaksojen päivämääriä pitää korjata opiskeluoikeuden uuden päättymispäivän mukaiseksi.

https://jira.eduuni.fi/browse/OY-4557

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
