### PR TITLE
EH-1682: Korjaa raporttirajapintojen tietorakenne

### DIFF
--- a/resources/db/hoksit/select_oht_by_tutkinto_between.sql
+++ b/resources/db/hoksit/select_oht_by_tutkinto_between.sql
@@ -8,6 +8,7 @@ SELECT
   oh.loppu AS loppupvm,
   oh.osa_aikaisuustieto AS "osaAikaisuus",
   oh.oppisopimuksen_perusta_koodi_uri AS "oppisopimuksenPerusta",
+  oo.oppilaitos_oid AS "oppilaitosOid",
   tjk.tyopaikan_nimi AS "tyopaikanNimi",
   tjk.tyopaikan_y_tunnus AS ytunnus,
   tjk.vastuullinen_tyopaikka_ohjaaja_nimi AS "ohjaajaNimi",

--- a/src/oph/ehoks/db/postgresql/common.clj
+++ b/src/oph/ehoks/db/postgresql/common.clj
@@ -229,7 +229,7 @@
   (memo/ttl
     select-oht-by-tutkinto-and-oppilaitos-between
     {}
-    :ttl/threshold 300))
+    :ttl/threshold 300000)) ; 5 minutes
 
 (defn select-oht-by-tutkinto-between
   "Hakee osaamisen hankkimistapoja tutkinnon perusteella tietylle aikavälille."
@@ -237,3 +237,10 @@
   (db-ops/query [queries/select-oht-by-tutkinto-between tutkinto start end]
                 {:identifiers #(do %)
                  :row-fn      db-ops/from-sql}))
+
+(def get-oht-by-tutkinto-between-memoized!
+  "Memoized get tutkinto between"
+  (memo/ttl
+    select-oht-by-tutkinto-between
+    {}
+    :ttl/threshold 300000)) ;5 minutes


### PR DESCRIPTION
## Kuvaus muutoksista

Oppilaitos ei saa avattua raportteja. Muutetaan raporttien palauttama tietorakenne sellaiseksi, jota käyttöliittymä odottaa.

https://jira.eduuni.fi/browse/EH-1682

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
