### PR TITLE
Fix validation API by adding `wrap-opiskeluoikeus` middleware

### DIFF
--- a/src/oph/ehoks/validation/handler.clj
+++ b/src/oph/ehoks/validation/handler.clj
@@ -2,6 +2,7 @@
   (:require [compojure.api.sweet :as c-api]
             [oph.ehoks.restful :as rest]
             [oph.ehoks.hoks.schema :as hoks-schema]
+            [oph.ehoks.middleware :refer [wrap-opiskeluoikeus]]
             [schema.core :as s]))
 
 (def routes
@@ -11,6 +12,7 @@
     :tags ["validointi"]
 
     (c-api/POST "/" [:as request]
+      :middleware [wrap-opiskeluoikeus]
       :summary "Validointi uuden HOKSin luontiin"
       :body [hoks hoks-schema/HOKSLuonti]
       :return (rest/response {})


### PR DESCRIPTION
## Kuvaus muutoksista
Validaatio-API:sta puuttui `wrap-opiskeluoikeus` middleware, jolloin opiskeluoikeudesta riippuvat skeematarkistukset epäonnistuvat. Lisätty kyseinen middleware.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
