### PR TITLE
Update AWS dashboard source

### DIFF
--- a/resources/aws-dashboard-source.json
+++ b/resources/aws-dashboard-source.json
@@ -395,15 +395,18 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "m1 + m2", "label": "HTTP 5XX", "id": "e1", "color": "#d62728", "region": "eu-west-1" } ],
-                    [ { "expression": "m3 + m4", "label": "HTTP 4XX", "id": "e2", "color": "#ffbb78", "region": "eu-west-1" } ],
-                    [ { "expression": "m5 + m6", "label": "HTTP 2XX", "id": "e3", "region": "eu-west-1" } ],
+                    [ { "expression": "m1 + m2 + m3", "label": "HTTP 5XX", "id": "e1", "color": "#d62728", "region": "eu-west-1" } ],
+                    [ { "expression": "m4 + m5 + m6", "label": "HTTP 4XX", "id": "e2", "color": "#ffbb78", "region": "eu-west-1" } ],
+                    [ { "expression": "m7 + m8 + m9", "label": "HTTP 2XX", "id": "e3", "region": "eu-west-1" } ],
                     [ "AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "TargetGroup", "targetgroup/sade-ehoks-oppija-FTG/214e9c0025e7c739", "LoadBalancer", "app/sade-ALB/d9414606100fe733", "AvailabilityZone", "eu-west-1b", { "region": "eu-west-1", "color": "#d62728", "id": "m1", "visible": false } ],
                     [ "...", "eu-west-1c", { "color": "#d62728", "region": "eu-west-1", "id": "m2", "visible": false } ],
-                    [ ".", "HTTPCode_Target_4XX_Count", ".", ".", ".", ".", ".", "eu-west-1b", { "region": "eu-west-1", "color": "#ffbb78", "id": "m3", "visible": false } ],
-                    [ "...", "eu-west-1c", { "region": "eu-west-1", "color": "#ffbb78", "id": "m4", "visible": false } ],
-                    [ ".", "HTTPCode_Target_2XX_Count", ".", ".", ".", ".", ".", "eu-west-1b", { "region": "eu-west-1", "color": "#2ca02c", "id": "m5", "visible": false } ],
-                    [ "...", "eu-west-1c", { "region": "eu-west-1", "color": "#2ca02c", "id": "m6", "visible": false } ]
+                    [ "...", "AvailabilityZone", "eu-west-1a", "LoadBalancer", "app/sade-ALB/d9414606100fe733", { "id": "m3", "color": "#d62728", "region": "eu-west-1", "visible": false } ],
+                    [ ".", "HTTPCode_Target_4XX_Count", ".", ".", ".", ".", ".", ".", { "id": "m4", "color": "#ffbb78", "region": "eu-west-1", "visible": false } ],
+                    [ "...", "LoadBalancer", "app/sade-ALB/d9414606100fe733", "AvailabilityZone", "eu-west-1b", { "region": "eu-west-1", "color": "#ffbb78", "id": "m5", "visible": false } ],
+                    [ "...", "eu-west-1c", { "region": "eu-west-1", "color": "#ffbb78", "id": "m6", "visible": false } ],
+                    [ ".", "HTTPCode_Target_2XX_Count", ".", ".", "AvailabilityZone", "eu-west-1a", "LoadBalancer", "app/sade-ALB/d9414606100fe733", { "id": "m7", "color": "#2ca02c", "region": "eu-west-1", "visible": false } ],
+                    [ "...", "LoadBalancer", "app/sade-ALB/d9414606100fe733", "AvailabilityZone", "eu-west-1b", { "region": "eu-west-1", "color": "#2ca02c", "id": "m8", "visible": false } ],
+                    [ "...", "eu-west-1c", { "region": "eu-west-1", "color": "#2ca02c", "id": "m9", "visible": false } ]
                 ],
                 "view": "timeSeries",
                 "stacked": true,


### PR DESCRIPTION
## Kuvaus muutoksista

AWS Dashboard-sorsan päivittäminen. Application ELB:n HTTP status-koodeja monitoroivasta graafista puuttui eu-west-1a Availavility Zonen 2XX/4XX/5XX-statuskoodimetriikat. Näitä ei oltu aiemmin lisätty, kun eivät olleet aiemmalla lisäyskerralla saatavilla.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
