### PR TITLE
Add few utility scripts and docs for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,12 @@ Rajapinnan käyttö on suositeltavampi vaihtoehto koska `lein import` ohittaa
 skeemavalidoinnit ja siten sen avulla pystyy luomaan dataa jota järjestelmä ei
 oikeasti hyväksyisi.
 
+## Skriptit
+
+Repositorioon on lisätty jonkin verran selvitystyötä ja testaamista helpottavia
+skriptejä. Näiden toimintaperiaatteesta voi lukea niille osoitetusta
+[dokumentaatiosta](./doc/scripts.md).
+
 ## Swagger
 
  * [Virkailijan swagger](http://localhost:3000/ehoks-virkailija-backend/doc)

--- a/doc/scripts.md
+++ b/doc/scripts.md
@@ -1,0 +1,183 @@
+# Skriptit
+
+Skriptit on lähtökohtaisesti suunniteltu helpottamaan QA-ympäristössä
+testaamista sekä helpottamaan ajoittaista selvitystyötä. Hokseja poistavien tai
+hoksin tietoja muuttavien skriptien suorittamiselle tuotantoympäristöstä ei
+lähtökohtaisesti pitäisi olla tarvetta. Kuitenkin, jos skriptejä on joskus syytä
+ajaa tuotantoympäristössä, skriptit tulisi laatia siten, että ennen
+muokkaavan/poistavan operaation suorittamista kysytään käyttäjältä aina
+varmistus. Tähän tarkoitukseen voidaan käyttää valmista skriptiä
+`scripts/ask-confirmation`. Myös, koska skriptien toiminnallisuus nojautuu
+asetettuihin ympäristömuuttujiin, on mahdollista että skriptejä ajetaan
+vahingossa väärää ympäristöä vasten. Varmistuksen kysyminen käyttäjältä on
+tarpeellista tästäkin syystä.
+
+Asetusten
+```bash
+set -euo pipefail
+```
+asettaminen skriptin alussa on suositeltavaa, jotta skriptin suoritus lopetetaan
+heti kun jonkin komennon exit-koodi on nollasta poikkeava.
+
+## Skriptien suorittamista varten vaadittavat työkalut
+
+Vaadittavat työkalut skriptien suorittamiseksi ovat
+- [bash-komentotulkki](https://www.gnu.org/software/bash/)
+- [POSIX-työkalut](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html) (cat, grep, xargs, etc.)
+- [jq](https://jqlang.github.io/jq/) (JSON-datan poimintaan, validointiin ja manipulointiin)
+
+## Ympäristömuuttujien asettamien aktivaatioskriptillä
+
+Aktivaatioskripti pyytää valitsemaan halutun ympäristön (esim. `dev`) ja
+syöttämään kehittäjän ympäristöä vastaavan käyttäjätunnuksen ja salasanan.
+Skripti asettaa joukon ympäristömuuttujia (joita monet muut skriptit
+hyödyntävät), hakee valmiiksi CAS Ticket Granting Ticketin (TGT) sekä luo
+Session Cookien virkailija-rajapinnan endpointtien käyttämistä varten.
+
+Aktivaatioskriptiä ei ole tarkoitus suorittaa erillisessä aliprosessissa, vaan
+skriptin komennot suoritetaan ("sourcetaan") käynnissä olevasta shellistä
+komennolla:
+```bash
+$ . scripts/env/activate
+```
+Jos skripti suoritetaan onnistuneesti, konsoliin pitäisi tulostua kaikkine
+vaiheineen jotakuinkin seuraavanlaiset rivit:
+```bash
+$ . scripts/env/activate
+Which environment (prod/dev)? dev
+Please provide your CAS credentials.
+Username: ehoks_kehittaja
+Password:
+Fetching CAS Ticket Granting Ticket (TGT)... Success.
+Refreshing session cookie... Success.
+(dev) $
+```
+Samaan tapaan kuin Python `venv`-virtuaaliympäristön aktivaation yhteydessä,
+skripti asettaa käyttäjän bash-promptiin (`PS1`) prefiksin, joka indikoi mikä
+ympäristö on aktivoitu. eHOKSin aktivaatiskriptin tapauksessa lisätty prefiksi
+on `(dev)` tai `(prod)`, riippuen mikä ympäristö on aktivoitu. On mahdollista,
+että prefiksi ei näy, jos käyttäjän `.bashrc`-konfiguraatiossa on asetettu
+`PROMPT_COMMAND`, joka muokkaa `PS1`-promptia ennen tämän näyttämistä
+konsolissa.
+
+## Ympäristömuuttujien siivoaminen `deactivate`-funktiolla
+
+Aktivaatioskriptissa määritellään funktio `deactivate`, jota voidaan käyttää
+siivoamaan skriptin asettamat ympäristömuuttujat. Komentorivillä riittää siis
+ajaa
+```bash
+deactivate
+```
+jolloin bash-komentotulkin pitäisi olla ympäristömuuttujien osalta samassa
+tilassa kuin ennen aktivaatioskriptin ajamista.
+
+## eHOKS
+
+### Hoksin hakeminen skriptillä `virkailija/get-hoks`
+
+Hoksin koko tietorakenteen hakemiseksi virkailija-rajapintaa käyttäen tarvitaan
+sekä `oppija_oid` että `hoks_id`.
+```bash
+hoks_id=44875; oppija_oid=$(scripts/virkailija/get-hoks-oppija $hoks_id); scripts/virkailija/get-hoks
+$oppija_oid $hoks_id > "hoks_$hoks_id.json"
+```
+Em. komento tallentaisi siis hoksin JSON-tietorakenteen tiedostoon
+`hoks_44875.json`. Molemmat kyselyt `scripts/virkailija/get-hoks-oppija` ja
+`scripts/virkailija/get-hoks` voi halutessaan yhdistää yhteen skriptiin, jolloin
+hoksin tietorakenteen hakemiseksi riittää pelkkä `hoks_id`:
+
+### Uuden hoksin luominen skriptillä `virkailija/create-hoks`
+
+Jos hoks on tallennettu tiedostoon `path/to/hoks.json`, onnistuu hoksin luominen
+valittuun ympäristöön skriptillä:
+```bash
+scripts/virkailija/create-hoks path/to/hoks.json
+```
+Hoksin JSON-tietorakenne voidaan halutessa lukea myös standardisyötevirrasta (`stdin`). Esim.
+```bash
+cat path/to/hoks.json | scripts/virkailija/create-hoks
+```
+tai
+```bash
+scripts/virkailija/create-hoks <<EOL
+{
+  "ensikertainen-hyvaksyminen": "2023-12-05",
+  "sahkoposti": "testikayttaja@testi.fi",
+  "osaamisen-hankkimisen-tarve": true,
+  "opiskeluoikeus-oid": "1.2.246.562.15.71095074820",
+  "oppija-oid": "1.2.246.562.24.54450598189"
+}
+EOL
+```
+
+### Hoksin korvaaminen skriptillä `virkailija/replace-hoks`
+
+`scripts/virkailija/replace-hoks` skripti toimii samalla periaatteella kuin
+`scripts/virkailija/create-hoks` (kts. tämän toimintaperiaate yltä), mutta
+hoksin luomisen sijaan korvaa olemassa olevan hoksin.
+
+**Skriptille riittää antaa korvaavan hoksin tietorakenne**, sillä sekä
+`hoks_id`:n että `oppija_oid`:n on löydyttävä tietorakenteesta, ja skripti
+käyttää näitä tietoja hyväksi. Esim.
+```bash
+scripts/virkailija/replace-hoks <<EOL
+{
+  "id": 44875,
+  "ensikertainen-hyvaksyminen": "2023-12-05",
+  "sahkoposti": "testikayttaja@testi.fi",
+  "osaamisen-hankkimisen-tarve": true,
+  "opiskeluoikeus-oid": "1.2.246.562.15.71095074820",
+  "oppija-oid": "1.2.246.562.24.54450598189"
+}
+EOL
+```
+
+### Hoksin päivittäminen skriptillä `virkailija/update-hoks`
+
+Skripti hoksin päätason tietojen päivittämiseen (PATCH-metodilla). Toimii
+samalla periaatteella kuin `scripts/virkailija/create-hoks` tai
+`scripts/virkailija/replace-hoks`, eli hoksin päivitys-JSON-tietorakenteen voi
+tarjota tiedostona tai standardisyötevirrasta (`stdin`). Hoksin ID:n on
+löydyttävä skriptille tarjottavasta, päivitystä kuvaavasta
+JSON-tietorakenteesta. Skripti hyödyntää tätä tietoa, eikä `hoks_id`:tä tarvitse
+tarjota skriptille erikseen.
+```bash
+scripts/virkailija/update-hoks 1.2.246.562.24.54450598189 <<EOL
+{
+  "id": 44875,
+  "osaamisen-saavuttamisen-pvm": "2023-12-07"
+}
+EOL
+```
+
+
+
+### Hoksin poistaminen pysyvästi skriptillä `virkailija/delete-hoks`
+
+Hoksin voi poistaa `hoks_id`:n skriptille:
+```bash
+scripts/virkailija/delete-hoks 44875
+```
+Tämä poistaa hoksin **pysyvästi**, joten **skriptiä kannattaa käyttää varoen**.
+Aktivoidusta ympäristöstä riippumatta, skripti pyytää käyttäjää varmistamaan
+poistotoimenpiteen ennen se suoritetaan
+
+## Koski
+
+### Opiskeluoikeuden tietojen hakeminen
+Olettaen, että kehittäjällä Koski-lukuoikudet, voidaan
+`scripts/koski/get-opiskeluoikeus`-skriptin avulla hakea opiskeluoikeuden tiedot
+Koskesta. Esimerkiksi, jos halutaan selvittää minkä tyyppiisä suorituksia
+opiskeluoikeuteen kuuluu, voidaan skriptin ulostulo putkittaa `jq`-työkalulle:
+```bash
+scripts/koski/get-opiskeluoikeus 1.2.246.562.15.71095074820 | jq -r '.suoritukset[].tyyppi.koodiarvo'
+```
+
+## Organisaatiopalvelu
+
+### Organisaation nimen hakemin OID:in perusteella
+
+Organisaation suomenkielisen nimen voi hakea komennolla:
+```bash
+scripts/organisaatio/get-name 1.2.246.562.10.54425555 | jq -r '.[0].nimi.fi'
+```

--- a/scripts/ask-confirmation
+++ b/scripts/ask-confirmation
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "$@"
+while true; do
+  read -rp "Are you sure you want to continue (yes/no)? " ans
+  case $ans in
+      [Yy]es) exit   ;;
+      [Nn]o)  exit 1 ;;
+      * ) echo "Please answer yes or no.";;
+  esac
+done

--- a/scripts/cas/get-service-ticket
+++ b/scripts/cas/get-service-ticket
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ] ; then
+
+  {
+    echo "Get CAS service ticket for authentication."
+    echo -e "Usage: $0 SERVICE_URL\n"
+  } >&2
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CAS_TGT
+
+if [ -z "$OPH_CAS_TGT" ]; then
+  {
+    echo "You need to fetch a Ticket Granting Ticket (TGT) first." \
+         "This script expects it to be stored in an environment variable" \
+         "OPH_CAS_TGT. Script \`scripts/env/activate\` should set this" \
+         "automatically, but you can refresh the TGT by running"
+    echo -e "\nexport OPH_CAS_TGT=\$(scripts/cas/get-tgt)\n"
+  } >&2
+  exit 1
+fi
+
+response=$(curl -s "$OPH_VIRKAILIJA_DOMAIN/cas/v1/tickets/$OPH_CAS_TGT" \
+                -d "service=$1")
+
+if ! [[ "$response" =~ ^ST-.*-ip[-0-9]+$ ]]; then
+  echo "$response" >&2
+  exit 1
+fi
+
+echo "$response"

--- a/scripts/cas/get-tgt
+++ b/scripts/cas/get-tgt
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 0 ] ; then
+  {
+    echo "Get CAS Ticket Granting Ticket (TGT)."
+    echo "Usage: $0"
+    echo "The script requires no parameters. "
+  } >&2
+    exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CAS_USERNAME OPH_CAS_PASSWORD
+
+response=$(curl -s "$OPH_VIRKAILIJA_DOMAIN/cas/v1/tickets" \
+                -d "username=$OPH_CAS_USERNAME" \
+                -d "password=$OPH_CAS_PASSWORD")
+
+tgt=$(echo "$response" | grep -o "TGT-.*-ip[-0-9]\+")
+
+if [ -z "$tgt" ]; then
+  echo "$response" 1>&2
+  exit 1
+fi
+
+echo "$tgt"

--- a/scripts/cas/refresh-session-cookie
+++ b/scripts/cas/refresh-session-cookie
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 0 ] ; then
+  {
+    echo "Get session cookie. This scripts requires no arguments."
+  } >&2
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CAS_USERNAME OPH_CAS_PASSWORD
+
+cookie_path="scripts/session-cookie.txt"
+service_url="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/session/opintopolku"
+
+echo -n "Refreshing session cookie... "
+
+response=$(curl -s -c $cookie_path -G "$service_url" \
+                -H "Accept: application/json" \
+                -d "ticket=$(scripts/cas/get-service-ticket "$service_url")")
+
+if [ -z "$response" ] ; then
+  echo "Success."
+else
+  echo "Failed."
+  echo "$response" >&2
+  exit 1
+fi

--- a/scripts/check-env-vars
+++ b/scripts/check-env-vars
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Checks existence of given environment variables
+for env_var in "$@"; do
+  if [ -z "${!env_var}" ] ; then
+    echo "jee"
+    {
+      echo "For this script to work, you need to have the following environment" \
+           "variables set: $*"
+      echo
+      echo "Note: running script \`scripts/env/activate\` will prompt for your CAS" \
+           "username and password and will automatically set the previously" \
+           "mentioned environment variables."
+    } >&2
+    exit 1
+  fi
+done

--- a/scripts/env/activate
+++ b/scripts/env/activate
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+deactivate () {
+  if [ -n "${_OLD_PS1:-}" ] ; then
+      PS1="${_OLD_PS1:-}"
+      export PS1
+      unset _OLD_PS1
+  fi
+
+  unset OPH_CURRENT_ENV OPH_VIRKAILIJA_DOMAIN OPH_AWS_REGION \
+        OPH_AWS_PROFILE OPH_CAS_USERNAME OPH_CAS_PASSWORD \
+        OPH_CALLER_ID deactivate
+}
+
+printf "Which environment (prod/dev)? "
+read -r env
+
+if [ "$env" != prod ] && [ "$env" != dev ] ; then
+  echo "Not a valid environment: $env"
+  return 1
+fi
+
+echo "Please provide your CAS credentials."
+read -rp "Username: "  OPH_CAS_USERNAME
+read -rsp "Password: " OPH_CAS_PASSWORD
+echo
+
+export OPH_CAS_USERNAME
+export OPH_CAS_PASSWORD
+export OPH_CALLER_ID=$OPH_CAS_USERNAME
+
+case $env in
+  prod) export OPH_VIRKAILIJA_DOMAIN=https://virkailija.opintopolku.fi ;;
+  dev)  export OPH_VIRKAILIJA_DOMAIN=https://virkailija.testiopintopolku.fi ;;
+  *)    return 1
+esac
+
+echo -n "Fetching CAS Ticket Granting Ticket (TGT)... "
+export OPH_CAS_TGT=$(scripts/cas/get-tgt 2>&1)
+
+if [[ $OPH_CAS_TGT =~ ^TGT-.* ]] ; then
+  echo "Success."
+else
+  echo "Failed."
+  echo "$OPH_CAS_TGT" >&2
+  deactivate
+  return 1
+fi
+
+scripts/cas/refresh-session-cookie || { deactivate; return 1; }
+
+export OPH_CURRENT_ENV="$env"
+export OPH_AWS_PROFILE="oph-$env"
+export OPH_AWS_REGION=eu-west-1
+
+_OLD_PS1="${PS1:-}"
+PS1="($env) ${PS1:-}"
+export PS1

--- a/scripts/koski/get-opiskeluoikeus
+++ b/scripts/koski/get-opiskeluoikeus
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "A script for fetching opiskeluoikeus from Koski."
+  echo "Usage: $0 OPISKELUOIKEUS_OID"
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CAS_USERNAME OPH_CAS_PASSWORD
+
+curl -s -X GET "$OPH_VIRKAILIJA_DOMAIN"/koski/api/opiskeluoikeus/"$1" \
+     --user "$OPH_CAS_USERNAME":"$OPH_CAS_PASSWORD"

--- a/scripts/organisaatio/get-name
+++ b/scripts/organisaatio/get-name
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "A script for fetching organization name from Organisaatiopalvelu."
+  echo "Usage: $0 ORGANISAATIO_OID"
+  exit 1
+fi
+
+curl -s -X GET "https://virkailija.opintopolku.fi/organisaatio-service/api/$1/nimet" \
+  -H "accept: application/json"

--- a/scripts/virkailija/create-hoks
+++ b/scripts/virkailija/create-hoks
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+case $# in
+  0) input="-" ;; # Read HOKS JSON from stdin
+  1) input=$1 ;; # Read HOKS JSON from file
+  *)
+    {
+      echo "Usage: $0 [HOKS_FILE]"
+      echo "If HOKS_FILE is not passed in as a positional argument, the script" \
+           "tries to read HOKS JSON string from stdin. OPPIJA_OID is parsed" \
+           "from the JSON."
+    } >&2
+    exit 1
+esac
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CURRENT_ENV OPH_CALLER_ID
+
+hoks=$(cat "$input")
+oppija_oid=$(echo "$hoks" | jq -er '."oppija-oid"')
+
+endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/oppijat/$oppija_oid/hoksit"
+
+if [ "$OPH_CURRENT_ENV" = prod ] || \
+   [ "$OPH_VIRKAILIJA_DOMAIN" = "https://virkailija.opintopolku.fi" ] ; then
+  scripts/ask-confirmation "You're about to CREATE a new HOKS in production" \
+                           "environment."
+fi
+
+curl -s -b scripts/session-cookie.txt -X POST \
+     -H 'Content-Type: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     -d "$hoks" \
+     "$endpoint"

--- a/scripts/virkailija/delete-hoks
+++ b/scripts/virkailija/delete-hoks
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+if [ $# -ne 1 ]; then
+  echo "DELETE /ehoks-virkailija-backend/api/v1/virkailija/hoks/{hoks-id}"
+  echo "Usage: $0 HOKS_ID"
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CALLER_ID
+
+endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/hoks/$1"
+
+scripts/ask-confirmation "You're about to permanently DELETE hoks $1." \
+                         "It cannot be restored after the script execution."
+
+curl -s -b scripts/session-cookie.txt -X DELETE \
+     -H "caller-id: $OPH_CALLER_ID" \
+     "$endpoint"

--- a/scripts/virkailija/get-hoks
+++ b/scripts/virkailija/get-hoks
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 OPPIJA_OID HOKS_ID" >&2
+  exit 1
+fi
+
+endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/oppijat/$1/hoksit/$2"
+
+curl -s -b scripts/session-cookie.txt -X GET \
+     -H 'Accept: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     "$endpoint"

--- a/scripts/virkailija/get-hoks-opiskeluoikeus
+++ b/scripts/virkailija/get-hoks-opiskeluoikeus
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 HOKS_ID" >&2
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CALLER_ID
+
+hoks_endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/hoks/$1"
+
+curl -s -b scripts/session-cookie.txt -X GET \
+     -H 'Accept: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     "$hoks_endpoint" \
+  | grep -o "1.2.246.562.15.[0-9]\+"

--- a/scripts/virkailija/get-hoks-oppija
+++ b/scripts/virkailija/get-hoks-oppija
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 HOKS_ID" >&2
+  exit 1
+fi
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CALLER_ID
+
+hoks_endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/hoks/$1"
+
+curl -s -b scripts/session-cookie.txt -X GET \
+     -H 'Accept: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     "$hoks_endpoint" \
+  | grep -o "1.2.246.562.24.[0-9]\+"

--- a/scripts/virkailija/replace-hoks
+++ b/scripts/virkailija/replace-hoks
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+case $# in
+  0) input="-" ;; # Read HOKS JSON from stdin
+  1) input=$1 ;; # Read HOKS JSON from file
+  *)
+    {
+      echo "Usage: $0 [HOKS_FILE]"
+      echo "If HOKS_FILE is not passed in as a positional argument, the script" \
+           "tries to read HOKS JSON string from stdin. OPPIJA_OID is parsed" \
+           "from the JSON."
+    } >&2
+    exit 1
+esac
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CURRENT_ENV OPH_CALLER_ID
+
+hoks=$(cat "$input")
+hoks_id=$(echo "$hoks" | jq -er '."id"')
+oppija_oid=$(echo "$hoks" | jq -er '."oppija-oid"')
+
+endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/oppijat/$oppija_oid/hoksit/$hoks_id"
+
+if [ "$OPH_CURRENT_ENV" = prod ] || \
+   [ "$OPH_VIRKAILIJA_DOMAIN" = "https://virkailija.opintopolku.fi" ] ; then
+  scripts/ask-confirmation "You're about to REPLACE a HOKS $hoks_id in" \
+                           "production environment."
+fi
+
+curl -s -b scripts/session-cookie.txt -X PUT \
+     -H 'Content-Type: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     -d "$hoks" \
+     "$endpoint"

--- a/scripts/virkailija/update-hoks
+++ b/scripts/virkailija/update-hoks
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+case $# in
+  1) input="-" ;; # Read HOKS update JSON from stdin
+  2) input=$2 ;; # Read HOKS update JSON from file
+  *)
+    {
+      echo "Usage: $0 OPPIJA_OID [HOKS_UPDATE_FILE]"
+      echo "If HOKS_UPDATE_FILE is not passed in as a positional argument," \
+           "the script tries to read HOKS JSON string from stdin. HOKS_ID is" \
+           "parsed from the JSON."
+    } >&2
+    exit 1
+esac
+
+scripts/check-env-vars OPH_VIRKAILIJA_DOMAIN OPH_CURRENT_ENV OPH_CALLER_ID
+
+oppija_oid=$1
+update=$(cat "$input")
+hoks_id=$(echo "$update" | jq -er '."id"')
+
+endpoint="$OPH_VIRKAILIJA_DOMAIN/ehoks-virkailija-backend/api/v1/virkailija/oppijat/$oppija_oid/hoksit/$hoks_id"
+
+if [ "$OPH_CURRENT_ENV" = prod ] || \
+   [ "$OPH_VIRKAILIJA_DOMAIN" = "https://virkailija.opintopolku.fi" ] ; then
+  scripts/ask-confirmation "You're about to UPDATE a HOKS in production" \
+                           "environment."
+fi
+
+curl -s -b scripts/session-cookie.txt -X PATCH \
+     -H 'Content-Type: application/json' \
+     -H "caller-id: $OPH_CALLER_ID" \
+     -d "$update" \
+     "$endpoint"


### PR DESCRIPTION
## Kuvaus muutoksista

Tämän PR:n muutokset ei vaikuta eHOKS-palvelun toiminnallisuuteen.

Lisätty muutama skripti helpottamaan testaamista ja ajoittaista selvitystyötä. Dokumentaatiota käyttöön kirjoittelin `docs/scripts.md`-tiedostoon. Skriptien toimivuus perustuu ympäristömuuttujiin, jotka asetetaan kun sourcetaan skripti `scripts/env/activate`, tyylillä:
```bash
. scripts/env/activate
```
eli toimii aika vastaavaan tapaan kuin Python-virtuaaliympäristöjen aktivointi. Em. skripti pytää käyttäjän virkailija-käyttäjätunnusta ja -salasanaa, hakee automaattisesti CAS Ticket Granting Ticketin (TGT) ja luo session cookien virkailija-rajapinnan käyttöä varten. Näin ollen, hakemiston `scripts/virkailija`-skriptit ovat valmiina käyttöä varten, TGT:n ja session cookien ollessa pitkän aikaa voimassa. Pari skriptiä lisäsin myös opiskeluoikeuksien ja organisaatioiden nimien hakemiseen.

`activate`-skriptin asettamat ympäristömuuttujat voi siivota ajamalla
```bash
deactivate
```

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
