### PR TITLE
EH-1601: Trimmaa json bodystä kaikki tekstimuotoiset kentät

### DIFF
--- a/src/oph/ehoks/common/schema.clj
+++ b/src/oph/ehoks/common/schema.clj
@@ -75,11 +75,10 @@
 (defn- trim-strings-matcher
   [schema]
   (when (= s/Str schema)
-    (coerce/safe
-      (fn [value]
-        (if (string? value)
-          (str/trim value)
-          value)))))
+    (fn [value]
+      (if (string? value)
+        (str/trim value)
+        value))))
 
 ; https://github.com/metosin/compojure-api/wiki/Coercion#custom-schema-coercion
 (defmethod cc/named-coercion :custom-schema [_]

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -747,7 +747,8 @@
 (def app-routes
   "Virkailija handler app routes"
   (c-api/api
-    {:swagger
+    {:coercion :custom-schema
+     :swagger
      {:ui "/ehoks-virkailija-backend/doc"
       :spec "/ehoks-virkailija-backend/doc/swagger.json"
       :data {:info {:title "eHOKS virkailija backend"


### PR DESCRIPTION
## Kuvaus muutoksista

Trimmaa json bodystä kaikki tekstimuotoiset kentät. Tarve oli trimmata vain työpaikan nimi, mutta tällä trimmautuu kaikki. Ei liene huono asia?

https://jira.eduuni.fi/browse/EH-1601

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
