### PR TITLE
EH-1560: oppija-oidin vaihtamisen validointi

### DIFF
--- a/resources/dev/ehoks-oph.properties
+++ b/resources/dev/ehoks-oph.properties
@@ -28,6 +28,7 @@ oppijanumerorekisteri-url=${virkailija-url}/oppijanumerorekisteri-service
 oppijanumerorekisteri.search-henkilo=${oppijanumerorekisteri-url}/henkilo
 oppijanumerorekisteri.get-henkilo-by-oid=${oppijanumerorekisteri-url}/henkilo/$1
 oppijanumerorekisteri.get-slave-duplicates-by-oid=${oppijanumerorekisteri-url}/henkilo/$1/slaves
+oppijanumerorekisteri.get-master-by-slave-oid=${oppijanumerorekisteri-url}/henkilo/$1/master
 
 kayttooikeus-service-url=${virkailija-url}/kayttooikeus-service
 kayttooikeus-service.kayttaja=${kayttooikeus-service-url}/kayttooikeus/kayttaja

--- a/resources/prod/ehoks-oph.properties
+++ b/resources/prod/ehoks-oph.properties
@@ -28,6 +28,7 @@ oppijanumerorekisteri-url=${virkailija-url}/oppijanumerorekisteri-service
 oppijanumerorekisteri.search-henkilo=${oppijanumerorekisteri-url}/henkilo
 oppijanumerorekisteri.get-henkilo-by-oid=${oppijanumerorekisteri-url}/henkilo/$1
 oppijanumerorekisteri.get-slave-duplicates-by-oid=${oppijanumerorekisteri-url}/henkilo/$1/slaves
+oppijanumerorekisteri.get-master-by-slave-oid=${oppijanumerorekisteri-url}/henkilo/$1/master
 
 kayttooikeus-service-url=${virkailija-url}/kayttooikeus-service
 kayttooikeus-service.kayttaja=${kayttooikeus-service-url}/kayttooikeus/kayttaja

--- a/src/oph/ehoks/external/oppijanumerorekisteri.clj
+++ b/src/oph/ehoks/external/oppijanumerorekisteri.clj
@@ -60,6 +60,16 @@
               :options {:as :json}}]
     (cas/with-service-ticket data)))
 
+(defn get-master-of-slave-oppija-oid
+  "Gets master oppija oid of a slave duplicate."
+  [oid]
+  (let [data {:method :get
+              :service (u/get-url "oppijanumerorekisteri-url")
+              :url (u/get-url
+                     "oppijanumerorekisteri.get-master-by-slave-oid" oid)
+              :options {:as :json}}]
+    (cas/with-service-ticket data)))
+
 (defn- convert-contact-values
   "Rename contact info keys to :value and :type"
   [contact-item]

--- a/src/oph/ehoks/hoks.clj
+++ b/src/oph/ehoks/hoks.clj
@@ -325,8 +325,8 @@
         old-oppija-oid (:oppija-oid old-hoks)]
     (when (oppija-oid-changed? new-oppija-oid old-oppija-oid)
       (oppijaindex/add-oppija! new-oppija-oid)
-      (oppijaindex/update-opiskeluoikeus-without-error-forwarding!
-        (:opiskeluoikeus-oid old-hoks) new-oppija-oid))))
+      (db-oo/update-opiskeluoikeus!
+        (:opiskeluoikeus-oid old-hoks) {:oppija-oid new-oppija-oid}))))
 
 (defn check-for-update!
   "Tarkistaa, saako HOKSin päivittää uusilla arvoilla."

--- a/src/oph/ehoks/hoks.clj
+++ b/src/oph/ehoks/hoks.clj
@@ -353,7 +353,8 @@
                            :oidHenkilo)]
         (when (not= master-oid new-oppija-oid)
           (throw (ex-info
-                   "Updating `oppija-oid` in HOKS is not allowed!"
+                   (str "Updating `oppija-oid` in HOKS is only allowed with "
+                        "latest master oppija oid!")
                    {:type           :disallowed-update
                     :old-oppija-oid old-oppija-oid
                     :new-oppija-oid new-oppija-oid})))))))

--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -306,6 +306,7 @@
       (response/not-found {:error "HOKS not found with given HOKS ID"})
       (do (hoks/check-for-update! old-hoks hoks)
           (let [new-hoks (db-handler (get-in request [:hoks :id]) hoks)]
+            (hoks/handle-oppija-oid-changes-in-indexes! new-hoks old-hoks)
             (assoc (response/no-content)
                    ::audit/changes {:old old-hoks :new new-hoks}))))))
 

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -195,6 +195,7 @@
     (hoks/check-for-update! old-hoks hoks)
     (let [new-hoks (db-handler (:id (:hoks request))
                                (hoks/add-missing-oht-yksiloiva-tunniste hoks))]
+      (hoks/handle-oppija-oid-changes-in-indexes! new-hoks old-hoks)
       (assoc (response/no-content)
              ::audit/changes {:old old-hoks :new new-hoks}))))
 

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -243,7 +243,9 @@
       (is (= (:status post-response) 200))
       (is (= (:status put-response) 400))
       (is (= (test-utils/parse-body (:body put-response))
-             {:error "Updating `oppija-oid` in HOKS is not allowed!"})))))
+             {:error
+              (str "Updating `oppija-oid` in HOKS is only allowed with "
+                   "latest master oppija oid!")})))))
 
 (deftest prevent-invalid-osaamisen-hankkimistapa
   (testing "Start and end dates of OHT are checked"

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -1302,7 +1302,11 @@
                  :opiskeluoikeus-oid "1.2.246.562.15.76000000018"
                  :oppija-oid "1.2.246.562.24.12312312319"})
               virkailija-for-test)]
-        (t/is (= (:status put-response) 204))))))
+        (t/is (= (:status put-response) 204))
+        (t/is (= (:oppija-oid
+                   (db-opiskeluoikeus/select-opiskeluoikeus-by-oid
+                     "1.2.246.562.15.76000000018"))
+                 "1.2.246.562.24.12312312319"))))))
 
 (t/deftest test-get-amount
   (t/testing "Test getting the amount of hokses"

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -1069,7 +1069,9 @@
               virkailija-for-test)]
         (t/is (= (:status patch-response) 400))
         (t/is (= (test-utils/parse-body (:body patch-response))
-                 {:error "Updating `oppija-oid` in HOKS is not allowed!"}))))))
+                 {:error
+                  (str "Updating `oppija-oid` in HOKS is only allowed with "
+                       "latest master oppija oid!")}))))))
 
 (def hoks-data
   {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
@@ -1262,7 +1264,9 @@
             put-body (test-utils/parse-body (:body put-response))]
         (t/is (= (:status put-response) 400))
         (t/is (= put-body
-                 {:error "Updating `oppija-oid` in HOKS is not allowed!"}))))))
+                 {:error
+                  (str "Updating `oppija-oid` in HOKS is only allowed with "
+                       "latest master oppija oid!")}))))))
 
 (t/deftest test-allow-updating-oppija-oid
   (t/testing "Allows changing a slave oppija-oid to master"


### PR DESCRIPTION
## Kuvaus muutoksista

Mahdollistetaan HOKSiin tallennetun oppija-oidin vaihtaminen validoimalla se oppijanumerorekisteriä vasten.

https://jira.eduuni.fi/browse/EH-1560

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
