### PR TITLE
EH-1536: schema pois bad requesteista

### DIFF
--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -422,3 +422,12 @@
         (is (= (:status response) 400))
         (is (= (:errors (utils/parse-body (:body response)))
                (expected-error y-tunnus)))))))
+
+(deftest schema-not-present-in-bad-requests
+  (testing ":schema not present in bad requests"
+    (let [response (hoks-utils/mock-st-post
+                     (hoks-utils/create-app nil) base-url {})]
+      (is (= (:status response) 400))
+      (is (nil? (-> (:body response)
+                    (utils/parse-body)
+                    :schema))))))

--- a/test/oph/ehoks/oppija/share_handler_test.clj
+++ b/test/oph/ehoks/oppija/share_handler_test.clj
@@ -65,7 +65,7 @@
                        {:wrong "things"}))
           body (utils/parse-body (:body response))]
       (t/is (= 400 (:status response)))
-      (t/is (:schema body))))
+      (t/is (nil? (:schema body)))))
 
   (t/testing "Shared link end date cannot be in the past"
     (let [response (mock-authenticated


### PR DESCRIPTION
## Kuvaus muutoksista

`:schema` pois bad requestin vastauksen bodystä.

https://jira.eduuni.fi/browse/EH-1536

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
