### PR TITLE
EH-1649: Muiden oppilaitosten HOKSien näyttäminen virkailijalle

### DIFF
--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -129,14 +129,10 @@
     (let [virkailijan-oppilaitosten-hoksit
           (filter #(user/has-privilege-to-hoks? % ticket-user :read)
                   hoksit)
-          virkailijan-oppilaitosten-opiskeluoikeuksia-active?
-          (any-hoks-has-active-opiskeluoikeus? virkailijan-oppilaitosten-hoksit)
-          has-read-access-to-hoks?
-          (fn [hoks]
-            (or (some #(= (:id %) (:id hoks))
-                      virkailijan-oppilaitosten-hoksit)
-                virkailijan-oppilaitosten-opiskeluoikeuksia-active?))
-          visible-hoksit (filter has-read-access-to-hoks? hoksit)]
+          visible-hoksit (if (any-hoks-has-active-opiskeluoikeus?
+                               virkailijan-oppilaitosten-hoksit)
+                           hoksit
+                           virkailijan-oppilaitosten-hoksit)]
       (assoc (restful/ok visible-hoksit)
              ::audit/target
              {:hoks-ids            (map :id visible-hoksit)

--- a/test/oph/ehoks/virkailija/virkailija_test_utils.clj
+++ b/test/oph/ehoks/virkailija/virkailija_test_utils.clj
@@ -30,6 +30,20 @@
                                         {:fi "Osaamisala suomeksi"
                                          :sv "På svenska"})}))
 
+(defn add-another-opiskeluoikeus [opiskeluoikeus]
+  (db-opiskeluoikeus/insert-opiskeluoikeus!
+    {:oid (:oid opiskeluoikeus)
+     :oppija_oid (:oppija-oid opiskeluoikeus)
+     :oppilaitos_oid (:oppilaitos-oid opiskeluoikeus)
+     :koulutustoimija_oid (:koulutustoimija-oid opiskeluoikeus)
+     :tutkinto-nimi (:tutkinto-nimi opiskeluoikeus
+                                    {:fi "Testialan perustutkinto"
+                                     :sv "Grundexamen inom testsbranschen"
+                                     :en "Testing"})
+     :osaamisala-nimi (:osaamisala-nimi opiskeluoikeus
+                                        {:fi "Osaamisala suomeksi"
+                                         :sv "På svenska"})}))
+
 (defn add-hoks [oppija]
   (db-hoks/insert-hoks! {:oppija-oid (:oid oppija)
                          :opiskeluoikeus-oid (:opiskeluoikeus-oid


### PR DESCRIPTION
## Kuvaus muutoksista

Korjataan muiden oppilaitosten HOKSien näyttäminen virkailijalle niin, että virkailija saa nähdä muiden oppilaitosten HOKSit niin kauan kuin hänen edustamissaan oppilaitoksissaan on (yksikin) HOKS voimassa kyseiselle oppijalle.

https://jira.eduuni.fi/browse/EH-1649

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
