### PR TITLE
EH-1451: re-enable deleting contact info from over 3 month old HOKSes/OHTs

### DIFF
--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -169,6 +169,9 @@
       "heratepalvelu/select_paattyneet_tyoelamajaksot_hyto.sql")
 (defq select-paattyneet-tyoelamajaksot-3kk
       "hoksit/select_paattyneet_tyoelamajaksot_3kk.sql")
+;; TODO: tätä voisi optimoida hajottamalla eri kyselyihin päättyneet
+;; HOKSit ja "unohtuneet" HOKSit jotka etsitään
+;; osaamisenhankkimisjaksojen vanhenemisen perusteella
 (defq select-vanhat-hoksit-having-yhteystiedot
       "hoksit/select_vanhat_hoksit_having_yhteystiedot.sql")
 (defq select-amisherate-kasittelytilat-by-hoks-id

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -113,8 +113,9 @@
         :header-params [caller-id :- s/Str]
         :return {:hankkimistapa-ids [s/Int]}
         (let [hankkimistavat (db-hoks/delete-tyopaikkaohjaajan-yhteystiedot!)]
-          ; TODO lisää auditlog entry, kun siivous enabloidaan
-          (restful/ok {:hankkimistapa-ids hankkimistavat})))
+          (assoc
+            (restful/ok {:hankkimistapa-ids hankkimistavat})
+            ::audit/target {:oht-ids hankkimistavat})))
 
       (c-api/DELETE "/opiskelijan-yhteystiedot" []
         :summary "Poistaa opiskelijan yhteystiedot yli kolme kuukautta
@@ -124,5 +125,6 @@
         :header-params [caller-id :- s/Str]
         :return {:hoks-ids [s/Int]}
         (let [hoks-ids (db-hoks/delete-opiskelijan-yhteystiedot!)]
-          ; TODO lisää auditlog entry, kun siivous enabloidaan
-          (restful/ok {:hoks-ids hoks-ids}))))))
+          (assoc
+            (restful/ok {:hoks-ids hoks-ids})
+            :audit/target {:hoks-ids hoks-ids}))))))

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -107,23 +107,22 @@
 
       (c-api/DELETE "/tyopaikkaohjaajan-yhteystiedot" []
         :summary "Poistaa työpaikkaohjaajan yhteystiedot yli kolme kuukautta
-            sitten päättyneistä työpaikkajaksoista. Käsittelee max 5000 jaksoa
+            sitten päättyneistä työpaikkajaksoista. Käsittelee max 100 jaksoa
             kerrallaan. Palauttaa kyseisten jaksojen id:t (hankkimistapa-id)
-            herätepalvelua varten. POISTETTU KÄYTÖSTÄ TILAPÄISESTI."
+            herätepalvelua varten."
         :header-params [caller-id :- s/Str]
         :return {:hankkimistapa-ids [s/Int]}
-        (let [hankkimistavat
-              []] ;(db-hoks/delete-tyopaikkaohjaajan-yhteystiedot!)]
+        (let [hankkimistavat (db-hoks/delete-tyopaikkaohjaajan-yhteystiedot!)]
           ; TODO lisää auditlog entry, kun siivous enabloidaan
           (restful/ok {:hankkimistapa-ids hankkimistavat})))
 
       (c-api/DELETE "/opiskelijan-yhteystiedot" []
         :summary "Poistaa opiskelijan yhteystiedot yli kolme kuukautta
-            sitten päättyneistä hokseista. Käsittelee max 500 opiskelijan
+            sitten päättyneistä hokseista. Käsittelee max 100 opiskelijan
             tiedot kerrallaan. Palauttaa kyseisten tapausten hoks id:t
-            herätepalvelua varten. POISTETTU KÄYTÖSTÄ TILAPÄISESTI."
+            herätepalvelua varten."
         :header-params [caller-id :- s/Str]
         :return {:hoks-ids [s/Int]}
-        (let [hoks-ids []] ;(db-hoks/delete-opiskelijan-yhteystiedot!)]
+        (let [hoks-ids (db-hoks/delete-opiskelijan-yhteystiedot!)]
           ; TODO lisää auditlog entry, kun siivous enabloidaan
           (restful/ok {:hoks-ids hoks-ids}))))))


### PR DESCRIPTION
## Kuvaus muutoksista

Otetaan takaisin käyttöön toiminnallisuus, joka etsii HOKSin tietokannasta vanhoja HOKSeja / työpaikkajaksoja ja poistaa niistä yhteystietoja.

https://jira.eduuni.fi/browse/EH-1514

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
