### PR TITLE
Remove notification code for missing osa-aikaisuustieto (EH-1598)

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -281,14 +281,10 @@
     (oppijaindex/add-hoks-dependents-in-index! hoks)
     (m/check-hoks-access! hoks request)
     (let [hoks-db (h/check-and-save-hoks! hoks)
-          resp-body {:uri (format "%s/%d" (:uri request) (:id hoks-db))}
-          notifications (h/check-for-osa-aikaisuustieto hoks)]
-      (assoc
-        (rest/rest-ok (if (seq notifications)
-                        (assoc resp-body :notifications notifications)
-                        resp-body)
-                      :id (:id hoks-db))
-        :audit-data {:new hoks}))
+          resp-body {:uri (format "%s/%d" (:uri request) (:id hoks-db))}]
+      (-> resp-body
+          (rest/rest-ok :id (:id hoks-db))
+          (assoc :audit-data {:new hoks})))
     (catch Exception e
       (case (:error (ex-data e))
         :disallowed-update (response/bad-request! {:error (.getMessage e)})


### PR DESCRIPTION
## Kuvaus muutoksista

Because osa-aikaisuustieto is mandatory nowadays, this code does not have much point.

https://jira.eduuni.fi/browse/EH-1598

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
