### PR TITLE
audit logging: exclude paths with `:module-id` from changes list

### DIFF
--- a/src/oph/ehoks/logging/audit.clj
+++ b/src/oph/ehoks/logging/audit.clj
@@ -22,6 +22,9 @@
 (declare vec-changes)
 (declare atom-changes)
 
+; Exclude certain changes based on the last key of the `path`.
+(def exclusions #{:module-id})
+
 (defn- changes
   "Takes an `old-value` and a `new-value` and recursively constructs a sequence
   containing information about the changes between the two values. Each entry in
@@ -46,7 +49,7 @@
 
 (defn atom-changes
   [old-value new-value path]
-  (if (= old-value new-value)
+  (if (or (= old-value new-value) (contains? exclusions (peek path)))
     []
     [(cond->
       {"path" (string/join "." path)}

--- a/test/oph/ehoks/logging/audit_test.clj
+++ b/test/oph/ehoks/logging/audit_test.clj
@@ -17,11 +17,6 @@
          expected-log-entry-on-ahato-update
          expected-log-entry-on-ahato-read)
 
-(defn- vec-remove
-  "Remove element from vector"
-  [coll index]
-  (into (subvec coll 0 index) (subvec coll (inc index))))
-
 (deftest test-handle-audit-logging
   (with-log
     (hoks-utils/with-hoks-and-app
@@ -37,8 +32,7 @@
         (are [actual expected] (= actual expected)
           hoks-create    (expected-log-entry-on-hoks-creation  logseq)
           ahato-creation (expected-log-entry-on-ahato-creation (+ 2 logseq))
-          (update ahato-update "changes" vec-remove 5)
-          (expected-log-entry-on-ahato-update   (+ 3 logseq))
+          ahato-update   (expected-log-entry-on-ahato-update   (+ 3 logseq))
           ahato-read     (expected-log-entry-on-ahato-read     (+ 4 logseq))))
       (utils/clear-db))))
 


### PR DESCRIPTION
## Kuvaus muutoksista

Audit-lokien `changes`-muutoslistassa on suhteettoman paljon `:module-id` päivityksiä. Tässä pikainen korjaus, jolla rajataan muutoslistauksesta pois `:module-id` avaimeen päättyvät polut.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
