### PR TITLE
More strict validation for different OID classes

### DIFF
--- a/src/oph/ehoks/hoks/vipunen_schema.clj
+++ b/src/oph/ehoks/hoks/vipunen_schema.clj
@@ -1,7 +1,10 @@
 (ns oph.ehoks.hoks.vipunen-schema
   (:require [schema.core :as s]
             [oph.ehoks.schema-tools :refer [describe modify]]
-            [oph.ehoks.schema.generator :as g])
+            [oph.ehoks.schema.generator :as g]
+            [oph.ehoks.schema.oid :refer [OpiskeluoikeusOID
+                                          OppijaOID
+                                          OrganisaatioOID]])
   (:import (java.time LocalDate)
            (java.util UUID)))
 
@@ -36,14 +39,6 @@
 (def KoulutuksenOsaKoodiUri
   "Koulutuksen osan (TUVA) koodi-URI:n regex."
   #"^koulutuksenosattuva_\d{3}$")
-
-(def Oid
-  "OID:n regex."
-  #"^1\.2\.246\.562\.[0-3]\d\.\d+$")
-
-(def OpiskeluoikeusOid
-  "Opiskeluoikeuden OID:n regex."
-  #"^1\.2\.246\.562\.15\.\d+$")
 
 (s/defschema
   KoodistoKoodi
@@ -80,7 +75,7 @@
      :added
      (describe
        ""
-       (s/optional-key :oppilaitos-oid) Oid
+       (s/optional-key :oppilaitos-oid) OrganisaatioOID
        "Mikäli kyseessä oppilaitos, oppilaitoksen oid-tunniste
        Opintopolku-palvelussa.")}))
 
@@ -199,7 +194,7 @@
   (describe
     "Näytön tai osaamisen osoittamisen järjestäjä"
     (s/optional-key :id) s/Int "Tunniste eHOKS-järjestelmässä"
-    (s/optional-key :oppilaitos-oid) Oid
+    (s/optional-key :oppilaitos-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid-numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")))
@@ -365,7 +360,7 @@
     (s/optional-key :osaamisen-osoittaminen)
     [OsaamisenOsoittaminen]
     "Hankitun osaamisen osoittaminen: Näyttö tai muu osaamisen osoittaminen"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")
@@ -409,7 +404,7 @@
     "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"
     :osa-alue-koodi-versio s/Int
     "Osa-alueen Koodisto-koodi-URIn versio (ammatillisenoppiaineet)"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")
@@ -445,7 +440,7 @@
     "Osa-alueen Koodisto-koodi-URI (ammatillisenoppiaineet)"
     :osa-alue-koodi-versio s/Int
     "Osa-alueen Koodisto-koodi-URIn versio (ammatillisenoppiaineet)"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")
@@ -501,7 +496,7 @@
     :tutkinnon-osa-koodi-versio s/Int
     "Tutkinnon osan Koodisto-koodi-URIn versio ePerusteet-palvelussa
      (tutkinnonosat)"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")))
@@ -537,7 +532,7 @@
     "Hankitun osaamisen osoittaminen: Näyttö tai muu osaamisen osoittaminen"
     (s/optional-key :osaamisen-hankkimistavat) [OsaamisenHankkimistapaVipunen]
     "Osaamisen hankkimistavat"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")
@@ -588,7 +583,7 @@
     "vaatimuksista tai osaamistavoitteista poikkeaminen"
     (s/optional-key :osaamisen-hankkimistavat) [OsaamisenHankkimistapaVipunen]
     "Osaamisen hankkimistavat"
-    (s/optional-key :koulutuksen-jarjestaja-oid) Oid
+    (s/optional-key :koulutuksen-jarjestaja-oid) OrganisaatioOID
     (str "Organisaation tunniste Opintopolku-palvelussa. Oid numero, joka on "
          "kaikilla organisaatiotasoilla: toimipisteen oid, koulun oid, "
          "koulutuksen järjestäjän oid.")
@@ -844,17 +839,17 @@
             eHOKS-järjestelmässä"}
    :oppija-oid {:methods {:any :optional
                           :post :required}
-                :types {:any Oid}
+                :types {:any OppijaOID}
                 :description "Oppijan tunniste Opintopolku-ympäristössä"}
    :opiskeluoikeus-oid
    {:methods {:any :optional
               :post :required}
-    :types {:any OpiskeluoikeusOid}
+    :types {:any OpiskeluoikeusOID}
     :description "Opiskeluoikeuden oid-tunniste Koski-järjestelmässä muotoa
                   '1.2.246.562.15.00000000001'."}
    :tuva-opiskeluoikeus-oid
    {:methods {:any :optional}
-    :types {:any OpiskeluoikeusOid}
+    :types {:any OpiskeluoikeusOID}
     :description "TUVA-opiskeluoikeuden oid-tunniste Koski-järjestelmässä muotoa
                   '1.2.246.562.15.00000000001'."}
    :urasuunnitelma-koodi-uri

--- a/src/oph/ehoks/schema/oid.clj
+++ b/src/oph/ehoks/schema/oid.clj
@@ -1,0 +1,86 @@
+(ns oph.ehoks.schema.oid
+  "Skeemamääritykset erityyppisille OID:eille"
+  (:require [clojure.string :as str]
+            [schema.core :refer [constrained defschema]]))
+
+;;;; Opetushallitukselle on myönnetty koulutustoimialan OID-solmuluokka:
+;;;; 1.2.246.562.NN.XXXXXXXXXXY, missä NN vaihtelee käyttötarkoituksen
+;;;; mukaan (esim. 15 = opiskeluoikeus, 10 = organisaatio, jne.) ja
+;;;; loppuosa XXXXXXXXXX on satunnaisgeneroitu luku välillä
+;;;; 1 000 000 000 - 9 999 999 999 (OID:in loppuosa ei siis koskaan ala
+;;;; nollalla) ja Y on XXXXXXXXXX osasta laskettu tarkistussumma.
+;;;;
+;;;; NOTE: Apparently there has been a bug in OID Generator earlier, so that it
+;;;; has generated OIDs that have 12 digits in the last component instead of 11
+;;;; and 10 instead of 0 as a last digit. These kinds of OIDs still exist today,
+;;;; so we need to take this into account in validation.
+
+(defn- luhn-checksum
+  "Takes a sequence of `digits` and returns a checksum which is calculated using
+  Luhn algorithm. The same algortihm used in OIDGenerator.java class in
+  `Opetushallitus/java-utils` repository and is replicated here."
+  [digits]
+  (loop [remaining (reverse digits)
+         alternate true
+         sum       0]
+    (if-let [digit (first remaining)]
+      (recur (rest remaining)
+             (not alternate)
+             (+ sum
+                (if alternate
+                  (let [n (* digit 2)]
+                    (if (> n 9)
+                      (inc (mod n 10))
+                      n))
+                  digit)))
+      (mod (- 10 (mod sum 10)) 10))))
+
+(defn- ibm-1-3-7-checksum
+  "Takes a sequence of `digits` and returns a checksum which is calculated using
+  IBM 1-3-7 algorithm. The same algortihm is used in OIDGenerator.java class in
+  `Opetushallitus/java-utils` repository and is replicated here."
+  [digits]
+  (loop [remaining   (reverse digits)
+         multipliers (cycle [7 3 1])
+         sum         0]
+    (if-let [digit (first remaining)]
+      (recur (rest remaining)
+             (rest multipliers)
+             (+ sum (* digit (first multipliers))))
+      (mod (- 10 (mod sum 10)) 10))))
+
+(defn- valid-oid?
+  "Takes an `oid` and returns `true` if it's valid. For the last component of
+  the OID, a checksum is calculated and checked that it matches the last digit.
+  IBM 1-3-7 checksum algorithm is used for henkilo/oppija (node 24) OIDs and
+  Luhn algorithm for everyting else.
+
+  NOTE: This function expects that validity checks against an OID regexp pattern
+  have been made for `oid` before calling this function!"
+  [oid]
+  (let [splitted-oid                 (str/split oid #"\.")
+        node                         (nth splitted-oid 4)
+        [first-10-digits last-digit] (split-at 10 (nth splitted-oid 5))
+        first-10-digits              (map #(Character/getNumericValue %)
+                                          first-10-digits)
+        ; Apparently there has been a bug in OID Generator earlier, so that it
+        ; has generated OIDs that have 12 digits in the last component instead
+        ; of 11 and 10 instead of 0 as a last digit. These kinds of OIDs still
+        ; exist today, so we need to take this into account in validation:
+        last-digit                   (if (> (count last-digit) 1)
+                                       0
+                                       (Character/getNumericValue
+                                         (first last-digit)))]
+    (= last-digit
+       (if (= node "24")
+         (ibm-1-3-7-checksum first-10-digits) ; Only used for oppija OIDs.
+         (luhn-checksum first-10-digits)))))
+
+(defschema OpiskeluoikeusOID
+           (constrained #"^1\.2\.246\.562\.15\.[1-9]\d{9}(\d|10)$" valid-oid?))
+
+(defschema OppijaOID
+           (constrained #"^1\.2\.246\.562\.24\.[1-9]\d{9}(\d|10)$" valid-oid?))
+
+(defschema OrganisaatioOID
+           (constrained #"^1\.2\.246\.562\.10\.[1-9]\d{9}(\d|10)$" valid-oid?))

--- a/src/oph/ehoks/schema/oid.clj
+++ b/src/oph/ehoks/schema/oid.clj
@@ -1,7 +1,7 @@
 (ns oph.ehoks.schema.oid
   "Skeemamääritykset erityyppisille OID:eille"
   (:require [clojure.string :as str]
-            [schema.core :refer [constrained defschema]]))
+            [schema.core :refer [cond-pre constrained defschema]]))
 
 ;;;; Opetushallitukselle on myönnetty koulutustoimialan OID-solmuluokka:
 ;;;; 1.2.246.562.NN.XXXXXXXXXXY, missä NN vaihtelee käyttötarkoituksen
@@ -82,5 +82,12 @@
 (defschema OppijaOID
            (constrained #"^1\.2\.246\.562\.24\.[1-9]\d{9}(\d|10)$" valid-oid?))
 
+; There are a few organisaatio OIDs where the check digit doesn't match with the
+; calculated Luhn checksum. This is why we don't do check digit check in case of
+; organisaatio OIDs.
+(def OrganisaatioOID' #"^1\.2\.246\.562\.10\.([1-9]\d{9}(\d|10)|0{10}1)$")
+; The following types of OIDs were generated in 2013-2014
+(def OrganisaatioOIDWithTimestamp #"^1\.2\.246\.562\.10\.201[34]\d{18}$")
+
 (defschema OrganisaatioOID
-           (constrained #"^1\.2\.246\.562\.10\.[1-9]\d{9}(\d|10)$" valid-oid?))
+           (cond-pre OrganisaatioOID' OrganisaatioOIDWithTimestamp))

--- a/test/oph/ehoks/db/opiskelijan_yhteystiedot_test.clj
+++ b/test/oph/ehoks/db/opiskelijan_yhteystiedot_test.clj
@@ -43,8 +43,8 @@
     :osaamisen-osoittaminen []}])
 
 (def simple-hoks-data
-  {:opiskeluoikeus-oid          "1.2.246.562.15.00000000001"
-   :oppija-oid                  "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid          "1.2.246.562.15.10000000009"
+   :oppija-oid                  "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen  (java.time.LocalDate/of 2022 7 1)
    :osaamisen-hankkimisen-tarve true
    :osaamisen-saavuttamisen-pvm (java.time.LocalDate/of 2022 9 1)
@@ -52,8 +52,8 @@
    :puhelinnumero               "0401234567"})
 
 (def full-hoks-data
-  {:opiskeluoikeus-oid          "1.2.246.562.15.00000000002"
-   :oppija-oid                  "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid          "1.2.246.562.15.20000000008"
+   :oppija-oid                  "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen  (java.time.LocalDate/of 2022 7 1)
    :osaamisen-hankkimisen-tarve true
    :sahkoposti                  "erkki.esimerkki@esimerkki.com"
@@ -61,8 +61,8 @@
    :hankittavat-paikalliset-tutkinnon-osat hpto-data})
 
 (def recent-hoks-data
-  {:opiskeluoikeus-oid          "1.2.246.562.15.00000000003"
-   :oppija-oid                  "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid          "1.2.246.562.15.30000000007"
+   :oppija-oid                  "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen  (java.time.LocalDate/of 2022 7 1)
    :osaamisen-saavuttamisen-pvm (.minusDays (java.time.LocalDate/now) 10)
    :osaamisen-hankkimisen-tarve true

--- a/test/oph/ehoks/db/tyopaikkaohjaajan_yhteystiedot_test.clj
+++ b/test/oph/ehoks/db/tyopaikkaohjaajan_yhteystiedot_test.clj
@@ -67,8 +67,8 @@
       :yksiloiva-tunniste "abcd"}]
     :osaamisen-osoittaminen []}])
 
-(def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                :oppija-oid "1.2.246.562.24.12312312312"
+(def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                :oppija-oid "1.2.246.562.24.12312312319"
                 :ensikertainen-hyvaksyminen (java.time.LocalDate/of 2022 7 1)
                 :osaamisen-hankkimisen-tarve true
                 :sahkoposti "erkki.esimerkki@esimerkki.com"

--- a/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
+++ b/test/oph/ehoks/external/oppijanumerorekisteri_test.clj
@@ -30,7 +30,7 @@
                :contact [{:value "kayttaja@domain.local"
                           :type "YHTEYSTIETO_SAHKOPOSTI"}]})}))))
 
-(def student-info {:oppijanumero "1.2.246.562.24.62444477777",
+(def student-info {:oppijanumero "1.2.246.562.24.62444477771",
                    :etunimet "Pauliina Joku",
                    :asiointiKieli {:kieliKoodi "fi", :kieliTyyppi "suomi"},
                    :syntymaaika "1975-04-20",
@@ -38,7 +38,7 @@
                    :sukunimi "Pouta",
                    :kansalaisuus [{:kansalaisuusKoodi "246"}],
                    :hetu "200475-0000",
-                   :oidHenkilo "1.2.246.562.24.62444477777",
+                   :oidHenkilo "1.2.246.562.24.62444477771",
                    :kutsumanimi "Pauliina",
                    :yhteystiedotRyhma
                    [{:id 118888872,
@@ -75,7 +75,7 @@
                       {:yhteystietoTyyppi "YHTEYSTIETO_PUHELINNUMERO",
                        :yhteystietoArvo nil}]}]})
 
-(def converted-student-info {:oid "1.2.246.562.24.62444477777"
+(def converted-student-info {:oid "1.2.246.562.24.62444477771"
                              :first-name "Pauliina Joku"
                              :surname "Pouta"
                              :common-name "Pauliina"
@@ -104,10 +104,10 @@
 (deftest convert-all-nil-contact-info
   (testing "contact group containg only nil contact values should be pruned"
     (is (= (onr/convert-student-info
-             {:oppijanumero "1.2.246.562.24.62444477777",
+             {:oppijanumero "1.2.246.562.24.62444477771",
               :etunimet "Pauliina Joku",
               :sukunimi "Pouta",
-              :oidHenkilo "1.2.246.562.24.62444477777",
+              :oidHenkilo "1.2.246.562.24.62444477771",
               :kutsumanimi "Pauliina",
               :yhteystiedotRyhma
               [{:id 118888872,
@@ -123,7 +123,7 @@
                                :yhteystietoArvo nil}
                               {:yhteystietoTyyppi "YHTEYSTIETO_PUHELINNUMERO",
                                :yhteystietoArvo nil}]}]})
-           {:oid "1.2.246.562.24.62444477777"
+           {:oid "1.2.246.562.24.62444477771"
             :first-name "Pauliina Joku"
             :surname "Pouta"
             :common-name "Pauliina"

--- a/test/oph/ehoks/heratepalvelu/herate_handler_test.clj
+++ b/test/oph/ehoks/heratepalvelu/herate_handler_test.clj
@@ -1,8 +1,6 @@
 (ns oph.ehoks.heratepalvelu.herate-handler-test
   (:require [clj-time.core :as t]
             [clojure.test :refer [deftest testing is use-fixtures]]
-            [oph.ehoks.external.aws-sqs :as sqs]
-            [oph.ehoks.external.koski :as k]
             [oph.ehoks.hoks.hoks-test-utils :as hoks-utils]
             [oph.ehoks.utils :as utils]
             [ring.mock.request :as mock]))
@@ -14,8 +12,8 @@
 
 (deftest get-kasittelemattomat-heratteet
   (testing "GET /heratepalvelu/kasittelemattomat-heratteet"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen (str (t/today))
                      :osaamisen-saavuttamisen-pvm (str (t/today))

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -32,8 +32,8 @@
 
 (deftest get-created-hoks
   (testing "GET newly created HOKS"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           response
@@ -53,9 +53,9 @@
 
 (deftest get-created-hoks-with-tuva-oo
   (testing "GET newly created HOKS with TUVA opiskeluoikeus oid"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :tuva-opiskeluoikeus-oid "1.2.246.562.15.00000000002"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :tuva-opiskeluoikeus-oid "1.2.246.562.15.20000000008"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           response
@@ -75,9 +75,9 @@
 
 (deftest tuva-oo-oid-is-validated
   (testing "TUVA opiskeluoikeus oid form is validated as oid"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
                      :tuva-opiskeluoikeus-oid "foo"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           response
@@ -91,8 +91,8 @@
 
 (deftest get-last-version-of-hoks
   (testing "GET latest (second) version of HOKS"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}]
       (let [response
@@ -120,8 +120,8 @@
                     (fn [_] (swap! sqs-call-counter inc))
                     oph.ehoks.external.koski/get-opiskeluoikeus-info
                     (fn [_] {:tyyppi {:koodiarvo "tuva"}})]
-        (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000003"
-                         :oppija-oid "1.2.246.562.24.12312312312"
+        (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.30000000007"
+                         :oppija-oid "1.2.246.562.24.12312312319"
                          :ensikertainen-hyvaksyminen "2018-12-15"
                          :osaamisen-hankkimisen-tarve true
                          :hankittavat-koulutuksen-osat
@@ -259,8 +259,8 @@
 (deftest osaamisen-hankkimistavat-isnt-mandatory
   (testing "Osaamisen hankkimistavat should be optional field in ehoks"
     (let [app (hoks-utils/create-app nil)
-          hoks {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                :oppija-oid "1.2.246.562.24.12312312312"
+          hoks {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                :oppija-oid "1.2.246.562.24.12312312319"
                 :ensikertainen-hyvaksyminen "2018-12-15"
                 :osaamisen-hankkimisen-tarve false
                 :hankittavat-ammat-tutkinnon-osat
@@ -586,9 +586,9 @@
 
 (deftest get-hoks-by-opiskeluoikeus-oid
   (testing "GET HOKS by opiskeluoikeus-oid"
-    (let [opiskeluoikeus-oid "1.2.246.562.15.00000000001"
+    (let [opiskeluoikeus-oid "1.2.246.562.15.10000000009"
           hoks-data {:opiskeluoikeus-oid opiskeluoikeus-oid
-                     :oppija-oid "1.2.246.562.24.12312312312"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}
           app (hoks-utils/create-app nil)]
@@ -616,7 +616,7 @@
     (client/with-mock-responses
       [(fn [url options]
          (cond (.endsWith
-                 url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000001")
+                 url "/koski/api/opiskeluoikeus/1.2.246.562.15.10000000009")
                {:status 200
                 :body {:oppilaitos {:oid "1.2.246.562.10.12944436166"}}}
                (.endsWith url "/serviceValidate")
@@ -650,8 +650,8 @@
            {:status 200
             :body "ST-1234-testi"}))]
       (let [app (hoks-utils/create-app nil)
-            hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                       :oppija-oid "1.2.246.562.24.12312312312"
+            hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                       :oppija-oid "1.2.246.562.24.12312312319"
                        :laatija {:nimi "Teppo Tekijä"}
                        :paivittaja {:nimi "Pekka Päivittäjä"}
                        :hyvaksyja {:nimi "Heikki Hyväksyjä"}
@@ -666,8 +666,8 @@
                {:error "User type 'PALVELU' is required"}))))))
 
 (deftest post-kyselylinkki
-  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                   :oppija-oid "1.2.246.562.24.12312312312"
+  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                   :oppija-oid "1.2.246.562.24.12312312319"
                    :osaamisen-hankkimisen-tarve true
                    :ensikertainen-hyvaksyminen "2018-12-15"}
         app (hoks-utils/create-app nil)
@@ -688,11 +688,11 @@
 
     (is (= "https://palaute.fi/abc123"
            (:kyselylinkki (first (h/get-kyselylinkit-by-oppija-oid
-                                   "1.2.246.562.24.12312312312")))))))
+                                   "1.2.246.562.24.12312312319")))))))
 
 (deftest put-kyselylinkki-lahetysdata
-  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                   :oppija-oid "1.2.246.562.24.12312312312"
+  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                   :oppija-oid "1.2.246.562.24.12312312319"
                    :osaamisen-hankkimisen-tarve true
                    :ensikertainen-hyvaksyminen "2018-12-15"}
         app (hoks-utils/create-app nil)
@@ -719,7 +719,7 @@
       "1.2.246.562.10.00000000001")
 
     (is (nil? (:sahkoposti (first (h/get-kyselylinkit-by-oppija-oid
-                                    "1.2.246.562.24.12312312312")))))
+                                    "1.2.246.562.24.12312312319")))))
 
     (utils/with-service-ticket
       app
@@ -728,15 +728,15 @@
 
     (is (= "testi@testi.fi"
            (:sahkoposti (first (h/get-kyselylinkit-by-oppija-oid
-                                 "1.2.246.562.24.12312312312")))))
+                                 "1.2.246.562.24.12312312319")))))
     (is (= "viestintapalvelussa"
            (:lahetystila (first (h/get-kyselylinkit-by-oppija-oid
-                                  "1.2.246.562.24.12312312312")))))))
+                                  "1.2.246.562.24.12312312319")))))))
 
 (deftest get-paged-vipunen-data
   (testing "GET paged HOKSes for Vipunen"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           app (hoks-utils/create-app nil)
@@ -762,8 +762,8 @@
 
 (deftest get-paged-deleted
   (testing "GET paged HOKSes with deleted item"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           app (hoks-utils/create-app nil)
@@ -808,8 +808,8 @@
 
 (deftest get-paged-delta-with-deleted
   (testing "GET paged delta stream of HOKSes"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :osaamisen-hankkimisen-tarve true
                      :ensikertainen-hyvaksyminen "2018-12-15"}
           app (hoks-utils/create-app nil)
@@ -871,8 +871,8 @@
 (deftest no-internal-server-error-in-response-validation-failure
   (testing (str "Response validation failure shouldn't give "
                 "`internal-server-error` in response")
-    (let [hoks {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                :oppija-oid "1.2.246.562.24.12312312319"
                 :osaamisen-hankkimisen-tarve true
                 :ensikertainen-hyvaksyminen "2018-12-15"}
           hato {:tutkinnon-osa-koodi-uri "tutkinnonosat_300268"
@@ -881,7 +881,7 @@
                 "Ei poikkeamia."
                 :opetus-ja-ohjaus-maara 10.1
                 :osaamisen-osoittaminen
-                [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+                [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924331"}
                   :nayttoymparisto {:nimi "Testiympäristö"
                                     :y-tunnus "invalid"
                                     :kuvaus "Testi test"}
@@ -953,7 +953,7 @@
           data
           (assoc test-data/hoks-data
                  :opiskeluoikeus-oid
-                 "1.2.246.562.15.00000000006")
+                 "1.2.246.562.15.60000000004")
           post-response
           (hoks-utils/create-mock-post-request "" data app)]
       (is (= (:status post-response) 200)))))

--- a/test/oph/ehoks/hoks/hoks_parts/hankittavat_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_parts/hankittavat_handler_test.clj
@@ -88,7 +88,7 @@
                                      parts-test-data/hyto-data) :id 1)})))))
 
 (def ^:private one-value-of-hyto-patched
-  {:koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000012"})
+  {:koulutuksen-jarjestaja-oid "1.2.246.562.10.10000000017"})
 
 (deftest patch-one-value-of-hankittava-yhteinen-tutkinnon-osa
   (testing "PATCH one value hankittavat yhteisen tutkinnon osat"

--- a/test/oph/ehoks/hoks/hoks_parts/parts_test_data.clj
+++ b/test/oph/ehoks/hoks/hoks_parts/parts_test_data.clj
@@ -28,10 +28,10 @@
                  :hankkijan-edustaja
                  {:nimi "Heikki Hankkija"
                   :rooli "Opettaja"
-                  :oppilaitos-oid "1.2.246.562.10.54452422420"}}]
-               :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000005"
+                  :oppilaitos-oid "1.2.246.562.10.54452422428"}}]
+               :koulutuksen-jarjestaja-oid "1.2.246.562.10.50000000005"
                :osaamisen-osoittaminen
-               [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+               [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924331"}
                  :nayttoymparisto {:nimi "Testiympäristö 2"
                                    :y-tunnus "1234567-1"
                                    :kuvaus "Testi test"}
@@ -39,7 +39,7 @@
                  :koulutuksen-jarjestaja-osaamisen-arvioijat
                  [{:nimi "Timo Testaaja"
                    :organisaatio {:oppilaitos-oid
-                                  "1.2.246.562.10.54452521332"}}]
+                                  "1.2.246.562.10.54452521336"}}]
                  :tyoelama-osaamisen-arvioijat
                  [{:nimi "Taneli Työmies"
                    :organisaatio {:nimi "Tanelin Paja Ky"
@@ -74,7 +74,7 @@
      :hankkijan-edustaja
      {:nimi "Heikki Hankkija"
       :rooli "Opettaja"
-      :oppilaitos-oid "1.2.246.562.10.54452422420"}
+      :oppilaitos-oid "1.2.246.562.10.54452422428"}
      :tyopaikalla-jarjestettava-koulutus
      {:vastuullinen-tyopaikka-ohjaaja
       {:nimi "Oiva Ohjaaja"
@@ -82,9 +82,9 @@
       :tyopaikan-nimi "Ohjaus Oyk"
       :tyopaikan-y-tunnus "5523718-7"
       :keskeiset-tyotehtavat ["Testitehtävä2"]}}]
-   :koulutuksen-jarjestaja-oid               "1.2.246.562.10.00000000005"
+   :koulutuksen-jarjestaja-oid               "1.2.246.562.10.50000000005"
    :osaamisen-osoittaminen
-   [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+   [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924331"}
      :nayttoymparisto {:nimi "Testiympäristö 2"
                        :y-tunnus "5523718-7"
                        :kuvaus "Testi test"}
@@ -92,7 +92,7 @@
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Timo Testaaja"
        :organisaatio {:oppilaitos-oid
-                      "1.2.246.562.10.54452521332"}}]
+                      "1.2.246.562.10.54452521336"}}]
      :tyoelama-osaamisen-arvioijat
      [{:nimi "Taneli Työmies"
        :organisaatio {:nimi "Tanelin Paja Ky"
@@ -121,7 +121,7 @@
      :hankkijan-edustaja
      {:nimi "Heikki Hankkija"
       :rooli "Opettaja"
-      :oppilaitos-oid "1.2.246.562.10.54452422420"}
+      :oppilaitos-oid "1.2.246.562.10.54452422428"}
      :tyopaikalla-jarjestettava-koulutus
      {:vastuullinen-tyopaikka-ohjaaja
       {:nimi "Oiva Ohjaaja"
@@ -139,8 +139,8 @@
      :hankkijan-edustaja
      {:nimi "Heikki Hankkija"
       :rooli "Opettaja"
-      :oppilaitos-oid "1.2.246.562.10.54452422420"}}]
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000005"})
+      :oppilaitos-oid "1.2.246.562.10.54452422428"}}]
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.50000000005"})
 
 (def hao-data-without-osa-aikaisuus
   {:tutkinnon-osa-koodi-uri "tutkinnonosat_300268"
@@ -159,7 +159,7 @@
      :hankkijan-edustaja
      {:nimi "Heikki Hankkija"
       :rooli "Opettaja"
-      :oppilaitos-oid "1.2.246.562.10.54452422420"}
+      :oppilaitos-oid "1.2.246.562.10.54452422428"}
      :tyopaikalla-jarjestettava-koulutus
      {:vastuullinen-tyopaikka-ohjaaja
       {:nimi "Oiva Ohjaaja"
@@ -167,7 +167,7 @@
       :tyopaikan-nimi "Ohjaus Oyk"
       :tyopaikan-y-tunnus "5523718-7"
       :keskeiset-tyotehtavat ["Testitehtävä2"]}}]
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000005"})
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.50000000005"})
 
 (def patch-all-hao-data
   (merge
@@ -179,7 +179,7 @@
      [{:jarjestajan-edustaja
        {:nimi "Veikko Valvoja"
         :rooli "Valvoja"
-        :oppilaitos-oid "1.2.246.562.10.54451211340"}
+        :oppilaitos-oid "1.2.246.562.10.54451211343"}
        :osaamisen-hankkimistapa-koodi-uri
        "osaamisenhankkimistapa_oppisopimus"
        :osaamisen-hankkimistapa-koodi-versio 2
@@ -199,20 +199,20 @@
        :hankkijan-edustaja
        {:nimi "Harri Hankkija"
         :rooli "Opettajan sijainen"
-        :oppilaitos-oid "1.2.246.562.10.55552422420"}
+        :oppilaitos-oid "1.2.246.562.10.55552422424"}
        :alku "2022-01-12"
        :loppu "2022-02-11"
        :yksiloiva-tunniste "jk;l"}]
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000116"}))
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.10000000116"}))
 
 (def hpto-data {:nimi "222"
                 :osaamisen-hankkimistavat []
-                :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000001"
+                :koulutuksen-jarjestaja-oid "1.2.246.562.10.10000000009"
                 :olennainen-seikka true
                 :opetus-ja-ohjaus-maara 16.0
                 :osaamisen-osoittaminen
                 [{:jarjestaja {:oppilaitos-oid
-                               "1.2.246.562.10.00000000002"}
+                               "1.2.246.562.10.20000000008"}
                   :koulutuksen-jarjestaja-osaamisen-arvioijat []
                   :osa-alueet []
                   :sisallon-kuvaus ["ensimmäinen sisältö" "toinenkin"]
@@ -228,7 +228,7 @@
 (def hyto-data
   {:tutkinnon-osa-koodi-uri "tutkinnonosat_3002683"
    :tutkinnon-osa-koodi-versio 1
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000007"
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.70000000003"
    :osa-alueet
    [{:osa-alue-koodi-uri "ammatillisenoppiaineet_ku"
      :osa-alue-koodi-versio 1
@@ -251,14 +251,14 @@
          :loppu "2021-03-19"}]
        :keskeytymisajanjaksot []}]
      :osaamisen-osoittaminen
-     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.00000000002"}
+     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.20000000008"}
        :nayttoymparisto {:nimi "aaa"}
        :osa-alueet [{:koodi-uri "ammatillisenoppiaineet_en"
                      :koodi-versio 4}]
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Erkki Esimerkkitetsaaja"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.13490579333"}}]
+                        "1.2.246.562.10.13490579334"}}]
        :alku "2018-12-12"
        :loppu "2018-12-20"
        :sisallon-kuvaus ["Kuvaus"]
@@ -269,7 +269,7 @@
 (def hyto-data-wo-osa-aikaisuus
   {:tutkinnon-osa-koodi-uri "tutkinnonosat_3002683"
    :tutkinnon-osa-koodi-versio 1
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000007"
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.70000000003"
    :osa-alueet
    [{:osa-alue-koodi-uri "ammatillisenoppiaineet_ku"
      :osa-alue-koodi-versio 1
@@ -297,14 +297,14 @@
         :vastuullinen-tyopaikka-ohjaaja
         {:nimi "ohjaaja o"}}}]
      :osaamisen-osoittaminen
-     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.00000000002"}
+     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.20000000008"}
        :nayttoymparisto {:nimi "aaa"}
        :osa-alueet [{:koodi-uri "ammatillisenoppiaineet_en"
                      :koodi-versio 4}]
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Erkki Esimerkkitetsaaja"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.13490579333"}}]
+                        "1.2.246.562.10.13490579334"}}]
        :alku "2018-12-12"
        :loppu "2018-12-20"
        :sisallon-kuvaus ["Kuvaus"]
@@ -324,21 +324,21 @@
    :tutkinnon-osa-koodi-versio 100022
    :valittu-todentamisen-prosessi-koodi-uri "osaamisentodentamisenprosessi_3"
    :tutkinnon-osa-koodi-uri "tutkinnonosat_100022"
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921419"
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921410"
    :tarkentavat-tiedot-osaamisen-arvioija
    {:lahetetty-arvioitavaksi "2019-03-18"
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Erkki Esimerkki"
-      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921623"}}
+      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921626"}}
      {:nimi "Joku Tyyppi"
-      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921000"}}]}
+      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921006"}}]}
    :tarkentavat-tiedot-naytto
    [{:osa-alueet [{:koodi-uri "ammatillisenoppiaineet_fy"
                    :koodi-versio 1}]
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Aapo Arvioija"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921674"}}]
-     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921685"}
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921675"}}]
+     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921683"}
      :nayttoymparisto {:nimi "Toinen Esimerkki Oyj"
                        :y-tunnus "1234566-3"
                        :kuvaus "Testiyrityksen testiosasostalla"}
@@ -365,16 +365,16 @@
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Aarne Arvioija"
       :organisaatio {:oppilaitos-oid
-                     "1.2.246.562.10.54453923411"}}]}
+                     "1.2.246.562.10.54453923416"}}]}
    :tarkentavat-tiedot-naytto
    [{:osa-alueet [{:koodi-uri "ammatillisenoppiaineet_li"
                    :koodi-versio 6}]
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Teuvo Testaaja"
        :organisaatio {:oppilaitos-oid
-                      "1.2.246.562.10.12346234690"}}]
+                      "1.2.246.562.10.12346234698"}}]
      :jarjestaja {:oppilaitos-oid
-                  "1.2.246.562.10.93270534262"}
+                  "1.2.246.562.10.93270534261"}
 
      :nayttoymparisto {:nimi "Testi Oyj"
                        :y-tunnus "1289211-4"
@@ -388,7 +388,7 @@
      :alku "2019-02-01"
      :loppu "2019-03-01"
      :yksilolliset-kriteerit ["Ensimmäinen kriteeri"]}]
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945322"
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945328"
    :vaatimuksista-tai-tavoitteista-poikkeaminen "Ei poikkeamaa."})
 
 (def tarkentavat-tiedot-osaamisen-arvioija
@@ -396,7 +396,7 @@
    :aiemmin-hankitun-osaamisen-arvioijat
    [{:nimi "Uusi Ominaisuus"
      :organisaatio {:oppilaitos-oid
-                    "1.2.246.562.10.54453931322"}}]})
+                    "1.2.246.562.10.54453931328"}}]})
 
 (def ahyto-data
   {:valittu-todentamisen-prosessi-koodi-uri
@@ -409,12 +409,12 @@
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Arttu Arvioija"
       :organisaatio {:oppilaitos-oid
-                     "1.2.246.562.10.54453931311"}}]}
+                     "1.2.246.562.10.54453931310"}}]}
    :osa-alueet
    [{:osa-alue-koodi-uri "ammatillisenoppiaineet_bi"
      :osa-alue-koodi-versio 4
      :koulutuksen-jarjestaja-oid
-     "1.2.246.562.10.54453923578"
+     "1.2.246.562.10.54453923572"
      :vaatimuksista-tai-tavoitteista-poikkeaminen
      "Testaus ei kuulu vaatimuksiin."
      :valittu-todentamisen-prosessi-koodi-uri
@@ -429,9 +429,9 @@
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Teppo Testaaja"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.54539267901"}}]
+                        "1.2.246.562.10.54539267903"}}]
        :jarjestaja {:oppilaitos-oid
-                    "1.2.246.562.10.55890967901"}
+                    "1.2.246.562.10.55890967908"}
 
        :nayttoymparisto {:nimi "Ab Yhtiö Oy"
                          :y-tunnus "1234128-3"
@@ -450,9 +450,9 @@
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Erkki Esimerkkitestaaja"
        :organisaatio {:oppilaitos-oid
-                      "1.2.246.562.10.13490579090"}}]
+                      "1.2.246.562.10.13490579094"}}]
      :jarjestaja {:oppilaitos-oid
-                  "1.2.246.562.10.93270579090"}
+                  "1.2.246.562.10.93270579092"}
      :nayttoymparisto {:nimi "Testi Oy"
                        :y-tunnus "1234567-1"
                        :kuvaus "Testiyhtiö"}
@@ -476,18 +476,18 @@
      :valittu-todentamisen-prosessi-koodi-versio 4
      :tutkinnon-osa-koodi-versio 2
      :tutkinnon-osa-koodi-uri "tutkinnonosat_10203"
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.13490590921"
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.13490590927"
      :tarkentavat-tiedot-osaamisen-arvioija
      {:lahetetty-arvioitavaksi "2017-03-29"
       :aiemmin-hankitun-osaamisen-arvioijat
       [{:nimi "Arttu Arvioi"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.54453931312"}}]}
+                       "1.2.246.562.10.54453931310"}}]}
      :osa-alueet
      [{:osa-alue-koodi-uri "ammatillisenoppiaineet_ru"
        :osa-alue-koodi-versio 4
        :koulutuksen-jarjestaja-oid
-       "1.2.246.562.10.54453923577"
+       "1.2.246.562.10.54453923572"
        :vaatimuksista-tai-tavoitteista-poikkeaminen
        "Testaus ei kuulu."
        :valittu-todentamisen-prosessi-koodi-uri
@@ -504,7 +504,7 @@
            :organisaatio {:oppilaitos-oid
                           "1.2.246.562.10.54539267911"}}]
          :jarjestaja {:oppilaitos-oid
-                      "1.2.246.562.10.55890967911"}
+                      "1.2.246.562.10.55890967916"}
          :nayttoymparisto {:nimi "Ab Yhtiö"
                            :y-tunnus "1234128-3"
                            :kuvaus "Testi1"}
@@ -521,9 +521,9 @@
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Erkki Esimerkkitest"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.13490579091"}}]
+                        "1.2.246.562.10.13490579094"}}]
        :jarjestaja {:oppilaitos-oid
-                    "1.2.246.562.10.93270579093"}
+                    "1.2.246.562.10.93270579092"}
        :nayttoymparisto {:nimi "Testi"
                          :y-tunnus "1234567-1"
                          :kuvaus "Testiyht"}
@@ -549,23 +549,23 @@
      :valittu-todentamisen-prosessi-koodi-uri
      "osaamisentodentamisenprosessi_0003"
      :amosaa-tunniste "12345"
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945325"
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945328"
      :vaatimuksista-tai-tavoitteista-poikkeaminen "Ei poikkeamaa"
      :tarkentavat-tiedot-osaamisen-arvioija
      {:lahetetty-arvioitavaksi "2021-01-01"
       :aiemmin-hankitun-osaamisen-arvioijat
       [{:nimi "Aarne Arvioija toinen"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.54453923421"}}]}
+                       "1.2.246.562.10.54453923424"}}]}
      :tarkentavat-tiedot-naytto
      [{:osa-alueet [{:koodi-uri "ammatillisenoppiaineet_bi"
                      :koodi-versio 6}]
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Teuvo Test"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.12346234691"}}]
+                        "1.2.246.562.10.12346234698"}}]
        :jarjestaja {:oppilaitos-oid
-                    "1.2.246.562.10.93270534263"}
+                    "1.2.246.562.10.93270534261"}
        :nayttoymparisto {:nimi "Testi Oy"
                          :y-tunnus "1289212-2"
                          :kuvaus "Testiyhtiöö"}
@@ -588,21 +588,21 @@
      :tutkinnon-osa-koodi-versio 100033
      :valittu-todentamisen-prosessi-koodi-uri "osaamisentodentamisenprosessi_2"
      :tutkinnon-osa-koodi-uri "tutkinnonosat_100022"
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921429"
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921428"
      :tarkentavat-tiedot-osaamisen-arvioija
      {:lahetetty-arvioitavaksi "2012-03-18"
       :aiemmin-hankitun-osaamisen-arvioijat
       [{:nimi "Erkki Esimerk"
-        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921633"}}
+        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921634"}}
        {:nimi "Joku Tyyp"
-        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921001"}}]}
+        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921006"}}]}
      :tarkentavat-tiedot-naytto
      [{:osa-alueet [{:koodi-uri "ammatillisenoppiaineet_en"
                      :koodi-versio 3}]
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Aapo Arvo"
-         :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921684"}}]
-       :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921785"}
+         :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921683"}}]
+       :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921782"}
        :nayttoymparisto {:nimi "Esimerkki Oyj"
                          :y-tunnus "1234565-5"
                          :kuvaus "Testiyrityksen testiosa"}
@@ -624,10 +624,10 @@
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Muutettu Arvioija"
       :organisaatio {:oppilaitos-oid
-                     "1.2.246.562.10.54453932222"}}
+                     "1.2.246.562.10.54453932227"}}
      {:nimi "Toinen Arvioija"
       :organisaatio {:oppilaitos-oid
-                     "1.2.246.562.10.54453933333"}}]}
+                     "1.2.246.562.10.54453933332"}}]}
 
    :osa-alueet
    [{:osa-alue-koodi-uri "ammatillisenoppiaineet_bi"
@@ -644,9 +644,9 @@
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Teppo Testaaja2"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.54539267000"}}]
+                        "1.2.246.562.10.54539267002"}}]
        :jarjestaja {:oppilaitos-oid
-                    "1.2.246.562.10.55890967000"}
+                    "1.2.246.562.10.55890967007"}
 
        :nayttoymparisto {:nimi "Ab Betoni Oy"
                          :y-tunnus "1234128-3"
@@ -665,7 +665,7 @@
                        :kuvaus "Testiyhtiö"}
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Joku Arvioija"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453911333"}}]
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453911338"}}]
      :sisallon-kuvaus ["Testauksen suunnittelu"
                        "Jokin toinen testi"]
      :yksilolliset-kriteerit ["kriteeri"]
@@ -674,7 +674,7 @@
     {:nayttoymparisto {:nimi "Toka Oy"}
      :koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Joku Toinen Arvioija"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453911555"}}]
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453911551"}}]
      :sisallon-kuvaus ["Jotakin sisaltoa"]
      :yksilolliset-kriteerit ["testi" "toinen"]
      :alku "2014-05-05"
@@ -686,14 +686,14 @@
    {:lahetetty-arvioitavaksi "2020-01-01"
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Nimi Muutettu"
-      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453555555"}}
+      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453555556"}}
      {:nimi "Joku Tyyppi"
-      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921000"}}]}
+      :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921006"}}]}
    :tarkentavat-tiedot-naytto
    [{:koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Muutettu Arvioija"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921674"}}]
-     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921685"}
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921675"}}]
+     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921683"}
      :nayttoymparisto {:nimi "Testi Oy"
                        :y-tunnus "1234565-5"
                        :kuvaus "Testiyrityksen testiosasostalla"}
@@ -710,12 +710,12 @@
     :aiemmin-hankitun-osaamisen-arvioijat
     [{:nimi "Aarne Arvioija"
       :organisaatio {:oppilaitos-oid
-                     "1.2.246.562.10.54453923411"}}]}
+                     "1.2.246.562.10.54453923416"}}]}
    :tarkentavat-tiedot-naytto
    [{:koulutuksen-jarjestaja-osaamisen-arvioijat
      [{:nimi "Muutettu Arvioija"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921674"}}]
-     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921685"}
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921675"}}]
+     :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921683"}
      :nayttoymparisto {:nimi "Testi Oy"
                        :y-tunnus "1234565-5"
                        :kuvaus "Testiyrityksen testiosasostalla"}
@@ -749,10 +749,10 @@
         :loppu "2021-05-05"}]
       :jarjestajan-edustaja
       {:nimi "testi testaaja"
-       :oppilaitos-oid "1.2.246.562.10.00000000421"}
+       :oppilaitos-oid "1.2.246.562.10.10000000421"}
       :hankkijan-edustaja
       {:nimi "testi edustaja"
-       :oppilaitos-oid "1.2.246.562.10.00000000321"}
+       :oppilaitos-oid "1.2.246.562.10.10000000322"}
       :tyopaikalla-jarjestettava-koulutus
       {:tyopaikan-nimi "joku nimi"
        :keskeiset-tyotehtavat ["tehtava" "toinen"]
@@ -764,18 +764,18 @@
       :sisallon-kuvaus ["Kuvaus"]
       :yksilolliset-kriteerit ["Ensimmäinen kriteeri"]
       :vaatimuksista-tai-tavoitteista-poikkeaminen "nyt poikettiin"
-      :jarjestaja {:oppilaitos-oid "1.2.246.562.10.00000000002"}
+      :jarjestaja {:oppilaitos-oid "1.2.246.562.10.20000000008"}
       :nayttoymparisto {:nimi "aaa"}
       :osa-alueet [{:koodi-uri "ammatillisenoppiaineet_en"
                     :koodi-versio 4}]
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Erkki Esimerkkitetsaaja"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.13490579333"}}]
+                       "1.2.246.562.10.13490579334"}}]
       :tyoelama-osaamisen-arvioijat [{:nimi "Nimi" :organisaatio
                                       {:nimi "Organisaation nimi"}}]}]}])
 
 (def multiple-hyto-values-patched
   {:tutkinnon-osa-koodi-uri "tutkinnonosat_3002683"
-   :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000009"
+   :koulutuksen-jarjestaja-oid "1.2.246.562.10.90000000001"
    :osa-alueet osa-alueet-of-hyto})

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -24,15 +24,15 @@
     {:lahetetty-arvioitavaksi (java.time.LocalDate/of 2019 3 18)
      :aiemmin-hankitun-osaamisen-arvioijat
      [{:nimi "Erkki Esimerkki"
-       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921623"}}]}
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921419"
+       :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921626"}}]}
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453921410"
     :tarkentavat-tiedot-naytto
     [{:osa-alueet [{:koodi-uri "ammatillisenoppiaineet_fy"
                     :koodi-versio 1}]
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Aapo Arvioija"
-        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921674"}}]
-      :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921685"}
+        :organisaatio {:oppilaitos-oid "1.2.246.562.10.54453921675"}}]
+      :jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453921683"}
       :nayttoymparisto {:nimi "Toinen Esimerkki Oyj"
                         :y-tunnus "1234562-0"
                         :kuvaus "Testiyrityksen testiosasostalla"}
@@ -60,8 +60,8 @@
      :aiemmin-hankitun-osaamisen-arvioijat
      [{:nimi "Aarne Arvioija"
        :organisaatio {:oppilaitos-oid
-                      "1.2.246.562.10.54453923411"}}]}
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945322"
+                      "1.2.246.562.10.54453923416"}}]}
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54453945328"
     :vaatimuksista-tai-tavoitteista-poikkeaminen
     "Ei poikkeamaa."
     :tarkentavat-tiedot-naytto
@@ -70,9 +70,9 @@
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Teuvo Testaaja"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.12346234690"}}]
+                       "1.2.246.562.10.12346234698"}}]
       :jarjestaja {:oppilaitos-oid
-                   "1.2.246.562.10.93270534262"}
+                   "1.2.246.562.10.93270534261"}
 
       :nayttoymparisto {:nimi "Testi Oyj"
                         :y-tunnus "1289211-2"
@@ -94,7 +94,7 @@
     "Ei poikkeamia."
     :osaamisen-osoittaminen
     [{:jarjestaja
-      {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+      {:oppilaitos-oid "1.2.246.562.10.54453924331"}
       :nayttoymparisto {:nimi "Testiympäristö 2"
                         :y-tunnus "1234567-1"
                         :kuvaus "Testi test"}
@@ -103,7 +103,7 @@
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Timo Testaaja"
         :organisaatio
-        {:oppilaitos-oid "1.2.246.562.10.54452521332"}}]
+        {:oppilaitos-oid "1.2.246.562.10.54452521336"}}]
       :tyoelama-osaamisen-arvioijat
       [{:nimi "Taneli Työmies"
         :organisaatio {:nimi "Tanelin Paja Ky"
@@ -116,7 +116,7 @@
     [{:jarjestajan-edustaja
       {:nimi "Ville Valvoja"
        :rooli "Valvojan apulainen"
-       :oppilaitos-oid "1.2.246.562.10.54451211340"}
+       :oppilaitos-oid "1.2.246.562.10.54451211343"}
       :osaamisen-hankkimistapa-koodi-uri
       "osaamisenhankkimistapa_oppisopimus"
       :osaamisen-hankkimistapa-koodi-versio 2
@@ -141,11 +141,11 @@
       :hankkijan-edustaja
       {:nimi "Heikki Hankkija"
        :rooli "Opettaja"
-       :oppilaitos-oid "1.2.246.562.10.54452422420"}
+       :oppilaitos-oid "1.2.246.562.10.54452422428"}
       :alku (java.time.LocalDate/of 2019 1 11)
       :loppu (java.time.LocalDate/of 2019 3 14)
       :yksiloiva-tunniste "1234567890"}]
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54411232222"}])
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54411232223"}])
 
 (def oto-data
   [{:nimi "Testiopintojakso"
@@ -165,12 +165,12 @@
      :aiemmin-hankitun-osaamisen-arvioijat
      [{:nimi "Arttu Arvioija"
        :organisaatio {:oppilaitos-oid
-                      "1.2.246.562.10.54453931311"}}]}
+                      "1.2.246.562.10.54453931310"}}]}
     :osa-alueet
     [{:osa-alue-koodi-uri "ammatillisenoppiaineet_bi"
       :osa-alue-koodi-versio 4
       :koulutuksen-jarjestaja-oid
-      "1.2.246.562.10.54453923578"
+      "1.2.246.562.10.54453923572"
       :vaatimuksista-tai-tavoitteista-poikkeaminen
       "Testaus ei kuulu vaatimuksiin."
       :valittu-todentamisen-prosessi-koodi-uri
@@ -188,9 +188,9 @@
         :koulutuksen-jarjestaja-osaamisen-arvioijat
         [{:nimi "Teppo Testaaja"
           :organisaatio {:oppilaitos-oid
-                         "1.2.246.562.10.54539267901"}}]
+                         "1.2.246.562.10.54539267903"}}]
         :jarjestaja {:oppilaitos-oid
-                     "1.2.246.562.10.55890967901"}
+                     "1.2.246.562.10.55890967908"}
 
         :nayttoymparisto {:nimi "Ab Yhtiö Oy"
                           :y-tunnus "1234128-1"
@@ -210,9 +210,9 @@
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Erkki Esimerkkitestaaja"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.13490579090"}}]
+                       "1.2.246.562.10.13490579094"}}]
       :jarjestaja {:oppilaitos-oid
-                   "1.2.246.562.10.93270579090"}
+                   "1.2.246.562.10.93270579092"}
       :nayttoymparisto {:nimi "Testi Oy"
                         :y-tunnus "1289235-2"
                         :kuvaus "Testiyhtiö"}
@@ -319,8 +319,8 @@
     :loppu (java.time.LocalDate/of 2022 2 19)
     :laajuus 5.5M}])
 
-(def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                :oppija-oid "1.2.246.562.24.12312312312"
+(def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                :oppija-oid "1.2.246.562.24.12312312319"
                 :ensikertainen-hyvaksyminen
                 (java.time.LocalDate/of 2019 3 18)
                 :osaamisen-hankkimisen-tarve true
@@ -334,7 +334,7 @@
                 :hankittavat-koulutuksen-osat []
                 :opiskeluvalmiuksia-tukevat-opinnot oto-data})
 
-(def min-hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"})
+(def min-hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"})
 
 (deftest get-aiemmin-hankitut-ammat-tutkinnon-osat-test
   (testing "Set HOKS aiemmin hankitut tutkinnon osat"
@@ -433,12 +433,12 @@
                  (h/save-hoks!
                    (assoc hoks-data
                           :tuva-opiskeluoikeus-oid
-                          "1.2.246.562.15.00000000002")))]
+                          "1.2.246.562.15.20000000008")))]
       (eq
         (-> (utils/dissoc-module-ids (h/get-hoks-by-id (:id hoks)))
             (select-keys [:id :tuva-opiskeluoikeus-oid]))
         {:id 1
-         :tuva-opiskeluoikeus-oid "1.2.246.562.15.00000000002"}))))
+         :tuva-opiskeluoikeus-oid "1.2.246.562.15.20000000008"}))))
 
 (deftest tarkentavat-tiedot-osaamisen-arvioija-save
   (testing "If tarkentavat-tiedot-osaamisen-arvioija is missing
@@ -486,7 +486,7 @@
     (let [oh-data
           {:jarjestajan-edustaja {:nimi "Ville Valvoja"
                                   :rooli "Valvojan apulainen"
-                                  :oppilaitos-oid "1.2.246.562.10.54451211340"}
+                                  :oppilaitos-oid "1.2.246.562.10.54451211343"}
            :osaamisen-hankkimistapa-koodi-uri
            "osaamisenhankkimistapa_oppisopimus"
            :osaamisen-hankkimistapa-koodi-versio 2
@@ -500,7 +500,7 @@
            :ajanjakson-tarkenne "Ei tarkennettavia asioita"
            :hankkijan-edustaja {:nimi "Heikki Hankkija"
                                 :rooli "Opettaja"
-                                :oppilaitos-oid "1.2.246.562.10.54452422420"}
+                                :oppilaitos-oid "1.2.246.562.10.54452422428"}
            :alku (java.time.LocalDate/of 2019 1 11)}
           oh1 (ha/save-osaamisen-hankkimistapa!
                 (assoc

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -20,8 +20,8 @@
       utils/parse-body))
 
 (defn create-hoks [app]
-  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                   :oppija-oid "1.2.246.562.24.12312312312"
+  (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                   :oppija-oid "1.2.246.562.24.12312312319"
                    :ensikertainen-hyvaksyminen
                    (java.time.LocalDate/of 2019 3 18)
                    :osaamisen-hankkimisen-tarve false}]

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -14,8 +14,8 @@
 (deftest prevent-creating-hoks-with-existing-opiskeluoikeus
   (testing "Prevent POST HOKS with existing opiskeluoikeus"
     (let [app (hoks-utils/create-app nil)
-          hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+          hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}]
       (hoks-utils/mock-st-post app base-url hoks-data)
@@ -30,12 +30,12 @@
   (testing (str "Prevent creation and show correct error message when "
                 "shallow-deleted HOKS with same opiskeluoikeus is found")
     (let [app (hoks-utils/create-app nil)
-          hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+          hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}
-          new-hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                         :oppija-oid "1.2.246.562.24.12312312313"
+          new-hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                         :oppija-oid "1.2.246.562.24.12312312322"
                          :ensikertainen-hyvaksyminen "2018-12-15"
                          :osaamisen-hankkimisen-tarve false}]
       (hoks-utils/mock-st-post app base-url hoks-data)
@@ -50,8 +50,8 @@
 
 (deftest prevent-creating-hoks-with-non-existing-oppija
   (testing "Prevent POST HOKS with non-existing oppija"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                     :oppija-oid "1.2.246.562.24.40404040404"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                     :oppija-oid "1.2.246.562.24.40404040406"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}]
       (let [response
@@ -64,8 +64,8 @@
 
 (deftest prevent-creating-unauthorized-hoks
   (testing "Prevent POST unauthorized HOKS"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000002"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.20000000008"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}]
       (let [response
@@ -75,8 +75,8 @@
 
 (deftest prevent-getting-unauthorized-hoks
   (testing "Prevent GET unauthorized HOKS"
-    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.00000000002"
-                     :oppija-oid "1.2.246.562.24.12312312312"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.20000000008"
+                     :oppija-oid "1.2.246.562.24.12312312319"
                      :ensikertainen-hyvaksyminen "2018-12-15"
                      :osaamisen-hankkimisen-tarve false}]
 
@@ -85,7 +85,7 @@
               (hoks-utils/create-app nil)
               (-> (mock/request :post base-url)
                   (mock/json-body hoks-data))
-              "1.2.246.562.24.47861388608")
+              "1.2.246.562.10.47861388602")
             body (utils/parse-body (:body response))]
         (is (= (:status
                  (hoks-utils/mock-st-get (hoks-utils/create-app nil)
@@ -99,8 +99,8 @@
             (hoks-utils/mock-st-post
               app
               base-url
-              {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-               :oppija-oid "1.2.246.562.24.12312312312"
+              {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+               :oppija-oid "1.2.246.562.24.12312312319"
                :ensikertainen-hyvaksyminen "2018-12-15"
                :osaamisen-hankkimisen-tarve false})
             body (utils/parse-body (:body response))]
@@ -109,7 +109,7 @@
                    app
                    (get-in body [:data :uri])
                    {:id (get-in body [:meta :id])
-                    :opiskeluoikeus-oid "1.2.246.562.15.00000000001"})
+                    :opiskeluoikeus-oid "1.2.246.562.15.10000000009"})
                  :status)
                204)
             "Should not return bad request for updating opiskeluoikeus oid
@@ -120,7 +120,7 @@
                    app
                    (get-in body [:data :uri])
                    {:id (get-in body [:meta :id])
-                    :oppija-oid "1.2.246.562.24.12312312312"})
+                    :oppija-oid "1.2.246.562.24.12312312319"})
                  :status)
                204)
             "Should not return bad request for updating oppija oid if the
@@ -132,10 +132,10 @@
                              (get-in body [:data :uri]))
                            :body))]
           (is (= (get-in get-body [:data :opiskeluoikeus-oid])
-                 "1.2.246.562.15.00000000001")
+                 "1.2.246.562.15.10000000009")
               "Opiskeluoikeus oid should be unchanged")
           (is (= (get-in get-body [:data :oppija-oid])
-                 "1.2.246.562.24.12312312312")
+                 "1.2.246.562.24.12312312319")
               "Oppija oid should be unchanged"))))))
 
 (deftest prevent-oppija-oid-patch
@@ -145,8 +145,8 @@
             (hoks-utils/mock-st-post
               app
               base-url
-              {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-               :oppija-oid "1.2.246.562.24.12312312312"
+              {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+               :oppija-oid "1.2.246.562.24.12312312319"
                :ensikertainen-hyvaksyminen "2018-12-15"
                :osaamisen-hankkimisen-tarve false})
             body (utils/parse-body (:body response))]
@@ -155,7 +155,7 @@
                    app
                    (get-in body [:data :uri])
                    {:id (get-in body [:meta :id])
-                    :oppija-oid "1.2.246.562.24.12312312313"})
+                    :oppija-oid "1.2.246.562.24.12312312322"})
                  :status)
                400)
             "Should return bad request for updating oppija oid if the
@@ -167,7 +167,7 @@
                              (get-in body [:data :uri]))
                            :body))]
           (is (= (get-in get-body [:data :oppija-oid])
-                 "1.2.246.562.24.12312312312")
+                 "1.2.246.562.24.12312312319")
               "Oppija oid should be unchanged"))))))
 
 (deftest prevent-opiskeluoikeus-patch
@@ -177,8 +177,8 @@
             (hoks-utils/mock-st-post
               app
               base-url
-              {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-               :oppija-oid "1.2.246.562.24.12312312312"
+              {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+               :oppija-oid "1.2.246.562.24.12312312319"
                :ensikertainen-hyvaksyminen "2018-12-15"
                :osaamisen-hankkimisen-tarve false})
             body (utils/parse-body (:body response))]
@@ -187,7 +187,7 @@
                    app
                    (get-in body [:data :uri])
                    {:id (get-in body [:meta :id])
-                    :opiskeluoikeus-oid "1.2.246.562.15.00000000002"})
+                    :opiskeluoikeus-oid "1.2.246.562.15.20000000008"})
                  :status)
                400)
             "Should return bad request for updating opiskeluoikeus oid
@@ -199,7 +199,7 @@
                              (get-in body [:data :uri]))
                            :body))]
           (is (= (get-in get-body [:data :opiskeluoikeus-oid])
-                 "1.2.246.562.15.00000000001")
+                 "1.2.246.562.15.10000000009")
               "Opiskeluoikeus oid should be unchanged"))))))
 
 (deftest prevent-updating-opiskeluoikeus
@@ -216,7 +216,7 @@
                              (assoc :id 1)
                              (dissoc :opiskeluoikeus-oid :oppija-oid)
                              (assoc :opiskeluoikeus-oid
-                                    "1.2.246.562.15.00000000002"))
+                                    "1.2.246.562.15.20000000008"))
                          app)]
       (is (= (:status post-response) 200))
       (is (= (:status put-response) 400))
@@ -237,7 +237,7 @@
                              (assoc :id 1)
                              (dissoc :opiskeluoikeus-oid :oppija-oid)
                              (assoc :oppija-oid
-                                    "1.2.246.562.24.12312312313"))
+                                    "1.2.246.562.24.12312312322"))
                          app)]
       (is (= (:status post-response) 200))
       (is (= (:status put-response) 400))
@@ -264,13 +264,13 @@
           invalid-data-3
           (assoc test-data/hoks-data
                  :opiskeluoikeus-oid
-                 "1.2.246.562.15.00000000004")
+                 "1.2.246.562.15.40000000006")
           invalid-post-response-3
           (hoks-utils/create-mock-post-request "" invalid-data-3 app)
           invalid-data-4
           (assoc test-data/hoks-data
                  :opiskeluoikeus-oid
-                 "1.2.246.562.15.00000000005")
+                 "1.2.246.562.15.50000000005")
           invalid-post-response-4
           (hoks-utils/create-mock-post-request "" invalid-data-4 app)]
       (is (= (:status invalid-post-response-1) 400))

--- a/test/oph/ehoks/hoks/test_data.clj
+++ b/test/oph/ehoks/hoks/test_data.clj
@@ -21,9 +21,9 @@
         :alku "2019-03-10"
         :loppu "2025-03-19"}]
       :keskeytymisajanjaksot []}]
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000005"
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.50000000005"
     :osaamisen-osoittaminen
-    [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+    [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924331"}
       :nayttoymparisto {:nimi "Testiympäristö 2"
                         :y-tunnus "1234567-1"
                         :kuvaus "Testi test"}
@@ -31,7 +31,7 @@
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Timo Testaaja"
         :organisaatio {:oppilaitos-oid
-                       "1.2.246.562.10.54452521332"}}]
+                       "1.2.246.562.10.54452521336"}}]
       :tyoelama-osaamisen-arvioijat
       [{:nimi "Taneli Työmies"
         :organisaatio {:nimi "Tanelin Paja Ky"
@@ -45,7 +45,7 @@
 (def hyto-data-oht-matching-and-new-tunniste
   [{:tutkinnon-osa-koodi-uri "tutkinnonosat_3002683"
     :tutkinnon-osa-koodi-versio 1
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000007"
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.70000000003"
     :osa-alueet
     [{:osa-alue-koodi-uri "ammatillisenoppiaineet_ku"
       :osa-alue-koodi-versio 1
@@ -79,14 +79,14 @@
           :loppu "2021-03-19"}]
         :keskeytymisajanjaksot []}]
       :osaamisen-osoittaminen
-      [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.00000000002"}
+      [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.20000000008"}
         :nayttoymparisto {:nimi "aaa"}
         :osa-alueet [{:koodi-uri "ammatillisenoppiaineet_en"
                       :koodi-versio 4}]
         :koulutuksen-jarjestaja-osaamisen-arvioijat
         [{:nimi "Erkki Esimerkkitetsaaja"
           :organisaatio {:oppilaitos-oid
-                         "1.2.246.562.10.13490579333"}}]
+                         "1.2.246.562.10.13490579334"}}]
         :alku "2018-12-12"
         :loppu "2018-12-20"
         :sisallon-kuvaus ["Kuvaus"]
@@ -95,8 +95,8 @@
         :yksilolliset-kriteerit ["Ensimmäinen kriteeri"]}]}]}])
 
 (def hoks-data
-  {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-   :oppija-oid "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+   :oppija-oid "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen "2018-12-15"
    :osaamisen-hankkimisen-tarve false
    :osaamisen-saavuttamisen-pvm "2020-10-22"
@@ -113,8 +113,8 @@
    :aiemmin-hankitut-yhteiset-tutkinnon-osat [parts-test-data/ahyto-data]})
 
 (def hoks-data-without-osa-aikaisuus
-  {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-   :oppija-oid "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+   :oppija-oid "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen "2018-12-15"
    :osaamisen-hankkimisen-tarve false
    :osaamisen-saavuttamisen-pvm "2020-10-22"
@@ -132,16 +132,16 @@
    :aiemmin-hankitut-yhteiset-tutkinnon-osat [parts-test-data/ahyto-data]})
 
 (def new-hoks-with-valid-osa-aikaisuus
-  {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-   :oppija-oid "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+   :oppija-oid "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen "2018-12-15"
    :osaamisen-hankkimisen-tarve false
    :hankittavat-ammat-tutkinnon-osat
    [parts-test-data/hao-data-with-valid-osa-aikaisuus]})
 
 (def new-hoks-without-osa-aikaisuus
-  {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-   :oppija-oid "1.2.246.562.24.12312312312"
+  {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+   :oppija-oid "1.2.246.562.24.12312312319"
    :ensikertainen-hyvaksyminen "2018-12-15"
    :osaamisen-hankkimisen-tarve false
    :hankittavat-ammat-tutkinnon-osat
@@ -156,7 +156,7 @@
      :tutkinnon-osa-koodi-versio 2
      :vaatimuksista-tai-tavoitteista-poikkeaminen
      "Ei poikkeamia."
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000005"
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.50000000005"
      :osaamisen-hankkimistavat
      [{:alku "2018-12-12"
        :loppu "2018-12-20"
@@ -177,9 +177,9 @@
        :hankkijan-edustaja
        {:nimi "Heikki Hank"
         :rooli "Opettaja"
-        :oppilaitos-oid "1.2.246.562.10.54452422420"}}]
+        :oppilaitos-oid "1.2.246.562.10.54452422428"}}]
      :osaamisen-osoittaminen
-     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+     [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.54453924331"}
        :nayttoymparisto {:nimi "Testiympäristö 2"
                          :y-tunnus "1234567-1"
                          :kuvaus "Testi test"}
@@ -187,7 +187,7 @@
        :koulutuksen-jarjestaja-osaamisen-arvioijat
        [{:nimi "Timo Testaaja2"
          :organisaatio {:oppilaitos-oid
-                        "1.2.246.562.10.54452521332"}}]
+                        "1.2.246.562.10.54452521336"}}]
        :tyoelama-osaamisen-arvioijat
        [{:nimi "Taneli Työmies2"
          :organisaatio {:nimi "Tanelin Paja Oy"
@@ -205,7 +205,7 @@
    :hankittavat-paikalliset-tutkinnon-osat
    [{:nimi "testinimi"
      :koulutuksen-jarjestaja-oid
-     "1.2.246.562.10.00000000001"
+     "1.2.246.562.10.10000000009"
      :olennainen-seikka false
      :osaamisen-hankkimistavat
      [{:alku "2019-12-12"
@@ -228,10 +228,10 @@
        :hankkijan-edustaja
        {:nimi "Heikki Hankk"
         :rooli "Opettaja"
-        :oppilaitos-oid "1.2.246.562.10.54452422420"}}]
+        :oppilaitos-oid "1.2.246.562.10.54452422428"}}]
      :osaamisen-osoittaminen
      [{:jarjestaja {:oppilaitos-oid
-                    "1.2.246.562.10.00000000022"}
+                    "1.2.246.562.10.10000000025"}
        :koulutuksen-jarjestaja-osaamisen-arvioijat []
        :osa-alueet []
        :sisallon-kuvaus
@@ -254,7 +254,7 @@
    :hankittavat-yhteiset-tutkinnon-osat
    [{:tutkinnon-osa-koodi-uri "tutkinnonosat_3002690"
      :tutkinnon-osa-koodi-versio 3
-     :koulutuksen-jarjestaja-oid "1.2.246.562.10.00000000007"
+     :koulutuksen-jarjestaja-oid "1.2.246.562.10.70000000003"
      :osa-alueet
      [{:osa-alue-koodi-uri "ammatillisenoppiaineet_bi"
        :osa-alue-koodi-versio 1
@@ -275,14 +275,14 @@
          [{:alku "2021-09-01"
            :loppu "2021-09-21"}]}]
        :osaamisen-osoittaminen
-       [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.00000000032"}
+       [{:jarjestaja {:oppilaitos-oid "1.2.246.562.10.10000000033"}
          :nayttoymparisto {:nimi "aaab"}
          :osa-alueet [{:koodi-uri "ammatillisenoppiaineet_ru"
                        :koodi-versio 4}]
          :koulutuksen-jarjestaja-osaamisen-arvioijat
          [{:nimi "Erkki Esimerkkitest"
            :organisaatio {:oppilaitos-oid
-                          "1.2.246.562.10.13490579322"}}]
+                          "1.2.246.562.10.13490579326"}}]
          :alku "2018-12-12"
          :loppu "2019-12-20"
          :sisallon-kuvaus ["Kuvaus" "toinen"]

--- a/test/oph/ehoks/opiskelijapalaute_test.clj
+++ b/test/oph/ehoks/opiskelijapalaute_test.clj
@@ -160,11 +160,11 @@
 (defn mock-get-opiskeluoikeus-info-raw
   [oid]
   (case oid
-    "1.2.246.562.15.00000000001" {:suoritukset
+    "1.2.246.562.15.10000000009" {:suoritukset
                                   [{:tyyppi
                                     {:koodiarvo "ammatillinentutkinto"}}]
                                   :tyyppi {:koodiarvo "ammatillinenkoulutus"}}
-    "1.2.246.562.15.00000000002" {:suoritukset
+    "1.2.246.562.15.20000000008" {:suoritukset
                                   [{:tyyppi {:koodiarvo "joku_muu"}}]
                                   :tyyppi {:koodiarvo "ammatillinenkoulutus"}}
     (throw (ex-info "Opiskeluoikeus not found" {:status 404}))))
@@ -199,13 +199,13 @@
           (with-log
             (op/send!
               :paattokysely
-              (assoc hoks :opiskeluoikeus-oid "1.2.246.562.15.00000000002"))
+              (assoc hoks :opiskeluoikeus-oid "1.2.246.562.15.20000000008"))
             (is (logged? 'oph.ehoks.opiskelijapalaute
                          :info
                          #"No ammatillinen suoritus"))
             (op/send!
               :paattokysely
-              (assoc hoks :opiskeluoikeus-oid "1.2.246.562.15.00000000003"))
+              (assoc hoks :opiskeluoikeus-oid "1.2.246.562.15.30000000007"))
             (is (logged? 'oph.ehoks.opiskelijapalaute
                          :warn
                          #"Couldn't get opiskeluoikeus"))))))))

--- a/test/oph/ehoks/oppija/handler_test.clj
+++ b/test/oph/ehoks/oppija/handler_test.clj
@@ -69,7 +69,7 @@
               handler/app-routes (test-session-store store))]
     (utils/with-authenticated-oid
       store
-      "1.2.246.562.24.12312312312"
+      "1.2.246.562.24.12312312319"
       app
       (mock/header request "Caller-Id" "test"))))
 

--- a/test/oph/ehoks/oppija/oppija_external_test.clj
+++ b/test/oph/ehoks/oppija/oppija_external_test.clj
@@ -15,7 +15,7 @@
               handler/app-routes (test-session-store store))]
     (utils/with-authenticated-oid
       store
-      "1.2.246.562.24.12312312312"
+      "1.2.246.562.24.12312312319"
       app
       request)))
 

--- a/test/oph/ehoks/oppija/share_handler_test.clj
+++ b/test/oph/ehoks/oppija/share_handler_test.clj
@@ -38,7 +38,7 @@
               handler/app-routes (test-session-store store))]
     (utils/with-authenticated-oid
       store
-      "1.2.246.562.24.12312312312"
+      "1.2.246.562.24.12312312319"
       app
       request)))
 

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -14,7 +14,7 @@
 (t/use-fixtures :each utils/empty-database-after-test)
 
 (def opiskeluoikeus-data
-  {:oppilaitos {:oid "1.2.246.562.10.222222222222"}
+  {:oppilaitos {:oid "1.2.246.562.10.22222222220"}
    :tila {:opiskeluoikeusjaksot
           [{:alku "2023-07-03"
             :tila {:koodiarvo "lasna"
@@ -32,7 +32,7 @@
 
 (def onr-data
   {:status 200
-   :body {:oidHenkilo "1.2.246.562.24.111111111111"
+   :body {:oidHenkilo "1.2.246.562.24.11111111110"
           :hetu "250103-5360"
           :etunimet "Tero"
           :kutsumanimi "Tero"
@@ -41,7 +41,7 @@
 (def onr-data-master
   {:status 200
    :body {:duplicate false
-          :oidHenkilo "1.2.246.562.24.111111111222"
+          :oidHenkilo "1.2.246.562.24.11111111123"
           :hetu "250103-5360"
           :etunimet "Matti"
           :kutsumanimi "Masterinho"
@@ -173,7 +173,7 @@
 
 (def onr-data-name-changed
   {:status 200
-   :body {:oidHenkilo "1.2.246.562.24.111111111111"
+   :body {:oidHenkilo "1.2.246.562.24.11111111110"
           :hetu "250103-5360"
           :etunimet "Tero"
           :kutsumanimi "Tero"
@@ -199,36 +199,36 @@
 
 (t/deftest get-oppijat-without-index
   (t/testing "Get oppijat without index"
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111111"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222222"})
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111111"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222223"})
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111112"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222224"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111110"
+                           :opiskeluoikeus-oid "1.2.246.562.15.22222222220"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111110"
+                           :opiskeluoikeus-oid "1.2.246.562.15.23222222228"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.12111111119"
+                           :opiskeluoikeus-oid "1.2.246.562.15.24222222226"})
     (t/is
       (= (sut/get-oppijat-without-index)
-         [{:oppija_oid "1.2.246.562.24.11111111111"}
-          {:oppija_oid "1.2.246.562.24.11111111112"}]))
+         [{:oppija_oid "1.2.246.562.24.11111111110"}
+          {:oppija_oid "1.2.246.562.24.12111111119"}]))
     (t/is
       (= (sut/get-oppijat-without-index-count)
          2))))
 
 (t/deftest get-opiskeluoikeudet-without-index
   (t/testing "Get opiskeluoikeudet without index"
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111111"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222222"})
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111111"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222223"})
-    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111112"
-                           :opiskeluoikeus-oid "1.2.246.562.15.22222222224"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111110"
+                           :opiskeluoikeus-oid "1.2.246.562.15.22222222220"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.11111111110"
+                           :opiskeluoikeus-oid "1.2.246.562.15.23222222228"})
+    (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.12111111119"
+                           :opiskeluoikeus-oid "1.2.246.562.15.24222222226"})
     (t/is
       (= (sut/get-opiskeluoikeudet-without-index)
-         [{:oppija_oid "1.2.246.562.24.11111111111"
-           :opiskeluoikeus_oid "1.2.246.562.15.22222222222"}
-          {:oppija_oid "1.2.246.562.24.11111111111"
-           :opiskeluoikeus_oid "1.2.246.562.15.22222222223"}
-          {:oppija_oid "1.2.246.562.24.11111111112"
-           :opiskeluoikeus_oid "1.2.246.562.15.22222222224"}]))
+         [{:oppija_oid "1.2.246.562.24.11111111110"
+           :opiskeluoikeus_oid "1.2.246.562.15.22222222220"}
+          {:oppija_oid "1.2.246.562.24.11111111110"
+           :opiskeluoikeus_oid "1.2.246.562.15.23222222228"}
+          {:oppija_oid "1.2.246.562.24.12111111119"
+           :opiskeluoikeus_oid "1.2.246.562.15.24222222226"}]))
     (t/is
       (= (sut/get-opiskeluoikeudet-without-index-count)
          3))))
@@ -236,98 +236,98 @@
 (t/deftest get-opiskeluoikeudet-without-tutkinto-nimi
   (t/testing "Get opiskeluoikeudet without tutkinto_nimi"
     (db-oppija/insert-oppija!
-      {:oid "1.2.246.562.24.11111111111"
+      {:oid "1.2.246.562.24.11111111110"
        :nimi "Testi Oppija"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000002"
-       :oppija_oid "1.2.246.562.24.11111111111"})
+      {:oid "1.2.246.562.15.76000000000"
+       :oppija_oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000003"
-       :oppija_oid "1.2.246.562.24.11111111111"})
+      {:oid "1.2.246.562.15.76300000007"
+       :oppija_oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000004"
-       :oppija_oid "1.2.246.562.24.11111111111"
+      {:oid "1.2.246.562.15.76400000006"
+       :oppija_oid "1.2.246.562.24.11111111110"
        :tutkinto-nimi {:fi "Testitutkinto" :sv "test"}})
     (let [results (vec (sort-by :oid
                                 (sut/get-opiskeluoikeudet-without-tutkinto)))]
       (t/is (= (get-in results [0 :oid])
-               "1.2.246.562.15.76000000002"))
+               "1.2.246.562.15.76000000000"))
       (t/is (= (get-in results [1 :oid])
-               "1.2.246.562.15.76000000003")))))
+               "1.2.246.562.15.76300000007")))))
 
 (t/deftest get-opiskeluoikeudet-without-tutkinto-count
   (t/testing "Get count of opiskeluoikeudet without tutkinto_nimi"
     (db-oppija/insert-oppija!
-      {:oid "1.2.246.562.24.11111111111"
+      {:oid "1.2.246.562.24.11111111110"
        :nimi "Testi Oppija"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000002"
-       :oppija_oid "1.2.246.562.24.11111111111"})
+      {:oid "1.2.246.562.15.76000000000"
+       :oppija_oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000003"
-       :oppija_oid "1.2.246.562.24.11111111111"})
+      {:oid "1.2.246.562.15.76300000007"
+       :oppija_oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.76000000004"
-       :oppija_oid "1.2.246.562.24.11111111111"
+      {:oid "1.2.246.562.15.76400000006"
+       :oppija_oid "1.2.246.562.24.11111111110"
        :tutkinto-nimi {:fi "Testitutkinto" :sv "test"}})
     (t/is (= (sut/get-opiskeluoikeudet-without-tutkinto-count) 2))))
 
 (t/deftest get-oppija-opiskeluoikeudet
   (t/testing "Get oppija opiskeluoikeudet"
-    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.11111111111"})
+    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oppija-oid "1.2.246.562.24.11111111111"
-       :oid "1.2.246.562.15.22222222222"})
+      {:oppija-oid "1.2.246.562.24.11111111110"
+       :oid "1.2.246.562.15.22222222220"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oppija-oid "1.2.246.562.24.11111111111"
-       :oid "1.2.246.562.15.22222222224"})
-    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.11111111112"})
+      {:oppija-oid "1.2.246.562.24.11111111110"
+       :oid "1.2.246.562.15.24222222226"})
+    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.12111111119"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oppija-oid "1.2.246.562.24.11111111112"
-       :oid "1.2.246.562.15.22222222223"})
+      {:oppija-oid "1.2.246.562.24.12111111119"
+       :oid "1.2.246.562.15.23222222228"})
     (t/is
-      (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.11111111111")
-         [{:oid "1.2.246.562.15.22222222222"
-           :oppija-oid "1.2.246.562.24.11111111111"}
-          {:oid "1.2.246.562.15.22222222224"
-           :oppija-oid "1.2.246.562.24.11111111111"}]))
+      (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.11111111110")
+         [{:oid "1.2.246.562.15.22222222220"
+           :oppija-oid "1.2.246.562.24.11111111110"}
+          {:oid "1.2.246.562.15.24222222226"
+           :oppija-oid "1.2.246.562.24.11111111110"}]))
     (t/is
-      (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.11111111112")
-         [{:oid "1.2.246.562.15.22222222223"
-           :oppija-oid "1.2.246.562.24.11111111112"}]))))
+      (= (sut/get-oppija-opiskeluoikeudet "1.2.246.562.24.12111111119")
+         [{:oid "1.2.246.562.15.23222222228"
+           :oppija-oid "1.2.246.562.24.12111111119"}]))))
 
 (t/deftest get-oppija-by-oid
   (t/testing "Get oppija by oid"
     (db-oppija/insert-oppija!
-      {:oid "1.2.246.562.24.11111111111" :nimi "Test 1"})
+      {:oid "1.2.246.562.24.11111111110" :nimi "Test 1"})
     (db-oppija/insert-oppija!
-      {:oid "1.2.246.562.24.11111111112" :nimi "Test 2"})
-    (t/is (= (sut/get-oppija-by-oid "1.2.246.562.24.11111111111")
-             {:oid "1.2.246.562.24.11111111111" :nimi "Test 1"}))
-    (t/is (= (sut/get-oppija-by-oid "1.2.246.562.24.11111111112")
-             {:oid "1.2.246.562.24.11111111112" :nimi "Test 2"}))))
+      {:oid "1.2.246.562.24.12111111119" :nimi "Test 2"})
+    (t/is (= (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+             {:oid "1.2.246.562.24.11111111110" :nimi "Test 1"}))
+    (t/is (= (sut/get-oppija-by-oid "1.2.246.562.24.12111111119")
+             {:oid "1.2.246.562.24.12111111119" :nimi "Test 2"}))))
 
 (t/deftest get-opiskeluoikeus-by-oid!
   (t/testing "Get opiskeluoikeus by oid"
     (db-oppija/insert-oppija!
-      {:oid "1.2.246.562.24.11111111111" :nimi "Test 1"})
+      {:oid "1.2.246.562.24.11111111110" :nimi "Test 1"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.22222222222"
-       :oppija_oid "1.2.246.562.24.11111111111"})
+      {:oid "1.2.246.562.15.22222222220"
+       :oppija_oid "1.2.246.562.24.11111111110"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oid "1.2.246.562.15.22222222223"
-       :oppija_oid "1.2.246.562.24.11111111111"})
-    (t/is (= (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.22222222222")
-             {:oid "1.2.246.562.15.22222222222"
-              :oppija-oid "1.2.246.562.24.11111111111"}))
-    (t/is (= (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.22222222223")
-             {:oid "1.2.246.562.15.22222222223"
-              :oppija-oid "1.2.246.562.24.11111111111"}))))
+      {:oid "1.2.246.562.15.23222222228"
+       :oppija_oid "1.2.246.562.24.11111111110"})
+    (t/is (= (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.22222222220")
+             {:oid "1.2.246.562.15.22222222220"
+              :oppija-oid "1.2.246.562.24.11111111110"}))
+    (t/is (= (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.23222222228")
+             {:oid "1.2.246.562.15.23222222228"
+              :oppija-oid "1.2.246.562.24.11111111110"}))))
 
 (t/deftest add-oppija-opiskeluoikeus
   (t/testing "Add oppija and opiskeluoikeus"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -338,21 +338,21 @@
                     opiskeluoikeus-data
                     :alkamispäivä "2023-07-03"
                     :arvioituPäättymispäivä "2025-12-01"
-                    :oid "1.2.246.562.15.00000000001")}))]
-      (sut/add-oppija! "1.2.246.562.24.111111111111")
+                    :oid "1.2.246.562.15.10000000009")}))]
+      (sut/add-oppija! "1.2.246.562.24.11111111110")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testaaja"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
          :alkamispaiva (LocalDate/of 2023 7 3)
          :arvioitu-paattymispaiva (LocalDate/of 2025 12 1)
-         :oppija-oid "1.2.246.562.24.111111111111"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppija-oid "1.2.246.562.24.11111111110"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
@@ -361,7 +361,7 @@
 (t/deftest update-oppija-opiskeluoikeus
   (t/testing "Update oppija and opiskeluoikeus"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -370,19 +370,19 @@
            {:status 200
             :body (assoc
                     opiskeluoikeus-data
-                    :oid "1.2.246.562.15.00000000001")}))]
-      (sut/add-oppija! "1.2.246.562.24.111111111111")
+                    :oid "1.2.246.562.15.10000000009")}))]
+      (sut/add-oppija! "1.2.246.562.24.11111111110")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testaaja"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
-         :oppija-oid "1.2.246.562.24.111111111111"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
+         :oppija-oid "1.2.246.562.24.11111111110"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
@@ -390,23 +390,23 @@
 
     ; testataan että jos ei ole alkamispäivää korvataan aina uudella
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ ___ __]
          {:status 200
           :body (assoc
                   opiskeluoikeus-data
                   :alkamispäivä "2023-07-01"
-                  :oid "1.2.246.562.15.00000000001")})]
+                  :oid "1.2.246.562.15.10000000009")})]
       (t/is (sut/opiskeluoikeus-information-outdated?!
-              "1.2.246.562.15.00000000001"))
+              "1.2.246.562.15.10000000009"))
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
          :alkamispaiva (LocalDate/of 2023 7 1)
-         :oppija-oid "1.2.246.562.24.111111111111"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppija-oid "1.2.246.562.24.11111111110"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
@@ -414,44 +414,44 @@
 
     ; testataan että muuten pidetään indeksissä jo oleva
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ ___ __]
          {:status 200
           :body (assoc
                   opiskeluoikeus-data
                   :alkamispäivä "2023-07-03"
                   :arvioituPäättymispäivä "2025-10-01"
-                  :oid "1.2.246.562.15.00000000001")})]
+                  :oid "1.2.246.562.15.10000000009")})]
       (t/is (not (sut/opiskeluoikeus-information-outdated?!
-                   "1.2.246.562.15.00000000001")))
+                   "1.2.246.562.15.10000000009")))
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
          :alkamispaiva (LocalDate/of 2023 7 1)  ;; i.e. no change
-         :oppija-oid "1.2.246.562.24.111111111111"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppija-oid "1.2.246.562.24.11111111110"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
       (db-ops/update! :opiskeluoikeudet
                       {:updated_at (java.time.LocalDate/of 2022 9 1)}
-                      ["oid = ?" "1.2.246.562.15.00000000001"])
+                      ["oid = ?" "1.2.246.562.15.10000000009"])
       (t/is (sut/opiskeluoikeus-information-outdated?!
-              "1.2.246.562.15.00000000001")))
+              "1.2.246.562.15.10000000009")))
 
     ; odota cachen vanhenemista
     (Thread/sleep 500)
 
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url "oppijanumerorekisteri-service") -1)
            {:status 200
-            :body {:oidHenkilo "1.2.246.562.24.111111111111"
+            :body {:oidHenkilo "1.2.246.562.24.11111111110"
                    :hetu "250103-5360"
                    :etunimet "Tero"
                    :kutsumanimi "Tero"
@@ -459,17 +459,17 @@
            (> (.indexOf url "/koski/api/opiskeluoikeus") -1)
            {:status 200
             :body {:oppilaitos {:oid "1.2.246.562.10.222222222223"}}}))]
-      (sut/update-oppija! "1.2.246.562.24.111111111111")
+      (sut/update-oppija! "1.2.246.562.24.11111111110")
       (sut/update-opiskeluoikeus-without-error-forwarding!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testinen"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
-         :oppija-oid "1.2.246.562.24.111111111111"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
+         :oppija-oid "1.2.246.562.24.11111111110"
          :oppilaitos-oid "1.2.246.562.10.222222222223"
          :tutkinto-nimi {:fi "" :sv ""}
          :osaamisala-nimi {:fi "" :sv ""}}))))
@@ -477,7 +477,7 @@
 (t/deftest insert-and-update-oppija-opiskeluoikeus-with-hankintakoulutus
   (t/testing "Insert and update oppija and opiskeluoikeus with hankintakoulutus"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -486,22 +486,22 @@
            {:status 200
             :body   (assoc
                       opiskeluoikeus-data
-                      :oid "1.2.246.562.15.00000000001")}))]
-      (sut/add-oppija! "1.2.246.562.24.111111111111")
+                      :oid "1.2.246.562.15.10000000009")}))]
+      (sut/add-oppija! "1.2.246.562.24.11111111110")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111"))
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110"))
 
     ; odota cachen vanhenemista
     (Thread/sleep 500)
 
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"]
+      ["1.2.246.562.10.22222222220"]
       (sut/insert-hankintakoulutus-opiskeluoikeus!
-        "1.2.246.562.15.00000000001"
-        "1.2.246.562.24.111111111111"
+        "1.2.246.562.15.10000000009"
+        "1.2.246.562.24.11111111110"
         (assoc
           opiskeluoikeus-data
-          :oid "1.2.246.562.15.00000000002"
+          :oid "1.2.246.562.15.20000000008"
           :sisältyyOpiskeluoikeuteen
           {:oppilaitos {:oid "1.2.246.562.15.99999123"
                         :oppilaitosnumero
@@ -510,73 +510,73 @@
                         {:fi "Testi-yliopisto"
                          :sv "Testi-universitet"
                          :en "Testi University"}}
-           :oid        "1.2.246.562.15.00000000001"}))
+           :oid        "1.2.246.562.15.10000000009"}))
       (utils/eq
         (sut/get-opiskeluoikeus-by-oid!
-          "1.2.246.562.15.00000000002")
+          "1.2.246.562.15.20000000008")
         {:osaamisala-nimi {:fi "", :sv ""},
-         :oid "1.2.246.562.15.00000000002",
+         :oid "1.2.246.562.15.20000000008",
          :hankintakoulutus-opiskeluoikeus-oid
-         "1.2.246.562.15.00000000001",
-         :oppilaitos-oid "1.2.246.562.10.222222222222",
+         "1.2.246.562.15.10000000009",
+         :oppilaitos-oid "1.2.246.562.10.22222222220",
          :tutkinto-nimi
          {:en "Testing",
           :fi "Testialan perustutkinto",
           :sv "Grundexamen inom testsbranschen"},
-         :oppija-oid "1.2.246.562.24.111111111111",
+         :oppija-oid "1.2.246.562.24.11111111110",
          :hankintakoulutus-jarjestaja-oid
          "1.2.246.562.15.99999123"})
       (sut/insert-hankintakoulutus-opiskeluoikeus!
-        "1.2.246.562.15.00000000001"
-        "1.2.246.562.24.111111111111"
+        "1.2.246.562.15.10000000009"
+        "1.2.246.562.24.11111111110"
         (assoc
           opiskeluoikeus-data
-          :oid "1.2.246.562.15.00000000002"
+          :oid "1.2.246.562.15.20000000008"
           :sisältyyOpiskeluoikeuteen
-          {:oppilaitos {:oid "1.2.246.562.15.99999125"
+          {:oppilaitos {:oid "1.2.246.562.10.99999125000"
                         :oppilaitosnumero
                         {:koodiarvo "10076"}
                         :nimi
                         {:fi "Katujen-yliopisto"
                          :sv "Gatan-universitet"
                          :en "Street University"}}
-           :oid        "1.2.246.562.15.00000000001"}))
+           :oid        "1.2.246.562.15.10000000009"}))
       (utils/eq
         (sut/get-opiskeluoikeus-by-oid!
-          "1.2.246.562.15.00000000002")
+          "1.2.246.562.15.20000000008")
         {:osaamisala-nimi {:fi "", :sv ""},
-         :oid "1.2.246.562.15.00000000002",
+         :oid "1.2.246.562.15.20000000008",
          :hankintakoulutus-opiskeluoikeus-oid
-         "1.2.246.562.15.00000000001",
-         :oppilaitos-oid "1.2.246.562.10.222222222222",
+         "1.2.246.562.15.10000000009",
+         :oppilaitos-oid "1.2.246.562.10.22222222220",
          :tutkinto-nimi
          {:en "Testing",
           :fi "Testialan perustutkinto",
           :sv "Grundexamen inom testsbranschen"},
-         :oppija-oid "1.2.246.562.24.111111111111",
+         :oppija-oid "1.2.246.562.24.11111111110",
          :hankintakoulutus-jarjestaja-oid
-         "1.2.246.562.15.99999125"}))))
+         "1.2.246.562.10.99999125000"}))))
 
 (t/deftest set-paattynyt-test
   (t/testing "Setting paattynyt timestamp"
-    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.11111111112"})
+    (db-oppija/insert-oppija! {:oid "1.2.246.562.24.12111111119"})
     (db-opiskeluoikeus/insert-opiskeluoikeus!
-      {:oppija-oid "1.2.246.562.24.11111111112"
-       :oid "1.2.246.562.15.22222222223"})
+      {:oppija-oid "1.2.246.562.24.12111111119"
+       :oid "1.2.246.562.15.23222222228"})
     (let [timestamp (java.sql.Timestamp. 1568367627293)]
-      (sut/set-opiskeluoikeus-paattynyt! "1.2.246.562.15.22222222223" timestamp)
+      (sut/set-opiskeluoikeus-paattynyt! "1.2.246.562.15.23222222228" timestamp)
       (t/is
         (= (.compareTo
              timestamp
              (get
-               (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.22222222223")
+               (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.23222222228")
                :paattynyt))
            0)))))
 
 (t/deftest oppija-opiskeluoikeus-match-test
   (with-redefs [oph.ehoks.config/config {:enforce-opiskeluoikeus-match? true}]
     (let [opiskeluoikeudet [{:oid "1.2.246.562.15.55003456345"
-                             :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                             :oppilaitos {:oid "1.2.246.562.10.12000000005"
                                           :nimi {:fi "TestiFi"
                                                  :sv "TestiSv"
                                                  :en "TestiEn"}}
@@ -598,7 +598,7 @@
 (t/deftest hankintakoulutus-opiskeluoikeus-test
   (t/testing "Save opiskeluoikeus with sisältyyOpiskeluoikeuteen information"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -620,9 +620,9 @@
           ExceptionInfo
           #"Opiskeluoikeus sisältyy toiseen opiskeluoikeuteen"
           (sut/add-opiskeluoikeus!
-            "1.2.246.562.15.00000000005" "1.2.246.562.24.111111111111")))
+            "1.2.246.562.15.50000000005" "1.2.246.562.24.11111111110")))
       (t/is
-        (nil? (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001"))))))
+        (nil? (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009"))))))
 
 (t/deftest hankintakoulutus-filter-test
   (t/testing "Existing hankintakoulutus is filtered from opiskeluoikeudet"
@@ -668,7 +668,7 @@
 
     (t/testing "Active opiskeluoikeus returns true"
       (utils/with-ticket-auth
-        ["1.2.246.562.10.222222222222"
+        ["1.2.246.562.10.22222222220"
          (fn [_ url __]
            (cond
              (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -689,7 +689,7 @@
 
     (t/testing "Finished opiskeluoikeus returns false"
       (utils/with-ticket-auth
-        ["1.2.246.562.10.222222222222"
+        ["1.2.246.562.10.22222222220"
          (fn [_ url __]
            (cond
              (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -712,7 +712,7 @@
 
     (t/testing "Active opiskeluoikeus matching hoks is filtered from multiple"
       (utils/with-ticket-auth
-        ["1.2.246.562.10.222222222222"
+        ["1.2.246.562.10.22222222220"
          (fn [_ url __]
            (cond
              (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -729,7 +729,7 @@
 
     (t/testing "Active opiskeluoikeus is parsed from hoks and opiskeluoikeudet"
       (utils/with-ticket-auth
-        ["1.2.246.562.10.222222222222"
+        ["1.2.246.562.10.22222222220"
          (fn [_ url __]
            (cond
              (> (.indexOf url "oppijanumerorekisteri-service") -1)
@@ -759,63 +759,63 @@
 (t/deftest delete-opiskeluoikeus-from-index
   (t/testing "Delete opiskeluoikeus from index"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url (str "oppijanumerorekisteri-service/henkilo/"
-                                 "1.2.246.562.24.111111111111")) -1)
+                                 "1.2.246.562.24.11111111110")) -1)
            onr-data
            (> (.indexOf url "/koski/api/opiskeluoikeus") -1)
            {:status 200
             :body (assoc
                     opiskeluoikeus-data
-                    :oid "1.2.246.562.15.00000000001")}))]
-      (sut/add-oppija! "1.2.246.562.24.111111111111")
+                    :oid "1.2.246.562.15.10000000009")}))]
+      (sut/add-oppija! "1.2.246.562.24.11111111110")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.111111111111")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testaaja"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
-         :oppija-oid "1.2.246.562.24.111111111111"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
+         :oppija-oid "1.2.246.562.24.11111111110"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
 
       (db-opiskeluoikeus/delete-opiskeluoikeus-from-index!
-        "1.2.246.562.15.00000000001")
+        "1.2.246.562.15.10000000009")
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
         nil))))
 
 (t/deftest onr-modify-name-change
   (t/testing "onr-modified call has different name compared to oppijaindex"
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (when
           (> (.indexOf url "oppijanumerorekisteri-service") -1)
            onr-data))]
-      (sut/add-oppija! "1.2.246.562.24.111111111111")
+      (sut/add-oppija! "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testaaja"}))
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (when
           (> (.indexOf url "oppijanumerorekisteri-service") -1)
            onr-data-name-changed))]
-      (sut/handle-onrmodified "1.2.246.562.24.111111111111")
+      (sut/handle-onrmodified "1.2.246.562.24.11111111110")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111111")
-        {:oid "1.2.246.562.24.111111111111"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111110")
+        {:oid "1.2.246.562.24.11111111110"
          :nimi "Tero Testaaja-Paivitetty"}))))
 
 (t/deftest onr-modify-slaves-found
@@ -823,7 +823,7 @@
   oppijat-table. /slaves call from ONR returns three oppijas and they all have
   opiskeluoikeus and hoks."
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url (str "oppijanumerorekisteri-service/henkilo/"
@@ -836,38 +836,38 @@
                                  "1.2.246.562.24.46525423540")) -1)
            onr-data-slave3
            (> (.indexOf url (str "/koski/api/opiskeluoikeus/"
-                                 "1.2.246.562.15.00000000001")) -1)
+                                 "1.2.246.562.15.10000000009")) -1)
            {:status 200
             :body (assoc
                     opiskeluoikeus-data
-                    :oid "1.2.246.562.15.00000000001")}
+                    :oid "1.2.246.562.15.10000000009")}
            (> (.indexOf url (str "/koski/api/opiskeluoikeus/"
-                                 "1.2.246.562.15.00000000002")) -1)
+                                 "1.2.246.562.15.20000000008")) -1)
            {:status 200
             :body (assoc
                     opiskeluoikeus-data
-                    :oid "1.2.246.562.15.00000000002")}
+                    :oid "1.2.246.562.15.20000000008")}
            (> (.indexOf url (str "/koski/api/opiskeluoikeus/"
-                                 "1.2.246.562.15.00000000003")) -1)
+                                 "1.2.246.562.15.30000000007")) -1)
            {:status 200
             :body (assoc
                     opiskeluoikeus-data
-                    :oid "1.2.246.562.15.00000000003")}))]
+                    :oid "1.2.246.562.15.30000000007")}))]
       (sut/add-oppija! "1.2.246.562.24.30738063716")
       (sut/add-oppija! "1.2.246.562.24.20043052079")
       (sut/add-oppija! "1.2.246.562.24.46525423540")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000001" "1.2.246.562.24.30738063716")
+        "1.2.246.562.15.10000000009" "1.2.246.562.24.30738063716")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000002" "1.2.246.562.24.20043052079")
+        "1.2.246.562.15.20000000008" "1.2.246.562.24.20043052079")
       (sut/add-opiskeluoikeus!
-        "1.2.246.562.15.00000000003" "1.2.246.562.24.46525423540")
+        "1.2.246.562.15.30000000007" "1.2.246.562.24.46525423540")
       (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.30738063716"
-                             :opiskeluoikeus-oid "1.2.246.562.15.00000000001"})
+                             :opiskeluoikeus-oid "1.2.246.562.15.10000000009"})
       (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.20043052079"
-                             :opiskeluoikeus-oid "1.2.246.562.15.00000000002"})
+                             :opiskeluoikeus-oid "1.2.246.562.15.20000000008"})
       (db-hoks/insert-hoks! {:oppija-oid "1.2.246.562.24.46525423540"
-                             :opiskeluoikeus-oid "1.2.246.562.15.00000000003"})
+                             :opiskeluoikeus-oid "1.2.246.562.15.30000000007"})
       (utils/eq
         (sut/get-oppija-by-oid "1.2.246.562.24.30738063716")
         {:oid "1.2.246.562.24.30738063716"
@@ -881,70 +881,70 @@
         {:oid "1.2.246.562.24.46525423540"
          :nimi "Sami Testaa"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
          :oppija-oid "1.2.246.562.24.30738063716"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000002")
-        {:oid "1.2.246.562.15.00000000002"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.20000000008")
+        {:oid "1.2.246.562.15.20000000008"
          :oppija-oid "1.2.246.562.24.20043052079"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000003")
-        {:oid "1.2.246.562.15.00000000003"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.30000000007")
+        {:oid "1.2.246.562.15.30000000007"
          :oppija-oid "1.2.246.562.24.46525423540"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}}))
     (utils/with-ticket-auth
-      ["1.2.246.562.10.222222222222"
+      ["1.2.246.562.10.22222222220"
        (fn [_ url __]
          (cond
            (> (.indexOf url (str "slaves")) -1)
            onr-slaves-data
            (> (.indexOf url (str "oppijanumerorekisteri-service"
                                  "/henkilo"
-                                 "/1.2.246.562.24.111111111222")) -1)
+                                 "/1.2.246.562.24.11111111123")) -1)
            onr-data-master))]
-      (sut/handle-onrmodified "1.2.246.562.24.111111111222")
+      (sut/handle-onrmodified "1.2.246.562.24.11111111123")
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111222")
-        {:oid "1.2.246.562.24.111111111222"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111123")
+        {:oid "1.2.246.562.24.11111111123"
          :nimi "Matti Masteri"})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000001")
-        {:oid "1.2.246.562.15.00000000001"
-         :oppija-oid "1.2.246.562.24.111111111222"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.10000000009")
+        {:oid "1.2.246.562.15.10000000009"
+         :oppija-oid "1.2.246.562.24.11111111123"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000002")
-        {:oid "1.2.246.562.15.00000000002"
-         :oppija-oid "1.2.246.562.24.111111111222"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.20000000008")
+        {:oid "1.2.246.562.15.20000000008"
+         :oppija-oid "1.2.246.562.24.11111111123"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
          :osaamisala-nimi {:fi "" :sv ""}})
       (utils/eq
-        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.00000000003")
-        {:oid "1.2.246.562.15.00000000003"
-         :oppija-oid "1.2.246.562.24.111111111222"
-         :oppilaitos-oid "1.2.246.562.10.222222222222"
+        (sut/get-opiskeluoikeus-by-oid! "1.2.246.562.15.30000000007")
+        {:oid "1.2.246.562.15.30000000007"
+         :oppija-oid "1.2.246.562.24.11111111123"
+         :oppilaitos-oid "1.2.246.562.10.22222222220"
          :tutkinto-nimi {:fi "Testialan perustutkinto"
                          :sv "Grundexamen inom testsbranschen"
                          :en "Testing"}
@@ -959,8 +959,8 @@
         (sut/get-oppija-by-oid "1.2.246.562.24.46525423540")
         nil)
       (utils/eq
-        (sut/get-oppija-by-oid "1.2.246.562.24.111111111222")
-        {:oid "1.2.246.562.24.111111111222"
+        (sut/get-oppija-by-oid "1.2.246.562.24.11111111123")
+        {:oid "1.2.246.562.24.11111111123"
          :nimi "Matti Masteri"})
       (utils/eq
         (empty?
@@ -977,7 +977,7 @@
       (utils/eq
         (sort-by :id (map #(select-keys % [:id :oppija-oid])
                           (db-hoks/select-hoks-by-oppija-oid
-                            "1.2.246.562.24.111111111222")))
-        [{:id 1, :oppija-oid "1.2.246.562.24.111111111222"}
-         {:id 2, :oppija-oid "1.2.246.562.24.111111111222"}
-         {:id 3, :oppija-oid "1.2.246.562.24.111111111222"}]))))
+                            "1.2.246.562.24.11111111123")))
+        [{:id 1, :oppija-oid "1.2.246.562.24.11111111123"}
+         {:id 2, :oppija-oid "1.2.246.562.24.11111111123"}
+         {:id 3, :oppija-oid "1.2.246.562.24.11111111123"}]))))

--- a/test/oph/ehoks/schema/oid_test.clj
+++ b/test/oph/ehoks/schema/oid_test.clj
@@ -1,0 +1,78 @@
+(ns oph.ehoks.schema.oid-test
+  (:require [clojure.test :refer [are deftest testing]]
+            [oph.ehoks.schema.oid :refer [OpiskeluoikeusOID
+                                          OppijaOID
+                                          OrganisaatioOID]]
+            [schema.core :as s])
+  (:import [clojure.lang ExceptionInfo]))
+
+(deftest test-opiskeluoikeus-oid-validation
+  (testing "Valid opiskeluoikeus OIDs pass the validation."
+    (are [oid] (s/validate OpiskeluoikeusOID oid)
+      "1.2.246.562.15.41024330544"
+      "1.2.246.562.15.73222573930"
+      "1.2.246.562.15.68533489990"
+      "1.2.246.562.15.80624098275"
+      "1.2.246.562.15.97241700166"
+      "1.2.246.562.15.78573431000"
+      "1.2.246.562.15.298574987110"   ; checksum == 0
+      "1.2.246.562.15.983769802510")) ; checksum == 0
+  (testing "Invalid opiskeluoikeus OIDs won't pass the validation."
+    (are [oid] (thrown? ExceptionInfo (s/validate OpiskeluoikeusOID oid))
+      "asd"
+      "1.2.3"
+      "1.2.246.562.15.09873698279"    ; correct checksum but starts with zero
+      "1.2.246.562.15.1068968963"     ; correct checksum but too few digits
+      "1.2.246.562.15.987369457211"   ; correct checksum but too many digits
+      "1.2.246.562.15.897639829610"   ; checksum != 0
+      "1.2.246.562.24.41024330544"    ; oppija oid node
+      "1.2.246.562.10.73222573930"    ; organisaatio oid node
+      "1.2.246.562.15.41014330544"    ; checksum mismatch
+      "1.2.246.562.15.68533489991"))) ; checksum mismatch
+
+(deftest test-oppija-oid-validation
+  (testing "Valid oppija OIDs pass the validation."
+    (are [oid] (s/validate OppijaOID oid)
+      "1.2.246.562.24.54450598189"
+      "1.2.246.562.24.37998958910"
+      "1.2.246.562.24.92170778843"
+      "1.2.246.562.24.64297803263"
+      "1.2.246.562.24.89826171930"
+      "1.2.246.562.24.16068378700"
+      "1.2.246.562.24.898261719310"   ; checksum == 0
+      "1.2.246.562.24.160683787010")) ; checksum == 0
+  (testing "Invalid oppija OIDs won't pass the validation."
+    (are [oid] (thrown? ExceptionInfo (s/validate OppijaOID oid))
+      "asd"
+      "1.2.3"
+      "1.2.246.562.10.02589689322"    ; correct checksum but starts with zero
+      "1.2.246.562.24.7189698747"     ; correct checksum but too few digits
+      "1.2.246.562.24.639871578679"   ; correct checksum but too many digits
+      "1.2.246.562.15.54450598189"    ; opiskeluoikeus oid node
+      "1.2.246.562.10.37998958910"    ; organisaatio oid node
+      "1.2.246.562.24.642978032610"   ; checksum != 0
+      "1.2.246.562.24.54440598189"    ; checksum mismatch
+      "1.2.246.562.24.37998957910"))) ; checksum mismatch
+
+(deftest test-organisaatio-oid-validation
+  (testing "Valid organisaatio OIDs pass the validation."
+    (are [oid] (s/validate OrganisaatioOID oid)
+      "1.2.246.562.10.92214483247"
+      "1.2.246.562.10.18950669244"
+      "1.2.246.562.10.77831291537"
+      "1.2.246.562.10.38262856784"
+      "1.2.246.562.10.67924833642"
+      "1.2.246.562.10.587342913610"   ; checksum == 0
+      "1.2.246.562.10.143886286710")) ; checksum == 0
+  (testing "Invalid organisaatio OIDs won't pass the validation."
+    (are [oid] (thrown? ExceptionInfo (s/validate OrganisaatioOID oid))
+      "asd"
+      "1.2.3"
+      "1.2.246.562.10.09873698279"    ; correct checksum but starts with zero
+      "1.2.246.562.10.5286980957"     ; correct checksum but too few digits
+      "1.2.246.562.10.289763074597"   ; correct checksum but too many digits
+      "1.2.246.562.15.92214483247"    ; opiskeluoikeus oid node
+      "1.2.246.562.24.18950669244"    ; oppija oid node
+      "1.2.246.562.10.778312915310"   ; checksum != 0
+      "1.2.246.562.10.54440598189"    ; checksum mismatch
+      "1.2.246.562.10.37998957910"))) ; checksum mismatch

--- a/test/oph/ehoks/schema/oid_test.clj
+++ b/test/oph/ehoks/schema/oid_test.clj
@@ -62,20 +62,22 @@
       "1.2.246.562.10.77831291537"
       "1.2.246.562.10.38262856784"
       "1.2.246.562.10.67924833642"
-      "1.2.246.562.10.587342913610"   ; checksum == 0
-      "1.2.246.562.10.143886286710")) ; checksum == 0
+      "1.2.246.562.10.2013110716590316970385" ; These types OIDs also exist
+      "1.2.246.562.10.2014081110425906984827"
+      "1.2.246.562.10.587342913610"
+      "1.2.246.562.10.54440598189"
+      "1.2.246.562.10.37998957910"
+      "1.2.246.562.10.778312915310"
+      "1.2.246.562.10.143886286710"))
   (testing "Invalid organisaatio OIDs won't pass the validation."
     (are [oid] (thrown? ExceptionInfo (s/validate OrganisaatioOID oid))
       "asd"
       "1.2.3"
-      "1.2.246.562.10.09873698279"    ; correct checksum but starts with zero
-      "1.2.246.562.10.5286980957"     ; correct checksum but too few digits
-      "1.2.246.562.10.289763074597"   ; correct checksum but too many digits
+      "1.2.246.562.10.5286980957"
+      "1.2.246.562.10.2897630745971"
+      "1.2.246.562.10.20131107165903169703852"
       "1.2.246.562.15.92214483247"    ; opiskeluoikeus oid node
-      "1.2.246.562.24.18950669244"    ; oppija oid node
-      "1.2.246.562.10.778312915310"   ; checksum != 0
-      "1.2.246.562.10.54440598189"    ; checksum mismatch
-      "1.2.246.562.10.37998957910"))) ; checksum mismatch
+      "1.2.246.562.24.18950669244"))) ; oppija oid node
 
 ;;;; The following tests can be used to test OID validation with data stored in
 ;;;; files. They're commented because it's not necessary to run them everytime.
@@ -91,6 +93,7 @@
 ;       (is (s/validate OppijaOID oid)))))
 
 ; (deftest test-opiskeluoikeus-oid-validation-with-hato-koulutuksenjarjestajat
-;   (let [kj-oids (str/split-lines (slurp "./koulutuksenjarjestajat"))]
-;     (doseq [oid kj-oids]
+;   (let [organisaatio-oids (str/split-lines
+;                             (slurp "./organisaatio_oidit.csv"))]
+;     (doseq [oid organisaatio-oids]
 ;       (is (s/validate OrganisaatioOID oid)))))

--- a/test/oph/ehoks/schema/oid_test.clj
+++ b/test/oph/ehoks/schema/oid_test.clj
@@ -76,3 +76,21 @@
       "1.2.246.562.10.778312915310"   ; checksum != 0
       "1.2.246.562.10.54440598189"    ; checksum mismatch
       "1.2.246.562.10.37998957910"))) ; checksum mismatch
+
+;;;; The following tests can be used to test OID validation with data stored in
+;;;; files. They're commented because it's not necessary to run them everytime.
+
+; (deftest test-opiskeluoikeus-oid-validation-with-hoks-opiskeluoikeus-oids
+;   (let [opiskeluoikeus-oids (str/split-lines (slurp "./opiskeluoikeudet"))]
+;     (doseq [oid opiskeluoikeus-oids]
+;       (is (s/validate OpiskeluoikeusOID oid)))))
+;
+; (deftest test-opiskeluoikeus-oid-validation-with-hoks-oppija-oids
+;   (let [oppija-oids (str/split-lines (slurp "./oppijat"))]
+;     (doseq [oid oppija-oids]
+;       (is (s/validate OppijaOID oid)))))
+
+; (deftest test-opiskeluoikeus-oid-validation-with-hato-koulutuksenjarjestajat
+;   (let [kj-oids (str/split-lines (slurp "./koulutuksenjarjestajat"))]
+;     (doseq [oid kj-oids]
+;       (is (s/validate OrganisaatioOID oid)))))

--- a/test/oph/ehoks/user_test.clj
+++ b/test/oph/ehoks/user_test.clj
@@ -14,96 +14,96 @@
   (testing "Mapping kayttooikeus-service data to eHOKS privileges"
     (with-db
       (eq (user/get-auth-info
-            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.00000000002"
+            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.20000000008"
                               :kayttooikeudet [{:palvelu "EHOKS"
                                                 :oikeus "CRUD"}]}
-                             {:organisaatioOid "1.2.246.562.10.00000000001"
+                             {:organisaatioOid "1.2.246.562.10.10000000009"
                               :kayttooikeudet [{:palvelu "EHOKS"
                                                 :oikeus "OPHPAAKAYTTAJA"}]}]})
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{:read :write :update :delete}
               :roles #{}
               :child-organisations []}
-              {:oid "1.2.246.562.10.00000000001"
+              {:oid "1.2.246.562.10.10000000009"
                :privileges #{:read :write :update :delete}
                :roles #{:oph-super-user}
                :child-organisations []})})
 
       (eq (user/get-auth-info
-            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.00000000002"
+            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.20000000008"
                               :kayttooikeudet [{:palvelu "EHOKS"
                                                 :oikeus "READ"}]}]})
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{:read}
               :roles #{}
               :child-organisations []})})
 
       (eq (user/get-auth-info
-            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.00000000002"
+            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.20000000008"
                               :kayttooikeudet [{:palvelu "SERVICE"
                                                 :oikeus "CRUD"}]}]})
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{}
               :roles #{}
               :child-organisations []})})
 
       (db-oppija/insert-oppija!
-        {:oid "1.2.246.562.24.44000000002"
+        {:oid "1.2.246.562.24.44000000008"
          :nimi "Tellervo Testi"})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.76000000002"
-         :oppija_oid "1.2.246.562.24.44000000002"
-         :oppilaitos_oid "1.2.246.562.10.00000000003"
-         :koulutustoimija_oid "1.2.246.562.10.00000000002"
+        {:oid "1.2.246.562.15.76000000000"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.30000000007"
+         :koulutustoimija_oid "1.2.246.562.10.20000000008"
          :tutkinto-nimi {:fi "Testitutkinto 1"}
          :osaamisala-nimi {:fi "Testiosaamisala numero 1"}})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.76000000003"
-         :oppija_oid "1.2.246.562.24.44000000002"
-         :oppilaitos_oid "1.2.246.562.10.00000000004"
-         :koulutustoimija_oid "1.2.246.562.10.00000000002"
+        {:oid "1.2.246.562.15.76300000007"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.40000000006"
+         :koulutustoimija_oid "1.2.246.562.10.20000000008"
          :tutkinto-nimi {:fi "Testitutkinto 1"}
          :osaamisala-nimi {:fi "Testiosaamisala numero 1"}})
-      (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76000000002"
-                             :oppija_oid "1.2.246.562.24.44000000002"
+      (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76000000000"
+                             :oppija_oid "1.2.246.562.24.44000000008"
                              :ensikertainen_hyvaksyminen
                              (c/to-sql-date (c/from-string "2019-07-17"))})
-      (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76000000003"
-                             :oppija_oid "1.2.246.562.24.44000000002"
+      (db-hoks/insert-hoks! {:opiskeluoikeus_oid "1.2.246.562.15.76300000007"
+                             :oppija_oid "1.2.246.562.24.44000000008"
                              :ensikertainen_hyvaksyminen
                              (c/to-sql-date (c/from-string "2019-07-17"))})
 
       (eq (user/get-auth-info
-            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.00000000002"
+            {:organisaatiot [{:organisaatioOid "1.2.246.562.10.20000000008"
                               :kayttooikeudet [{:palvelu "SERVICE"
                                                 :oikeus "CRUD"}]}]})
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{}
               :roles #{}
-              :child-organisations ["1.2.246.562.10.00000000003"
-                                    "1.2.246.562.10.00000000004"]})}))))
+              :child-organisations ["1.2.246.562.10.30000000007"
+                                    "1.2.246.562.10.40000000006"]})}))))
 
 (deftest oph-super-user
   (testing "Check if user is OPH super user"
     (is (user/oph-super-user?
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000003"
+           '({:oid "1.2.246.562.10.30000000007"
               :privileges #{}
               :roles #{}}
-              {:oid "1.2.246.562.10.00000000001"
+              {:oid "1.2.246.562.10.10000000009"
                :privileges #{}
                :roles #{:oph-super-user}}
-              {:oid "1.2.246.562.10.00000000002"
+              {:oid "1.2.246.562.10.20000000008"
                :privileges #{}
                :roles #{}})}))
     (is (not
           (user/oph-super-user?
             {:organisation-privileges
-             '({:oid "1.2.246.562.10.00000000001"
+             '({:oid "1.2.246.562.10.10000000009"
                 :privileges #{}
                 :roles #{}})})))))
 
@@ -113,48 +113,48 @@
       (fn [url options]
         (cond
           (.endsWith
-            url "/rest/organisaatio/v4/1.2.246.562.10.00000000003")
+            url "/rest/organisaatio/v4/1.2.246.562.10.30000000007")
           {:status 200
            :body {:parentOidPath
-                  "|1.2.246.562.10.00000000001|1.2.246.562.10.00000000002"}}
+                  "|1.2.246.562.10.10000000009|1.2.246.562.10.20000000008"}}
           (.endsWith
-            url "/rest/organisaatio/v4/1.2.246.562.10.00000000001")
+            url "/rest/organisaatio/v4/1.2.246.562.10.10000000009")
           {:status 200
            :body {}}
           (.endsWith
-            url "/rest/organisaatio/v4/1.2.246.562.10.00000000002")
+            url "/rest/organisaatio/v4/1.2.246.562.10.20000000008")
           {:status 200
            :body {:parentOidPath
-                  "|1.2.246.562.10.00000000001|"}})))
+                  "|1.2.246.562.10.10000000009|"}})))
 
     (eq (user/get-organisation-privileges
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{:read :write :update :delete}
               :roles #{}}
-              {:oid "1.2.246.562.10.00000000001"
+              {:oid "1.2.246.562.10.10000000009"
                :privileges #{}
                :roles #{:oph-super-user}})}
-          "1.2.246.562.10.00000000002")
+          "1.2.246.562.10.20000000008")
         #{:read :write :update :delete})
 
     (is (nil?
           (user/get-organisation-privileges
             {:organisation-privileges
-             '({:oid "1.2.246.562.10.00000000002"
+             '({:oid "1.2.246.562.10.20000000008"
                 :privileges #{:read :write :update :delete}
                 :roles #{}}
-                {:oid "1.2.246.562.10.00000000003"
+                {:oid "1.2.246.562.10.30000000007"
                  :privileges #{}
                  :roles #{:oph-super-user}})}
-            "1.2.246.562.10.00000000001")))
+            "1.2.246.562.10.10000000009")))
 
     ; From parentOidPath
     (eq (user/get-organisation-privileges
           {:organisation-privileges
-           '({:oid "1.2.246.562.10.00000000002"
+           '({:oid "1.2.246.562.10.20000000008"
               :privileges #{:read :write :update :delete}
               :roles #{}})}
-          "1.2.246.562.10.00000000003")
+          "1.2.246.562.10.30000000007")
         #{:read :write :update :delete})
     (client/reset-functions!)))

--- a/test/oph/ehoks/utils.clj
+++ b/test/oph/ehoks/utils.clj
@@ -139,10 +139,10 @@
           (.endsWith
             url "/koski/api/sure/oids")
           {:status 200
-           :body [{:henkilö {:oid "1.2.246.562.24.44000000001"}
+           :body [{:henkilö {:oid "1.2.246.562.24.44000000008"}
                    :opiskeluoikeudet
-                   [{:oid "1.2.246.562.15.76000000001"
-                     :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                   [{:oid "1.2.246.562.15.76000000000"
+                     :oppilaitos {:oid "1.2.246.562.10.12000000005"
                                   :nimi {:fi "TestiFi"
                                          :sv "TestiSv"
                                          :en "TestiEn"}}
@@ -163,9 +163,9 @@
                     "</cas:authenticationDate></cas:attributes>"
                     "</cas:authenticationSuccess></cas:serviceResponse>")}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000001")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.10000000009")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000001"
+               :body {:oid "1.2.246.562.15.10000000009"
                       :tila {:opiskeluoikeusjaksot
                              [{:alku "2010-01-01"
                                :tila {:koodiarvo "lasna"
@@ -178,25 +178,25 @@
                       [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
                       :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000002")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.20000000008")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000002"
+               :body {:oid "1.2.246.562.15.20000000008"
                       :oppilaitos {:oid (or oppilaitos-oid
-                                            "1.2.246.562.24.47861388608")}
+                                            "1.2.246.562.10.47861388602")}
                       :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000003")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.30000000007")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000003"
+               :body {:oid "1.2.246.562.15.30000000007"
                       :oppilaitos {:oid (or oppilaitos-oid
                                             "1.2.246.562.10.12944436166")}
                       :suoritukset
                       [{:tyyppi {:koodiarvo "tuvaperusopetus"}}]
                       :tyyppi {:koodiarvo "tuva"}}}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000004")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.40000000006")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000004"
+               :body {:oid "1.2.246.562.15.40000000006"
                       :tila {:opiskeluoikeusjaksot
                              [{:alku "2023-10-01"
                                :tila {:koodiarvo "lasna"
@@ -210,9 +210,9 @@
                       [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
                       :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000005")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.50000000005")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000005"
+               :body {:oid "1.2.246.562.15.50000000005"
                       :tila {:opiskeluoikeusjaksot
                              [{:alku "2010-10-01"
                                :tila {:koodiarvo "lasna"
@@ -227,9 +227,9 @@
                       [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
                       :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
               (.endsWith
-                url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000006")
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.60000000004")
               {:status 200
-               :body {:oid "1.2.246.562.15.00000000006"
+               :body {:oid "1.2.246.562.15.60000000004"
                       :tila {:opiskeluoikeusjaksot
                              [{:alku "2010-12-01"
                                :tila {:koodiarvo "eronnut"
@@ -254,7 +254,7 @@
                          :kayttooikeudet [{:palvelu "EHOKS"
                                            :oikeus "CRUD"}]}]}]}
               (.endsWith
-                url "/rest/organisaatio/v4/1.2.246.562.24.47861388608")
+                url "/rest/organisaatio/v4/1.2.246.562.10.47861388602")
               {:status 200
                :body {:parentOidPath
                       "|"}}
@@ -265,7 +265,7 @@
                       "|1.2.246.562.10.00000000001|"}}
               (> (.indexOf url "oppijanumerorekisteri-service/henkilo") -1)
               (let [oid (last (.split url "/"))]
-                (if (= oid "1.2.246.562.24.40404040404")
+                (if (= oid "1.2.246.562.24.40404040406")
                   (throw (ex-info "Not found" {:status 404}))
                   {:status 200
                    :body {:oidHenkilo oid

--- a/test/oph/ehoks/virkailija/auth_test.clj
+++ b/test/oph/ehoks/virkailija/auth_test.clj
@@ -17,7 +17,7 @@
 (defn ticket-response [url options]
   (if (.endsWith url "/kayttooikeus-service/kayttooikeus/kayttaja")
     {:status 200
-     :body [{:oidHenkilo "1.2.246.562.24.11474338833"
+     :body [{:oidHenkilo "1.2.246.562.24.11474338834"
              :username "ehoksvirkailija"
              :organisaatiot
              [{:organisaatioOid "1.2.246.562.10.12944436166"
@@ -128,7 +128,7 @@
         (t/is (= (parse-body (:body response))
                  {:meta {}
                   :data
-                  {:oidHenkilo "1.2.246.562.24.11474338833"
+                  {:oidHenkilo "1.2.246.562.24.11474338834"
                    :isSuperuser false
                    :organisation-privileges
                    [{:oid "1.2.246.562.10.12944436166"

--- a/test/oph/ehoks/virkailija/cas_handler_test.clj
+++ b/test/oph/ehoks/virkailija/cas_handler_test.clj
@@ -18,7 +18,7 @@
 (defn- ticket-response [url options]
   (if (.endsWith url "/kayttooikeus-service/kayttooikeus/kayttaja")
     {:status 200
-     :body [{:oidHenkilo "1.2.246.562.24.11474338833"
+     :body [{:oidHenkilo "1.2.246.562.24.11474338834"
              :username "ehoksvirkailija"
              :organisaatiot
              [{:organisaatioOid "1.2.246.562.10.12944436166"

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -75,16 +75,16 @@
            {:status 200
             :body {:parentOidPath "|"}}
            (.endsWith
-             url "/koski/api/opiskeluoikeus/1.2.246.562.15.00000000001")
+             url "/koski/api/opiskeluoikeus/1.2.246.562.15.10000000009")
            {:status 200
-            :body {:oid "1.2.246.562.15.00000000001"
+            :body {:oid "1.2.246.562.15.10000000009"
                    :oppilaitos {:oid "1.2.246.562.10.12944436166"}
                    :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
            (.endsWith
-             url "/koski/api/opiskeluoikeus/1.2.246.562.15.760000000010")
+             url "/koski/api/opiskeluoikeus/1.2.246.562.15.76000000018")
            {:status 200
-            :body {:oid "1.2.246.562.15.760000000010"
-                   :oppilaitos {:oid "1.2.246.562.10.1200000000010"}
+            :body {:oid "1.2.246.562.15.76000000018"
+                   :oppilaitos {:oid "1.2.246.562.10.12000000013"}
                    :tila {:opiskeluoikeusjaksot
                           [{:alku "2023-07-03"
                             :tila {:koodiarvo "lasna"
@@ -94,26 +94,26 @@
                                    :koodistoVersio 1}}]}
                    :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
            (.endsWith
-             url "/koski/api/opiskeluoikeus/1.2.246.562.15.760000000011")
+             url "/koski/api/opiskeluoikeus/1.2.246.562.15.76000000000")
            {:status 200
-            :body {:oid "1.2.246.562.15.760000000011"
-                   :oppilaitos {:oid "1.2.246.562.10.1200000000010"}
+            :body {:oid "1.2.246.562.15.76000000000"
+                   :oppilaitos {:oid "1.2.246.562.10.12000000013"}
                    :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
            (.contains
              url "/koski/api/opiskeluoikeus/")
            {:status 200
             :body {:oid (last (s/split url #"/"))
-                   :oppilaitos {:oid "1.2.246.562.10.1200000000200"}
+                   :oppilaitos {:oid "1.2.246.562.10.12000000203"}
                    :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}))
        (fn [url options]
          (cond
            (.endsWith
              url "/koski/api/sure/oids")
            {:status 200
-            :body [{:henkilö {:oid "1.2.246.562.24.44000000001"}
+            :body [{:henkilö {:oid "1.2.246.562.24.44000000008"}
                     :opiskeluoikeudet
-                    [{:oid "1.2.246.562.15.76000000001"
-                      :oppilaitos {:oid "1.2.246.562.10.12000000000"
+                    [{:oid "1.2.246.562.15.76000000000"
+                      :oppilaitos {:oid "1.2.246.562.10.12000000005"
                                    :nimi {:fi "TestiFi"
                                           :sv "TestiSv"
                                           :en "TestiEn"}}
@@ -133,7 +133,7 @@
                {:name "Test"
                 :kayttajaTyyppi "VIRKAILIJA"
                 :organisation-privileges
-                [{:oid "1.2.246.562.10.12000000000"
+                [{:oid "1.2.246.562.10.12000000005"
                   :privileges #{:read}}]})))
 
 (t/deftest test-unauthorized-virkailija
@@ -142,7 +142,7 @@
                      (mock/request
                        :get
                        (str base-url "/virkailija/oppijat")
-                       {:oppilaitos-oid "1.2.246.562.10.12000000000"})
+                       {:oppilaitos-oid "1.2.246.562.10.12000000005"})
                      nil)]
       (t/is (= (:status response) 401)))))
 
@@ -153,7 +153,7 @@
                        (mock/request
                          :get
                          (str base-url "/virkailija/oppijat")
-                         {:oppilaitos-oid "1.2.246.562.10.12000000000"}))]
+                         {:oppilaitos-oid "1.2.246.562.10.12000000005"}))]
         (t/is (= (:status response) 200))))))
 
 (t/deftest test-virkailija-privileges
@@ -163,7 +163,7 @@
                        (mock/request
                          :get
                          (str base-url "/virkailija/oppijat")
-                         {:oppilaitos-oid "1.2.246.562.10.12000000001"}))]
+                         {:oppilaitos-oid "1.2.246.562.10.12100000004"}))]
         (t/is (= (:status response) 403))))))
 
 (defn- get-search
@@ -180,55 +180,55 @@
               (mock/request
                 :get
                 (str base-url "/virkailija/oppijat")
-                (assoc params :oppilaitos-oid "1.2.246.562.10.12000000000"))))]
+                (assoc params :oppilaitos-oid "1.2.246.562.10.12000000005"))))]
       (t/is (= (:status response) 200))
       (utils/parse-body (:body response))))
   ([params] (get-search params nil)))
 
 (defn- add-oppijat []
-  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+  (v-utils/add-oppija {:oid "1.2.246.562.24.43000000009"
                        :nimi "Teuvo Testaaja"
-                       :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
-                       :oppilaitos-oid "1.2.246.562.10.12000000000"
+                       :opiskeluoikeus-oid "1.2.246.562.15.76100000002"
+                       :oppilaitos-oid "1.2.246.562.10.12000000005"
                        :tutkinto-nimi {:fi "Testitutkinto 1"
                                        :sv "Testskrivning 1"}
                        :osaamisala-nimi
                        {:fi "Testiosaamisala numero 1" :sv "Kunnande 1"}
                        :koulutustoimija-oid ""})
-  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000002"
+  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                        :nimi "Tellervo Testi"
-                       :opiskeluoikeus-oid "1.2.246.562.15.76000000002"
-                       :oppilaitos-oid "1.2.246.562.10.12000000001"
+                       :opiskeluoikeus-oid "1.2.246.562.15.76200000009"
+                       :oppilaitos-oid "1.2.246.562.10.12100000004"
                        :tutkinto-nimi {:fi "Testitutkinto 2"
                                        :sv "Testskrivning 2"}
                        :osaamisala-nimi
                        {:fi "Testiosaamisala numero 2" :sv "Kunnande 2"}
                        :koulutustoimija-oid ""})
-  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000003"
+  (v-utils/add-oppija {:oid "1.2.246.562.24.45000000007"
                        :nimi "Olli Oppija"
-                       :opiskeluoikeus-oid "1.2.246.562.15.76000000003"
-                       :oppilaitos-oid "1.2.246.562.10.12000000000"
+                       :opiskeluoikeus-oid "1.2.246.562.15.76300000007"
+                       :oppilaitos-oid "1.2.246.562.10.12000000005"
                        :tutkinto-nimi {:fi "Testitutkinto 3"
                                        :sv "Testskrivning 3"}
                        :osaamisala-nimi {:fi "Osaamisala Kolme"
                                          :sv "Kunnande 3"}
                        :koulutustoimija-oid ""})
-  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000004"
+  (v-utils/add-oppija {:oid "1.2.246.562.24.46000000006"
                        :nimi "Oiva Oppivainen"
-                       :opiskeluoikeus-oid "1.2.246.562.15.76000000004"
-                       :oppilaitos-oid "1.2.246.562.10.12000000000"
+                       :opiskeluoikeus-oid "1.2.246.562.15.76400000006"
+                       :oppilaitos-oid "1.2.246.562.10.12000000005"
                        :tutkinto-nimi {:fi "Tutkinto 4"}
                        :koulutustoimija-oid ""}))
 
 (defn- add-hoksit []
-  (v-utils/add-hoks {:oid "1.2.246.562.24.44000000001"
-                     :opiskeluoikeus-oid "1.2.246.562.15.76000000001"})
-  (v-utils/add-hoks {:oid "1.2.246.562.24.44000000002"
-                     :opiskeluoikeus-oid "1.2.246.562.15.76000000002"})
-  (v-utils/add-hoks {:oid "1.2.246.562.24.44000000003"
-                     :opiskeluoikeus-oid "1.2.246.562.15.76000000003"})
-  (v-utils/add-hoks {:oid "1.2.246.562.24.44000000004"
-                     :opiskeluoikeus-oid "1.2.246.562.15.76000000004"}))
+  (v-utils/add-hoks {:oid "1.2.246.562.24.43000000009"
+                     :opiskeluoikeus-oid "1.2.246.562.15.76100000002"})
+  (v-utils/add-hoks {:oid "1.2.246.562.24.44000000008"
+                     :opiskeluoikeus-oid "1.2.246.562.15.76200000009"})
+  (v-utils/add-hoks {:oid "1.2.246.562.24.45000000007"
+                     :opiskeluoikeus-oid "1.2.246.562.15.76300000007"})
+  (v-utils/add-hoks {:oid "1.2.246.562.24.46000000006"
+                     :opiskeluoikeus-oid "1.2.246.562.15.76400000006"}))
 
 (t/deftest get-oppijat-without-filtering
   (t/testing "GET virkailija oppijat without any search filters"
@@ -241,9 +241,9 @@
         (t/is (= (set (map :hoks-id (:data body)))
                  #{1 3 4}))
         (t/is (= (set (map :oid (:data body)))
-                 #{"1.2.246.562.24.44000000004"
-                   "1.2.246.562.24.44000000003"
-                   "1.2.246.562.24.44000000001"}))))))
+                 #{"1.2.246.562.24.46000000006"
+                   "1.2.246.562.24.45000000007"
+                   "1.2.246.562.24.43000000009"}))))))
 
 (t/deftest get-oppijat-with-name-filter
   (t/testing "GET virkailija oppijat with name filtered"
@@ -255,7 +255,7 @@
         (t/is (= (get-in body [:meta :total-count]) 1))
         (t/is (= (get-in body [:data 0 :hoks-id]) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000001"))))))
+                 "1.2.246.562.24.43000000009"))))))
 
 (t/deftest get-oppijat-with-hoks-id
   (t/testing "oppijat endpoint returns correct result by exact hoks-id"
@@ -265,7 +265,7 @@
       (let [body (get-search {:hoks-id 3})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (:total-count (:meta body)) 1))
-        (t/is (= (get-in body [:data 0 :oid]) "1.2.246.562.24.44000000003"))
+        (t/is (= (get-in body [:data 0 :oid]) "1.2.246.562.24.45000000007"))
         (t/is (= (get-in body [:data 0 :hoks-id]) 3)))
       (let [body (get-search {:hoks-id 30033})]
         (t/is (= (count (:data body)) 0))
@@ -282,9 +282,9 @@
         (t/is (= (count (:data body)) 2))
         (t/is (= (get-in body [:meta :total-count]) 2))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000003"))
+                 "1.2.246.562.24.45000000007"))
         (t/is (= (get-in body [:data 1 :oid])
-                 "1.2.246.562.24.44000000004"))))))
+                 "1.2.246.562.24.46000000006"))))))
 
 (t/deftest get-oppijat-with-name-filter-and-order-asc
   (t/testing "GET virkailija oppijat ordered ascending and filtered with name"
@@ -296,9 +296,9 @@
         (t/is (= (count (:data body)) 2))
         (t/is (= (get-in body [:meta :total-count]) 2))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000004"))
+                 "1.2.246.562.24.46000000006"))
         (t/is (= (get-in body [:data 1 :oid])
-                 "1.2.246.562.24.44000000003"))))))
+                 "1.2.246.562.24.45000000007"))))))
 
 (t/deftest get-oppijat-filtered-with-tutkinto-and-osaamisala
   (t/testing "GET virkailija oppijat filtered with tutkinto and osaamisala"
@@ -310,7 +310,7 @@
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:meta :total-count]) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000003"))))))
+                 "1.2.246.562.24.45000000007"))))))
 
 (t/deftest oppijat-sql-injection
   (t/testing "oppijat endpoint doesn't have the SQL injection it used to"
@@ -334,137 +334,137 @@
         (t/is (= (count (:data body)) 2))
         (t/is (= (get-in body [:meta :total-count]) 2))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000003"))
+                 "1.2.246.562.24.45000000007"))
         (t/is (= (get-in body [:data 1 :oid])
-                 "1.2.246.562.24.44000000001"))))))
+                 "1.2.246.562.24.43000000009"))))))
 
 (t/deftest get-oppijat-with-swedish-locale-without-translation
   (t/testing
    "Doesn't have swedish translation and no search filters, shouldn't filter"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000003"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.45000000007"
                            :nimi "Olli Oppija"
-                           :opiskeluoikeus-oid "1.2.246.562.15.76000000003"
-                           :oppilaitos-oid "1.2.246.562.10.12000000000"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76300000007"
+                           :oppilaitos-oid "1.2.246.562.10.12000000005"
                            :tutkinto-nimi {:fi "Testitutkinto 3"
                                            :sv "Testskrivning 3"}
                            :osaamisala-nimi {:fi "Osaamisala Kolme"}
                            :koulutustoimija-oid ""})
-      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000003"
-                         :opiskeluoikeus-oid "1.2.246.562.15.76000000003"})
+      (v-utils/add-hoks {:oid "1.2.246.562.24.45000000007"
+                         :opiskeluoikeus-oid "1.2.246.562.15.76300000007"})
       (let [body (get-search {:order-by-column "tutkinto"
                               :desc true
                               :locale "sv"})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:meta :total-count]) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000003"))))))
+                 "1.2.246.562.24.45000000007"))))))
 
 (t/deftest test-list-virkailija-oppija-with-multi-opiskeluoikeus
   (t/testing "GET virkailija oppijat"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.760000000020"
-         :oppija_oid "1.2.246.562.24.44000000001"
-         :oppilaitos_oid "1.2.246.562.10.1200000000020"
+        {:oid "1.2.246.562.15.760000000000"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.12000000526"
          :koulutustoimija_oid ""
          :tutkinto-nimi {:fi "Tutkinto 2"}
          :osaamisala-nimi {:fi "Osaamisala 2"}})
-      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000001"
-                         :opiskeluoikeus-oid "1.2.246.562.15.760000000010"})
-      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000001"
-                         :opiskeluoikeus-oid "1.2.246.562.15.760000000020"})
+      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000008"
+                         :opiskeluoikeus-oid "1.2.246.562.15.76000000018"})
+      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000008"
+                         :opiskeluoikeus-oid "1.2.246.562.15.760000000000"})
 
       (let [body (get-search
-                   {:oppilaitos-oid "1.2.246.562.10.1200000000020"}
+                   {:oppilaitos-oid "1.2.246.562.10.12000000526"}
                    {:name "Test"
                     :kayttajaTyyppi "VIRKAILIJA"
-                    :oidHenkilo "1.2.246.562.24.220000000030"
+                    :oidHenkilo "1.2.246.562.24.22000000033"
                     :organisation-privileges
-                    [{:oid "1.2.246.562.10.1200000000020"
+                    [{:oid "1.2.246.562.10.12000000526"
                       :privileges #{:read}}]})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000001")))
+                 "1.2.246.562.24.44000000008")))
       (let [body (get-search
-                   {:oppilaitos-oid "1.2.246.562.10.1200000000010"}
+                   {:oppilaitos-oid "1.2.246.562.10.12000000013"}
                    {:name "Test"
                     :kayttajaTyyppi "VIRKAILIJA"
-                    :oidHenkilo "1.2.246.562.24.220000000020"
+                    :oidHenkilo "1.2.246.562.24.22000000020"
                     :organisation-privileges
-                    [{:oid "1.2.246.562.10.1200000000010"
+                    [{:oid "1.2.246.562.10.12000000013"
                       :privileges #{:read}}]})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000001"))))))
+                 "1.2.246.562.24.44000000008"))))))
 
 (t/deftest test-list-virkailija-oppija-with-multi-opiskeluoikeus-one-hoks
   (t/testing "GET virkailija oppijat"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.760000000020"
-         :oppija_oid "1.2.246.562.24.44000000001"
-         :oppilaitos_oid "1.2.246.562.10.1200000000020"
+        {:oid "1.2.246.562.15.760000000000"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.12000000526"
          :koulutustoimija_oid ""
          :tutkinto-nimi {:fi "Tutkinto 2"}
          :osaamisala-nimi {:fi "Osaamisala 2"}})
-      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000001"
-                         :opiskeluoikeus-oid "1.2.246.562.15.760000000010"})
+      (v-utils/add-hoks {:oid "1.2.246.562.24.44000000008"
+                         :opiskeluoikeus-oid "1.2.246.562.15.76000000018"})
 
       (let [body (get-search
-                   {:oppilaitos-oid "1.2.246.562.10.1200000000020"}
+                   {:oppilaitos-oid "1.2.246.562.10.12000000526"}
                    {:name "Test"
                     :kayttajaTyyppi "VIRKAILIJA"
-                    :oidHenkilo "1.2.246.562.24.220000000030"
+                    :oidHenkilo "1.2.246.562.24.22000000033"
                     :organisation-privileges
-                    [{:oid "1.2.246.562.10.1200000000020"
+                    [{:oid "1.2.246.562.10.12000000526"
                       :privileges #{:read}}]})]
         (t/is (= (count (:data body)) 0))
         (t/is (= (get-in body [:data 0 :oid])
                  nil)))
       (let [body (get-search
-                   {:oppilaitos-oid "1.2.246.562.10.1200000000010"}
+                   {:oppilaitos-oid "1.2.246.562.10.12000000013"}
                    {:name "Test"
                     :kayttajaTyyppi "VIRKAILIJA"
-                    :oidHenkilo "1.2.246.562.24.220000000020"
+                    :oidHenkilo "1.2.246.562.24.22000000020"
                     :organisation-privileges
-                    [{:oid "1.2.246.562.10.1200000000010"
+                    [{:oid "1.2.246.562.10.12000000013"
                       :privileges #{:read}}]})]
         (t/is (= (count (:data body)) 1))
         (t/is (= (get-in body [:data 0 :oid])
-                 "1.2.246.562.24.44000000001"))))))
+                 "1.2.246.562.24.44000000008"))))))
 
 (t/deftest test-virkailija-with-no-read
   (t/testing "Prevent GET virkailija oppijat without read privilege"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Testi 1"
-                           :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
-                           :oppilaitos-oid "1.2.246.562.10.12000000000"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000000"
+                           :oppilaitos-oid "1.2.246.562.10.12000000005"
                            :koulutustoimija-oid ""})
       (let [response (with-test-virkailija
                        (mock/request
                          :get
                          (str base-url "/virkailija/oppijat")
-                         {:oppilaitos-oid "1.2.246.562.10.12000000000"})
+                         {:oppilaitos-oid "1.2.246.562.10.12000000005"})
                        {:name "Test"
                         :kayttajaTyyppi "VIRKAILIJA"
                         :organisation-privileges
-                        [{:oid "1.2.246.562.10.12000000000"
+                        [{:oid "1.2.246.562.10.12000000005"
                           :privileges #{}}]})]
         (t/is (= (:status response) 403))))))
 
@@ -479,10 +479,10 @@
              {:status 200
               :body {:parentOidPath "|"}}))]
 
-        (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+        (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                              :nimi "Testi 1"
-                             :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
-                             :oppilaitos-oid "1.2.246.562.10.12000000000"
+                             :opiskeluoikeus-oid "1.2.246.562.15.76000000000"
+                             :oppilaitos-oid "1.2.246.562.10.12000000005"
                              :koulutustoimija-oid ""})
         (t/is
           (not
@@ -490,35 +490,35 @@
               {:organisation-privileges
                [{:oid "1.2.246.562.10.12000000002"
                  :privileges #{:read}}]}
-              "1.2.246.562.24.44000000001")))
+              "1.2.246.562.24.44000000008")))
         (t/is
           (not
             (m/virkailija-has-access?
               {:organisation-privileges
-               [{:oid "1.2.246.562.10.12000000000"
+               [{:oid "1.2.246.562.10.12000000005"
                  :privileges #{}}]}
-              "1.2.246.562.24.44000000001")))
+              "1.2.246.562.24.44000000008")))
         (t/is
           (m/virkailija-has-access?
             {:organisation-privileges
-             [{:oid "1.2.246.562.10.12000000000"
+             [{:oid "1.2.246.562.10.12000000005"
                :privileges #{:read}}]}
-            "1.2.246.562.24.44000000001"))))))
+            "1.2.246.562.24.44000000008"))))))
 
 (t/deftest test-virkailija-hoks-write-forbidden
   (t/testing "Virkailija HOKS write is forbidden"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.760000000020"
-         :oppija_oid "1.2.246.562.24.44000000001"
-         :oppilaitos_oid "1.2.246.562.10.1200000000200"
+        {:oid "1.2.246.562.15.760000000000"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.12000000203"
          :tutkinto-nimi {:fi "Testitutkinto 2"}
          :osaamisala-nimi {:fi "Testiosaamisala 2"}})
       (let [response
@@ -528,24 +528,24 @@
                   :post
                   (str
                     base-url
-                    "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
-                {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                 :oppija-oid "1.2.246.562.24.44000000001"
+                    "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
+                {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                 :oppija-oid "1.2.246.562.24.44000000008"
                  :ensikertainen-hyvaksyminen "2018-12-15"
                  :osaamisen-hankkimisen-tarve false})
               {:name "Testivirkailija"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.1200000000200"
+               [{:oid "1.2.246.562.10.12000000203"
                  :privileges #{:write :read :update :delete}}
-                {:oid "1.2.246.562.10.1200000000010"
+                {:oid "1.2.246.562.10.12000000013"
                  :privileges #{:read}}]})]
         (t/is (= (:status response) 403))))))
 
 (defn- create-oppija-for-hoks-post [oppilaitos-oid]
-  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+  (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                        :nimi "Teuvo Testaaja"
-                       :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
+                       :opiskeluoikeus-oid "1.2.246.562.15.76000000000"
                        :oppilaitos-oid oppilaitos-oid
                        :tutkinto-nimi {:fi "Testitutkinto 1"}
                        :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
@@ -558,15 +558,15 @@
         (mock/request
           :post
           (str base-url
-               "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
+               "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
         (merge {:opiskeluoikeus-oid opiskeluoikeus-oid
-                :oppija-oid "1.2.246.562.24.44000000001"
+                :oppija-oid "1.2.246.562.24.44000000008"
                 :ensikertainen-hyvaksyminen "2018-12-15"
                 :osaamisen-hankkimisen-tarve false}
                additional-keys))
       {:name "Testivirkailija"
        :kayttajaTyyppi "VIRKAILIJA"
-       :oidHenkilo "1.2.246.562.24.44000000333"
+       :oidHenkilo "1.2.246.562.24.44000000338"
        :organisation-privileges
        [{:oid organisaatio-oid
          :privileges #{:write :read :update :delete}}]}))
@@ -576,20 +576,20 @@
 (t/deftest test-virkailija-hoks-forbidden
   (t/testing "Virkailija HOKS forbidden"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.76000000001"
-                           :oppilaitos-oid "1.2.246.562.10.12000000000"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000000"
+                           :oppilaitos-oid "1.2.246.562.10.12000000005"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (let [response
             (post-new-hoks
-              "1.2.246.562.15.00000000001" "1.2.246.562.10.12000000001")]
+              "1.2.246.562.15.10000000009" "1.2.246.562.10.12100000004")]
         (t/is (= (:status response) 403)))
       (let [hoks-db (db-hoks/insert-hoks!
-                      {:opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                       :oppija-oid "1.2.246.562.24.44000000001"
+                      {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                       :oppija-oid "1.2.246.562.24.44000000008"
                        :osaamisen-hankkimisen-tarve false
                        :ensikertainen-hyvaksyminen
                        (java.time.LocalDate/of 2018 12 15)})
@@ -599,12 +599,12 @@
                 :get
                 (str
                   base-url
-                  "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit/"
+                  "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit/"
                   (:id hoks-db)))
               {:name "Testivirkailija"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.12000000001"
+               [{:oid "1.2.246.562.10.12100000004"
                  :privileges #{:write :read :update :delete}}]})]
         (t/is (= (:status response) 403))))))
 
@@ -615,9 +615,9 @@
       (get-in (utils/parse-body (:body post-response)) [:data :uri]))
     {:name "Testivirkailija"
      :kayttajaTyyppi "VIRKAILIJA"
-     :oidHenkilo "1.2.246.562.24.44000000333"
+     :oidHenkilo "1.2.246.562.24.44000000338"
      :organisation-privileges
-     [{:oid "1.2.246.562.10.12000000001"
+     [{:oid "1.2.246.562.10.12000000005"
        :privileges #{:write :read :update :delete}}]}))
 
 (def hato-data
@@ -627,7 +627,7 @@
     "Ei poikkeamia."
     :osaamisen-osoittaminen
     [{:jarjestaja
-      {:oppilaitos-oid "1.2.246.562.10.54453924330"}
+      {:oppilaitos-oid "1.2.246.562.10.54453924331"}
       :nayttoymparisto {:nimi "Testiympäristö 2"
                         :y-tunnus "1234567-1"
                         :kuvaus "Testi test"}
@@ -636,7 +636,7 @@
       :koulutuksen-jarjestaja-osaamisen-arvioijat
       [{:nimi "Timo Testaaja"
         :organisaatio
-        {:oppilaitos-oid "1.2.246.562.10.54452521332"}}]
+        {:oppilaitos-oid "1.2.246.562.10.54452521336"}}]
       :tyoelama-osaamisen-arvioijat
       [{:nimi "Taneli Työmies"
         :organisaatio {:nimi "Tanelin Paja Ky"
@@ -649,7 +649,7 @@
     [{:jarjestajan-edustaja
       {:nimi "Ville Valvoja"
        :rooli "Valvojan apulainen"
-       :oppilaitos-oid "1.2.246.562.10.54451211340"}
+       :oppilaitos-oid "1.2.246.562.10.54451211343"}
       :osaamisen-hankkimistapa-koodi-uri
       "osaamisenhankkimistapa_oppisopimus"
       :osaamisen-hankkimistapa-koodi-versio 2
@@ -674,14 +674,14 @@
       :hankkijan-edustaja
       {:nimi "Heikki Hankkija"
        :rooli "Opettaja"
-       :oppilaitos-oid "1.2.246.562.10.54452422420"}
+       :oppilaitos-oid "1.2.246.562.10.54452422428"}
       :alku "2019-01-11"
       :loppu "2019-03-14"
       :yksiloiva-tunniste "testi-yksilöivä-tunniste"}
      {:jarjestajan-edustaja
       {:nimi "Ville Valvoja"
        :rooli "Valvojan apulainen"
-       :oppilaitos-oid "1.2.246.562.10.54451211340"}
+       :oppilaitos-oid "1.2.246.562.10.54451211343"}
       :osaamisen-hankkimistapa-koodi-uri "osaamisenhankkimistapa_oppisopimus"
       :osaamisen-hankkimistapa-koodi-versio 2
       :oppisopimuksen-perusta-koodi-uri "oppisopimuksenperusta_01"
@@ -699,18 +699,18 @@
       :hankkijan-edustaja
       {:nimi "Heikki Hankkija"
        :rooli "Opettaja"
-       :oppilaitos-oid "1.2.246.562.10.54452422420"}
+       :oppilaitos-oid "1.2.246.562.10.54452422428"}
       :alku "2023-01-11"
       :loppu "2023-03-14"}]
-    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54411232222"}])
+    :koulutuksen-jarjestaja-oid "1.2.246.562.10.54411232223"}])
 
 (t/deftest test-virkailija-create-hoks
   (t/testing "POST hoks virkailija"
     (utils/with-db
-      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
       (let [post-response
             (post-new-hoks
-              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010"
+              "1.2.246.562.15.76000000018" "1.2.246.562.10.12000000013"
               {:hankittavat-ammat-tutkinnon-osat hato-data})
             get-response (get-created-hoks post-response)]
         (let [body (utils/parse-body (:body get-response))]
@@ -737,12 +737,12 @@
   (t/testing "Error thrown from koski is propagated to handler"
     (utils/with-db
       (logtest/with-log
-        (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+        (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
         (with-redefs [k/get-opiskeluoikeus-info-raw
                       mocked-get-opiskeluoikeus-info-raw]
           (let [post-response
-                (post-new-hoks "1.2.246.562.15.760000000010"
-                               "1.2.246.562.10.1200000000010")]
+                (post-new-hoks "1.2.246.562.15.76000000018"
+                               "1.2.246.562.10.12000000013")]
             (t/is (= (:status post-response) 400)
                   (str "Log entries:" (logtest/the-log)))
             (t/is (= (utils/parse-body (:body post-response))
@@ -750,7 +750,7 @@
 
 (defn mocked-get-oo-tuva [oid]
   {:oid oid
-   :oppilaitos {:oid "1.2.246.562.10.1200000000010"}
+   :oppilaitos {:oid "1.2.246.562.10.12000000013"}
    :tyyppi {:koodiarvo "tuva"}})
 
 (t/deftest test-tuva-hoks-with-tuva-opiskeluoikeus-oid-fails
@@ -758,14 +758,14 @@
                   "tuva-opiskeluoikeus-oid")
     (utils/with-db
       (logtest/with-log
-        (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+        (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
         (with-redefs [k/get-opiskeluoikeus-info-raw
                       mocked-get-oo-tuva]
           (let [post-response
-                (post-new-hoks "1.2.246.562.15.760000000010"
-                               "1.2.246.562.10.1200000000010"
+                (post-new-hoks "1.2.246.562.15.76000000018"
+                               "1.2.246.562.10.12000000013"
                                {:tuva-opiskeluoikeus-oid
-                                "1.2.246.562.15.760000000010"
+                                "1.2.246.562.15.76000000018"
                                 :hankittavat-koulutuksen-osat
                                 [{:koulutuksen-osa-koodi-uri
                                   "koulutuksenosattuva_104"
@@ -774,26 +774,26 @@
                                   :loppu "2022-09-21"
                                   :laajuus 10}]})]
             (t/is (= (:status post-response) 400))
-            (t/is (logtest/logged? "audit" :info #"failure.*24.44000000001")
+            (t/is (logtest/logged? "audit" :info #"failure.*24.44000000008")
                   (str "log entries:" (logtest/the-log)))
             (t/is (re-find #"Ota tuva-opiskeluoikeus-oid pois"
                            (slurp (:body post-response))))))))))
 
 (defn mocked-get-oo-non-tuva [oid]
   {:oid oid
-   :oppilaitos {:oid "1.2.246.562.10.1200000000010"}
+   :oppilaitos {:oid "1.2.246.562.10.12000000013"}
    :tyyppi {:koodiarvo "ammatillinenkoulutus"}})
 
 (t/deftest test-hoks-with-hankittavat-koulutuksen-osat
   (t/testing (str "Error is thrown if trying to save (non-tuva) hoks with "
                   "hankittavat-koulutuksen-osat")
     (utils/with-db
-      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
       (with-redefs [k/get-opiskeluoikeus-info-raw
                     mocked-get-oo-non-tuva]
         (let [post-response
-              (post-new-hoks "1.2.246.562.15.760000000010"
-                             "1.2.246.562.10.1200000000010"
+              (post-new-hoks "1.2.246.562.15.76000000018"
+                             "1.2.246.562.10.12000000013"
                              {:hankittavat-koulutuksen-osat
                               [{:koulutuksen-osa-koodi-uri
                                 "koulutuksenosattuva_104"
@@ -818,8 +818,8 @@
       (with-redefs [oph.ehoks.external.oppijanumerorekisteri/find-student-by-oid
                     mocked-find-student-by-oid]
         (let [post-response
-              (post-new-hoks "1.2.246.562.15.760000000010"
-                             "1.2.246.562.10.1200000000010")]
+              (post-new-hoks "1.2.246.562.15.76000000018"
+                             "1.2.246.562.10.12000000013")]
           (t/is (= (:status post-response) 400))
           (t/is (= (utils/parse-body (:body post-response))
                    {:error "Oppija not found in Oppijanumerorekisteri"})))))))
@@ -827,10 +827,10 @@
 (t/deftest test-virkailija-patch-hoks
   (t/testing "PATCH hoks virkailija"
     (utils/with-db
-      (create-oppija-for-hoks-post "1.2.246.562.24.44000000001")
+      (create-oppija-for-hoks-post "1.2.246.562.24.44000000008")
       (let [post-response
             (post-new-hoks
-              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010")
+              "1.2.246.562.15.76000000018" "1.2.246.562.10.12000000013")
             body (utils/parse-body (:body post-response))
             hoks-url (get-in body [:data :uri])
             patch-response
@@ -844,7 +844,7 @@
               {:name "Testivirkailija"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.1200000000010"
+               [{:oid "1.2.246.562.10.12000000013"
                  :privileges #{:write :read :update :delete}}]})
             get-response
             (with-test-virkailija
@@ -854,7 +854,7 @@
               {:name "Testivirkailija"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.1200000000010"
+               [{:oid "1.2.246.562.10.12000000013"
                  :privileges #{:write :read :update :delete}}]})]
         (t/is (get-in (utils/parse-body (:body get-response))
                       [:data :osaamisen-hankkimisen-tarve]))
@@ -864,23 +864,23 @@
   {:name "Testivirkailija"
    :kayttajaTyyppi "VIRKAILIJA"
    :organisation-privileges
-   [{:oid "1.2.246.562.10.1200000000010"
+   [{:oid "1.2.246.562.10.12000000013"
      :privileges #{:write :read :update :delete}}]})
 
 (t/deftest test-prevent-virkailija-patch-hoks
   (t/testing "PATCH hoks virkailija"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (db-opiskeluoikeus/insert-opiskeluoikeus!
-        {:oid "1.2.246.562.15.760000000020"
-         :oppija_oid "1.2.246.562.24.44000000001"
-         :oppilaitos_oid "1.2.246.562.10.1200000000200"
+        {:oid "1.2.246.562.15.760000000000"
+         :oppija_oid "1.2.246.562.24.44000000008"
+         :oppilaitos_oid "1.2.246.562.10.12000000203"
          :tutkinto-nimi {:fi "Testitutkinto 2"}
          :osaamisala-nimi {:fi "Testiosaamisala 2"}})
       (let [response
@@ -890,9 +890,9 @@
                   :post
                   (str
                     base-url
-                    "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
-                {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                 :oppija-oid "1.2.246.562.24.44000000001"
+                    "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
+                {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                 :oppija-oid "1.2.246.562.24.44000000008"
                  :ensikertainen-hyvaksyminen "2018-12-15"
                  :osaamisen-hankkimisen-tarve false})
               virkailija-for-test)
@@ -909,19 +909,19 @@
               {:name "Testivirkailija 2"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.1200000000200"
+               [{:oid "1.2.246.562.10.12000000203"
                  :privileges #{:write :read :update :delete}}
-                {:oid "1.2.246.562.10.1200000000010"
+                {:oid "1.2.246.562.10.12000000013"
                  :privileges #{:read}}]})]
         (t/is (= (:status patch-response) 403))))))
 
 (t/deftest prevent-patch-hoks-with-updated-opiskeluoikeus
   (t/testing "PATCH hoks virkailija"
     (utils/with-db
-      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
       (let [post-response
             (post-new-hoks
-              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010")
+              "1.2.246.562.15.76000000018" "1.2.246.562.10.12000000013")
             body (utils/parse-body (:body post-response))
             hoks-url (get-in body [:data :uri])
             patch-response
@@ -932,7 +932,7 @@
                   hoks-url)
                 {:osaamisen-hankkimisen-tarve true
                  :id (get-in body [:meta :id])
-                 :opiskeluoikeus-oid "1.2.246.562.15.760000000011"})
+                 :opiskeluoikeus-oid "1.2.246.562.15.76000000000"})
               virkailija-for-test)]
         (t/is (= (:status patch-response) 400))
         (t/is (= (utils/parse-body (:body patch-response))
@@ -941,10 +941,10 @@
 (t/deftest prevent-patch-hoks-with-updated-oppija-oid
   (t/testing "PATCH hoks virkailija"
     (utils/with-db
-      (create-oppija-for-hoks-post "1.2.246.562.10.12000000001")
+      (create-oppija-for-hoks-post "1.2.246.562.10.12000000005")
       (let [post-response
             (post-new-hoks
-              "1.2.246.562.15.760000000010" "1.2.246.562.10.1200000000010")
+              "1.2.246.562.15.76000000018" "1.2.246.562.10.12000000013")
             body (utils/parse-body (:body post-response))
             hoks-url (get-in body [:data :uri])
             patch-response
@@ -955,15 +955,15 @@
                   hoks-url)
                 {:osaamisen-hankkimisen-tarve true
                  :id (get-in body [:meta :id])
-                 :oppija-oid "1.2.246.562.10.1200000000011"})
+                 :oppija-oid "1.2.246.562.24.12000000014"})
               virkailija-for-test)]
         (t/is (= (:status patch-response) 400))
         (t/is (= (utils/parse-body (:body patch-response))
                  {:error "Oppija-oid update not allowed!"}))))))
 
 (def hoks-data
-  {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-   :oppija-oid "1.2.246.562.24.44000000001"
+  {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+   :oppija-oid "1.2.246.562.24.44000000008"
    :ensikertainen-hyvaksyminen "2018-12-15"
    :osaamisen-hankkimisen-tarve false})
 
@@ -971,10 +971,10 @@
   (t/testing "PUT hoks virkailija"
     (logtest/with-log
       (utils/with-db
-        (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+        (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                              :nimi "Teuvo Testaaja"
-                             :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                             :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                             :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                             :oppilaitos-oid "1.2.246.562.10.12000000013"
                              :tutkinto-nimi {:fi "Testitutkinto 1"}
                              :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                              :koulutustoimija-oid ""})
@@ -985,7 +985,7 @@
                     :post
                     (str
                       base-url
-                      "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
+                      "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
                   hoks-data)
                 virkailija-for-test)
               body (utils/parse-body (:body response))
@@ -1061,10 +1061,10 @@
 (t/deftest test-put-prevent-updating-opiskeluoikeus
   (t/testing "PUT hoks virkailija"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
@@ -1075,7 +1075,7 @@
                   :post
                   (str
                     base-url
-                    "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
+                    "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
                 hoks-data)
               virkailija-for-test)
             body (utils/parse-body (:body response))
@@ -1089,7 +1089,7 @@
                 {:id (get-in body [:meta :id])
                  :osaamisen-hankkimisen-tarve true
                  :ensikertainen-hyvaksyminen "2018-12-15"
-                 :opiskeluoikeus-oid "1.2.246.562.15.760000000011"
+                 :opiskeluoikeus-oid "1.2.246.562.15.76000000000"
                  :hankittavat-ammat-tutkinnon-osat
                  hato-data})
               virkailija-for-test)
@@ -1101,10 +1101,10 @@
 (t/deftest test-put-prevent-updating-oppija-oid
   (t/testing "PUT hoks virkailija"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
@@ -1115,7 +1115,7 @@
                   :post
                   (str
                     base-url
-                    "/virkailija/oppijat/1.2.246.562.24.44000000001/hoksit"))
+                    "/virkailija/oppijat/1.2.246.562.24.44000000008/hoksit"))
                 hoks-data)
               virkailija-for-test)
             body (utils/parse-body (:body response))
@@ -1129,8 +1129,8 @@
                 {:id (get-in body [:meta :id])
                  :osaamisen-hankkimisen-tarve true
                  :ensikertainen-hyvaksyminen "2018-12-15"
-                 :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                 :oppija-oid "1.2.246.562.24.44000000002"
+                 :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                 :oppija-oid "1.2.246.562.24.45000000007"
                  :hankittavat-ammat-tutkinnon-osat
                  hato-data})
               virkailija-for-test)
@@ -1142,16 +1142,16 @@
 (t/deftest test-get-amount
   (t/testing "Test getting the amount of hokses"
     (utils/with-db
-      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000001"
+      (v-utils/add-oppija {:oid "1.2.246.562.24.44000000008"
                            :nimi "Teuvo Testaaja"
-                           :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-                           :oppilaitos-oid "1.2.246.562.10.1200000000010"
+                           :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+                           :oppilaitos-oid "1.2.246.562.10.12000000013"
                            :tutkinto-nimi {:fi "Testitutkinto 1"}
                            :osaamisala-nimi {:fi "Testiosaamisala numero 1"}
                            :koulutustoimija-oid ""})
       (db-hoks/insert-hoks!
-        {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-         :oppija-oid "1.2.246.562.24.44000000001"
+        {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+         :oppija-oid "1.2.246.562.24.44000000008"
          :osaamisen-hankkimisen-tarve false
          :ensikertainen-hyvaksyminen
          (java.time.LocalDate/of 2018 12 15)})
@@ -1165,7 +1165,7 @@
               {:name "Testivirkailija"
                :kayttajaTyyppi "VIRKAILIJA"
                :organisation-privileges
-               [{:oid "1.2.246.562.10.1200000000010"
+               [{:oid "1.2.246.562.10.12000000013"
                  :privileges #{:write :read :update :delete}
                  :oikeus "OPHPAAKAYTTAJA"
                  :palvelu "EHOKS"
@@ -1184,16 +1184,16 @@
                        :voimassa_loppupvm (str loppupvm "Z")})]
         (utils/with-db
           (v-utils/add-oppija
-            {:oid "1.2.246.562.24.44000000001"
+            {:oid "1.2.246.562.24.44000000008"
              :nimi "Teuvo Testaaja"
-             :opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-             :oppilaitos-oid "1.2.246.562.10.1200000000010"
-             :koulutustoimija-oid "1.2.246.562.10.1200000000011"
+             :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+             :oppilaitos-oid "1.2.246.562.10.12000000013"
+             :koulutustoimija-oid "1.2.246.562.10.1200000000511"
              :tutkinto-nimi {:fi "Testitutkinto 1"}
              :osaamisala-nimi {:fi "Testiosaamisala numero 1"}})
           (db-hoks/insert-hoks!
-            {:opiskeluoikeus-oid "1.2.246.562.15.760000000010"
-             :oppija-oid "1.2.246.562.24.44000000001"
+            {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
+             :oppija-oid "1.2.246.562.24.44000000008"
              :osaamisen-hankkimisen-tarve false
              :ensikertainen-hyvaksyminen
              (java.time.LocalDate/of 2018 12 15)})
@@ -1201,26 +1201,26 @@
             {:kyselylinkki "https://kysely.linkki/ABC123"
              :hoks-id 1
              :tyyppi "aloittaneet"
-             :oppija-oid "1.2.246.562.24.44000000001"
+             :oppija-oid "1.2.246.562.24.44000000008"
              :alkupvm alkupvm
              :lahetystila "ei_lahetetty"})
           (insert-kyselylinkki!
             {:kyselylinkki "https://kysely.linkki/DEF456"
              :hoks-id 1
              :tyyppi "tutkinnonsuorittaneet"
-             :oppija-oid "1.2.246.562.24.44000000001"
+             :oppija-oid "1.2.246.562.24.44000000008"
              :alkupvm alkupvm})
           (let [resp (with-test-virkailija
                        (mock/request
                          :get
                          (str
                            base-url
-                           "/virkailija/oppijat/1.2.246.562.24.44000000001"
+                           "/virkailija/oppijat/1.2.246.562.24.44000000008"
                            "/hoksit/1/opiskelijapalaute"))
                        {:name "Testivirkailija"
                         :kayttajaTyyppi "VIRKAILIJA"
                         :organisation-privileges
-                        [{:oid "1.2.246.562.10.1200000000010"
+                        [{:oid "1.2.246.562.10.12000000013"
                           :privileges #{:write :read :update :delete}
                           :oikeus "OPHPAAKAYTTAJA"
                           :palvelu "EHOKS"
@@ -1238,12 +1238,12 @@
                          :get
                          (str
                            base-url
-                           "/virkailija/oppijat/1.2.246.562.24.44000000001"
+                           "/virkailija/oppijat/1.2.246.562.24.44000000008"
                            "/hoksit/1/opiskelijapalaute"))
                        {:name "Testivirkailija"
                         :kayttajaTyyppi "VIRKAILIJA"
                         :organisation-privileges
-                        [{:oid "1.2.246.562.10.1200000000010"
+                        [{:oid "1.2.246.562.10.12000000013"
                           :privileges #{:write :read :update :delete}
                           :oikeus "OPHPAAKAYTTAJA"
                           :palvelu "EHOKS"
@@ -1254,7 +1254,7 @@
               (= (first (:data body))
                  {:hoks-id           1
                   :tyyppi            "aloittaneet"
-                  :oppija-oid        "1.2.246.562.24.44000000001"
+                  :oppija-oid        "1.2.246.562.24.44000000008"
                   :alkupvm           (str alkupvm)
                   :lahetyspvm        (str alkupvm)
                   :sahkoposti        "testi@testi.fi"

--- a/test/oph/ehoks/virkailija/virkailija_external_test.clj
+++ b/test/oph/ehoks/virkailija/virkailija_external_test.clj
@@ -25,7 +25,7 @@
                      {:virkailija-user {:name "Test"
                                         :kayttajaTyyppi "VIRKAILIJA"
                                         :organisation-privileges
-                                        [{:oid "1.2.246.562.10.12000000000"
+                                        [{:oid "1.2.246.562.10.12000000005"
                                           :privileges #{:read}}]}}})
             app (common-api/create-app
                   handler/app-routes (test-session-store store))]

--- a/test/oph/ehoks/virkailija/virkailija_test_utils.clj
+++ b/test/oph/ehoks/virkailija/virkailija_test_utils.clj
@@ -4,10 +4,10 @@
             [oph.ehoks.db.db-operations.opiskeluoikeus :as db-opiskeluoikeus]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]))
 
-(def dummy-user {:oid "1.2.246.562.24.12312312312"
+(def dummy-user {:oid "1.2.246.562.24.12312312319"
                  :nimi "Teuvo Testaaja"
-                 :opiskeluoikeus-oid "1.2.246.562.15.00000000001"
-                 :oppilaitos-oid "1.2.246.562.10.12000000000"
+                 :opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                 :oppilaitos-oid "1.2.246.562.10.12000000005"
                  :tutkinto-nimi {:fi "Testitutkinto 1" :sv "Testskrivning 1"}
                  :osaamisala-nimi
                  {:fi "Testiosaamisala numero 1" :sv "Kunnande 1"}


### PR DESCRIPTION
## Kuvaus muutoksista

Osana OY-4553 tikettiä on tarkoitus tehdä työkalu OPH-pääkäyttäjille oppijanumeroiden manuaaliseen päivittämiseen "Ylläpito"-välilehdelle. Koska päivityksiä on määrä tehdä käsin (käytännössä luultavasti siis copy-pastetaan oppija-oideja Ylläpito-välilehden kenttiin), on syytä tiukentaa OID:ien validointia, jotta vältetään vahingossa tehdyt virheelliset päivitykset. OID:ien validointi on tottakai hyödyllistä olla olemassa muutenkin: Vaikka järjestelmien välillä pallotellaankin suurimmaksi osin automaattisesti generoituja OID:eja, voi olla että joissain tapauksissa näitä naputellaan myös lähdejärjestelmiin käsipelin.

[OID-generaattori](https://github.com/Opetushallitus/java-utils/blob/master/oid-generator/src/main/java/fi/vm/sade/oidgenerator/OIDGenerator.java) lisää OID:ien loppuosan (viimeinen pisteellä eroteltu numero) loppuun tarkistusnumeron, ja tätä on hyödynnetty tässä PR:ssä tehdyssä validoinnissa (säännöllisten lausekkeiden tiukentamisen lisäksi). Ei ole täysin bullet-proof ratkaisu, mutta tämän pitäisi napata ainakin valtaosa näppäilyvirheistä, esimerkiksi jos copy-pasteamisen yhteydessä OID:in lopusta jää uupumaan yksi numero.

Tuossa OID-generaattorin Luhn-tarkistussumma-algoritmitoteutuksessa on ilmeisesti joskus ollut bugi, jossa tarkistusnumero 0:n sijasta onkin tullut tarkistusnumeroksi 10 :smile: Tällä tavoin generoituja OID:eja on siis olemassa vieläkin, ja niitä näkee jonkin verran esimerkiksi eri organisaatioiden OID:eissa. Tämä seikka on otettu kuitenkin huomioon validoinnissa.

Tein toisen PR:n https://github.com/Opetushallitus/ehoks/pull/573, missä teen pienet muutokset, jotta OPH-pääkäyttäjä voi päivittää hoksia "virkailija"-rajapinnan PATCH-metodilla (nykyisellään kaikki oppijanumeron muutokset on estetty). Vastaavasti `ehoks-ui`-repon puolelle on tulossa "Ylläpito"-välilehdelle "lomake" oppijanumeron päivitykseen: https://github.com/Opetushallitus/ehoks-ui/pull/456

https://jira.eduuni.fi/browse/OY-4553

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
