### PR TITLE
EH-1584: Writing herätteet directly to DynamoDB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,14 @@ jobs:
           git clone https://github.com/Opetushallitus/ci-tools.git
           lein deps
 
-      # Do the tests even use the database?
-      - name: Run Database
+      - name: Run Databases
         shell: bash
         env:
           CONFIG: oph-configuration/test-ci.edn
         run: |
           ./scripts/ci-scripts/run_postgres.sh
           lein dbmigrate
+          make stamps/local-ddb-schema   # DynamoDB
 
       - name: Pre-Build
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /checkouts
 /classes
 /lib
+/myenv
 /scripts/session-cookie.txt
 /scripts/cas-tgt-url.txt
 /resources/uberjar/buildversion.txt

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ stamps/db-running: stamps/db-image
 	docker ps --format '{{.Names}}' | grep -qx 'ehoks-postgres' \
 	|| docker run -d --rm --name ehoks-postgres \
 		-p 5432:5432 ehoks-postgres > $@ || (rm $@ && false)
-	until echo pingping | nc localhost 5432; do \
+	until psql -h localhost -U postgres ehoks -c "SELECT 3" \
+			| grep -x ' *3 *'; do \
 		echo "Waiting for database to come up..."; \
 		sleep 1; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ stamps/local-ddb-running:
 
 DDB_TABLES = amisherate jaksotunnus tep-nippu tpk-nippu
 
-stamps/local-ddb-schema: $(DDB_TABLES:%=stamps/local-ddb-schema-%)
+stamps/local-ddb-schema: stamps/local-ddb-running $(DDB_TABLES:%=stamps/local-ddb-schema-%)
 	touch $@
 
 stamps/local-ddb-schema-%: resources/dev/demo-data/%-schema.json
@@ -90,4 +90,6 @@ stop:
 	-rm stamps/db-running
 	-test -f stamps/server-running && kill $$(cat stamps/server-running)
 	-rm stamps/server-running
+	-test -f stamps/local-ddb-running && docker rm -f ehoks-dynamodb
+	-rm stamps/local-ddb-running
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ tyylit.
 
 ### Testien ajaminen
 
-(Pystytä ensin tietokanta, testit toimivat aitoa tietokantaa vasten:
-`make stamps/db-schema`)
+Pystytä ensin tietokanta, testit toimivat aitoa tietokantaa vasten:
+`make stamps/db-schema`.  DynamoDB-testit tarvitsevat myös lokaalin
+DynamoDB:n: `make stamps/local-ddb-schema`.
 
 Kerran:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Muut riippuvuudet:
 + Ehkä: `make` automaatiosääntöjen käyttöön (ks alla)
 + Ehkä: `curl` jos haluaa käyttää rajapintaa suoraan (esim luoda testidataa), myös jotkin skriptit käyttävät tätä
 + Ehkä: `jq` joidenkin skriptien toimintaan
-+ Ehkä: `aws` kun tarvitsee käsitellä DynamoDB:tä
 + Ehkä: `graphviz` tietokantakaavioihin kun tekee `make schemaDoc`
 
 ### RESTful API

--- a/oph-configuration/default.edn
+++ b/oph-configuration/default.edn
@@ -15,6 +15,9 @@
  :heratepalvelu-queue "services-heratepalvelu-eHOKSHerateQueue"
  :heratepalvelu-tyoelamapalaute-queue "services-heratepalvelu-tep-HerateQueue"
  :heratepalvelu-resend-queue "services-heratepalvelu-eHOKSAmisResendQueue"
+ :heratepalvelu-amis-table "pallero-services-heratepalvelu-AMISHerateTable717F426F-1NY1YMTKJOF7Y"
+ :heratepalvelu-jakso-table "pallero-services-heratepalvelu-tep-jaksotunnusTable87D50EF4-1KUH8IGOE8ZV3"
+ :heratepalvelu-nippu-table "pallero-services-heratepalvelu-tep-nippuTableDE910D47-102WQ3OSVMOEI"
  :send-herate-messages? false
  :audit? true
  :db-type "postgresql"

--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,9 @@
   :profiles {:test {:resource-paths ["resources/test" "resources/test/src"]
                     :dependencies [[ring/ring-mock]
                                    [ring/ring-devel]]
-                    :env {:config "oph-configuration/test.edn"}}
+                    :env {:config "oph-configuration/test.edn"
+                          :aws-region "eu-west-1"
+                          :aws-endpoint-url "http://localhost:18000"}}
              :schemaspy {:dependencies [[net.sourceforge.schemaspy/schemaspy "5.0.0"]]}
              :dev {:main oph.ehoks.dev-server
                    :dependencies [[ring/ring-mock]

--- a/resources/dev/demo-data/anonymised-example-1.json
+++ b/resources/dev/demo-data/anonymised-example-1.json
@@ -9,7 +9,7 @@
 				"osaamisen-hankkimistavat": []
 			}
 		],
-		"ensikertainen-hyvaksyminen": "2022-10-06",
+		"ensikertainen-hyvaksyminen": "2023-10-06",
 		"hankittavat-koulutuksen-osat": [],
 		"sahkoposti": "glubba-blubba@edu.keuda.fi",
 		"osaamisen-hankkimisen-tarve": true,
@@ -17,7 +17,7 @@
 		"aiemmin-hankitut-paikalliset-tutkinnon-osat": [],
 		"opiskeluoikeus-oid": "1.2.246.562.15.76811932086",
 		"aiemmin-hankitut-ammat-tutkinnon-osat": [],
-		"paivitetty": "2023-05-16T00:00:00Z",
+		"paivitetty": "2024-05-16T00:00:00Z",
 		"hankittavat-yhteiset-tutkinnon-osat": [
 			{
 				"tutkinnon-osa-koodi-uri": "tutkinnonosat_106727",
@@ -233,14 +233,14 @@
 								"yksiloiva-tunniste": "44728951585344033343",
 								"muut-oppimisymparistot": [
 									{
-										"alku": "2023-06-03",
-										"loppu": "2023-06-30",
+										"alku": "2024-06-03",
+										"loppu": "2024-06-30",
 										"oppimisymparisto-koodi-uri": "oppimisymparistot_0002",
 										"oppimisymparisto-koodi-versio": 1
 									}
 								],
-								"alku": "2023-06-03",
-								"loppu": "2023-06-30"
+								"alku": "2024-06-03",
+								"loppu": "2024-06-30"
 							}
 						]
 					},
@@ -295,9 +295,9 @@
 								}
 							}
 						],
-						"alku": "2023-03-09",
+						"alku": "2024-03-09",
 						"yksilolliset-kriteerit": [],
-						"loppu": "2023-03-15"
+						"loppu": "2024-03-15"
 					}
 				],
 				"osaamisen-hankkimistavat": [
@@ -308,14 +308,14 @@
 						"yksiloiva-tunniste": "44728950164671337776",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2022-08-10",
-								"loppu": "2023-01-13",
+								"alku": "2023-08-10",
+								"loppu": "2024-01-13",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2022-08-10",
-						"loppu": "2023-01-13"
+						"alku": "2023-08-10",
+						"loppu": "2024-01-13"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -336,8 +336,8 @@
 						"osaamisen-hankkimistapa-koodi-versio": 1,
 						"yksiloiva-tunniste": "447289501649525720624952571844",
 						"muut-oppimisymparistot": [],
-						"alku": "2023-01-16",
-						"loppu": "2023-03-17"
+						"alku": "2024-01-16",
+						"loppu": "2024-03-17"
 					}
 				]
 			},
@@ -355,14 +355,14 @@
 						"yksiloiva-tunniste": "44728950185149468939",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-03-20",
-								"loppu": "2023-06-02",
+								"alku": "2024-03-20",
+								"loppu": "2024-06-02",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-03-20",
-						"loppu": "2023-06-02"
+						"alku": "2024-03-20",
+						"loppu": "2024-06-02"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -371,14 +371,14 @@
 						"yksiloiva-tunniste": "44728950185590812544",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-08-07",
-								"loppu": "2023-10-27",
+								"alku": "2024-08-07",
+								"loppu": "2024-10-27",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-08-07",
-						"loppu": "2023-10-27"
+						"alku": "2024-08-07",
+						"loppu": "2024-10-27"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -399,8 +399,8 @@
 						"osaamisen-hankkimistapa-koodi-versio": 1,
 						"yksiloiva-tunniste": "447289501856807906785680790783",
 						"muut-oppimisymparistot": [],
-						"alku": "2023-10-30",
-						"loppu": "2023-12-15"
+						"alku": "2024-10-30",
+						"loppu": "2024-12-15"
 					}
 				]
 			},

--- a/resources/dev/demo-data/anonymised-example-2.json
+++ b/resources/dev/demo-data/anonymised-example-2.json
@@ -10,7 +10,7 @@
 				"osaamisen-hankkimistavat": []
 			}
 		],
-		"ensikertainen-hyvaksyminen": "2021-08-13",
+		"ensikertainen-hyvaksyminen": "2023-08-13",
 		"hankittavat-koulutuksen-osat": [],
 		"sahkoposti": "siibarbiibar@edu.keuda.fi",
 		"osaamisen-hankkimisen-tarve": true,
@@ -279,11 +279,11 @@
 								}
 							}
 						],
-						"alku": "2022-04-20",
+						"alku": "2024-04-20",
 						"yksilolliset-kriteerit": [
 							""
 						],
-						"loppu": "2022-05-27"
+						"loppu": "2024-05-27"
 					}
 				],
 				"osaamisen-hankkimistavat": [
@@ -294,14 +294,14 @@
 						"yksiloiva-tunniste": "33895328003589565523",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2021-12-02",
-								"loppu": "2022-02-09",
+								"alku": "2023-12-02",
+								"loppu": "2024-02-09",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2021-12-02",
-						"loppu": "2022-02-09"
+						"alku": "2023-12-02",
+						"loppu": "2024-02-09"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -322,8 +322,8 @@
 						"osaamisen-hankkimistapa-koodi-versio": 1,
 						"yksiloiva-tunniste": "338953280041441482914144148322",
 						"muut-oppimisymparistot": [],
-						"alku": "2022-04-12",
-						"loppu": "2022-05-27"
+						"alku": "2024-04-12",
+						"loppu": "2024-05-27"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -332,14 +332,14 @@
 						"yksiloiva-tunniste": "33895328004177443373",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2021-08-09",
-								"loppu": "2021-10-10",
+								"alku": "2023-08-09",
+								"loppu": "2023-10-10",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2021-08-09",
-						"loppu": "2021-10-10"
+						"alku": "2023-08-09",
+						"loppu": "2023-10-10"
 					}
 				]
 			},
@@ -373,9 +373,9 @@
 								}
 							}
 						],
-						"alku": "2023-08-15",
+						"alku": "2025-08-15",
 						"yksilolliset-kriteerit": [],
-						"loppu": "2023-08-21"
+						"loppu": "2025-08-21"
 					}
 				],
 				"osaamisen-hankkimistavat": [
@@ -386,14 +386,14 @@
 						"yksiloiva-tunniste": "33895328025056794728",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-02-13",
-								"loppu": "2023-06-02",
+								"alku": "2025-02-13",
+								"loppu": "2025-06-02",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-02-13",
-						"loppu": "2023-06-02"
+						"alku": "2025-02-13",
+						"loppu": "2025-06-02"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -402,14 +402,14 @@
 						"yksiloiva-tunniste": "33895328025346931574",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-06-03",
-								"loppu": "2023-08-13",
+								"alku": "2025-06-03",
+								"loppu": "2025-08-13",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0003",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-06-03",
-						"loppu": "2023-08-13"
+						"alku": "2025-06-03",
+						"loppu": "2025-08-13"
 					}
 				]
 			},
@@ -427,14 +427,14 @@
 						"yksiloiva-tunniste": "33895328045587728569",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-08-14",
-								"loppu": "2023-09-09",
+								"alku": "2025-08-14",
+								"loppu": "2025-09-09",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-08-14",
-						"loppu": "2023-09-09"
+						"alku": "2025-08-14",
+						"loppu": "2025-09-09"
 					},
 					{
 						"keskeytymisajanjaksot": [],
@@ -443,14 +443,14 @@
 						"yksiloiva-tunniste": "33895328045699528135",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2023-10-07",
-								"loppu": "2023-12-22",
+								"alku": "2025-10-07",
+								"loppu": "2025-12-22",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2023-10-07",
-						"loppu": "2023-12-22"
+						"alku": "2025-10-07",
+						"loppu": "2025-12-22"
 					}
 				]
 			},
@@ -500,9 +500,9 @@
 								}
 							}
 						],
-						"alku": "2022-09-13",
+						"alku": "2024-09-13",
 						"yksilolliset-kriteerit": [],
-						"loppu": "2022-09-28"
+						"loppu": "2024-09-28"
 					}
 				],
 				"osaamisen-hankkimistavat": [
@@ -520,12 +520,13 @@
 								"valmistautua asiakaspalvelutilanteisiin\n\npalvella asiakkaita, myydä ja tarjoilla kahvilan ruoka- ja juomatuotteita\n\nrekisteröidä myyntiä ja laskuttaa asiakkaita\nhyödyntää alakohtaista kielitaitoa asiakaspalvelussa\ntehdä työvuoron tilityksen ja valmistella seuraavaa työvuoroa\narvioida omaa osaamistaan ja toimintaansa työyhteisön jäsenenä.\n"
 							]
 						},
+						"osa-aikaisuustieto": 100,
 						"osaamisen-hankkimistapa-koodi-uri": "osaamisenhankkimistapa_koulutussopimus",
 						"osaamisen-hankkimistapa-koodi-versio": 1,
 						"yksiloiva-tunniste": "338953281646081596934608159694",
 						"muut-oppimisymparistot": [],
-						"alku": "2022-09-12",
-						"loppu": "2022-09-28"
+						"alku": "2024-09-12",
+						"loppu": "2024-09-28"
 					}
 				]
 			},
@@ -551,14 +552,14 @@
 						"yksiloiva-tunniste": "33895328284510474639",
 						"muut-oppimisymparistot": [
 							{
-								"alku": "2022-08-10",
-								"loppu": "2022-12-16",
+								"alku": "2024-08-10",
+								"loppu": "2024-12-16",
 								"oppimisymparisto-koodi-uri": "oppimisymparistot_0001",
 								"oppimisymparisto-koodi-versio": 1
 							}
 						],
-						"alku": "2022-08-10",
-						"loppu": "2022-12-16"
+						"alku": "2024-08-10",
+						"loppu": "2024-12-16"
 					}
 				]
 			}

--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_koski_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_koski_routes.clj
@@ -74,8 +74,7 @@
                  :koodistoUri "koulutus"
                  :koodistoVersio 11}
                 :perusteenDiaarinumero "77/011/2014"
-                :perusteenNimi
-                {:fi tutkinto}
+                :perusteenNimi {:fi tutkinto}
                 :koulutustyyppi
                 {:koodiarvo "1"
                  :nimi
@@ -92,7 +91,7 @@
                 :alkamispäivä "2016-08-05"
                 :suorituskieli {}
                 :osasuoritukset []
-                :tyyppi {}}]
+                :tyyppi {:koodiarvo "ammatillinentutkinto"}}]
               :tyyppi
               {:koodiarvo opiskeluoikeus-tyyppi
                :nimi

--- a/src/db/migration/V1_1721307219687__AMIS_palaute_sync_view.sql
+++ b/src/db/migration/V1_1721307219687__AMIS_palaute_sync_view.sql
@@ -1,0 +1,47 @@
+
+CREATE VIEW palaute_for_amis_heratepalvelu AS
+SELECT
+	h.sahkoposti,
+	p.heratepvm,
+	p.voimassa_loppupvm,
+	p.toimipiste_oid,
+	h.puhelinnumero,
+	p.hankintakoulutuksen_toteuttaja,
+	p.voimassa_alkupvm AS alkupvm,
+	p.hoks_id AS ehoks_id,
+	CASE p.herate_source
+		WHEN 'ehoks_update' THEN 'sqs_viesti_ehoksista'
+		WHEN 'koski_update' THEN 'tiedot_muuttuneet_koskessa'
+		ELSE p.herate_source::TEXT END AS herate_source,
+	p.koulutustoimija,
+	p.kyselylinkki,
+	p.tyyppi AS kyselytyyppi,
+	p.kyselytyyppi as internal_kyselytyyppi,
+	h.opiskeluoikeus_oid,
+	h.oppija_oid,
+	oo.oppilaitos_oid AS oppilaitos,
+	NULL AS osaamisala,  -- TODO: populate this in opiskeluoikeudet
+	p.rahoituskausi,
+	p.suorituskieli,
+	date(p.created_at) AS tallennuspvm,
+	p.tutkintotunnus,
+	concat(p.koulutustoimija, '/', oo.oppija_oid) AS toimija_oppija,
+	concat(p.tyyppi, '/', p.rahoituskausi) AS tyyppi_kausi
+FROM (SELECT *,
+	CASE WHEN EXTRACT(MONTH FROM heratepvm) <= 6
+		THEN CONCAT(EXTRACT(YEAR FROM heratepvm) - 1, '-',
+			EXTRACT(YEAR FROM heratepvm))
+		ELSE CONCAT(EXTRACT(YEAR FROM heratepvm), '-',
+			EXTRACT(YEAR FROM heratepvm) + 1) END
+		AS rahoituskausi,
+	CASE kyselytyyppi
+		WHEN 'valmistuneet' THEN 'tutkinnon_suorittaneet'
+		WHEN 'osia_suorittaneet' THEN 'tutkinnon_osia_suorittaneet'
+		ELSE kyselytyyppi::TEXT END
+		AS tyyppi
+	FROM palautteet
+	WHERE kyselytyyppi IN
+		('aloittaneet','valmistuneet','osia_suorittaneet'))
+	AS p
+JOIN hoksit h ON (p.hoks_id = h.id)
+JOIN opiskeluoikeudet oo ON (h.opiskeluoikeus_oid = oo.oid);

--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -167,9 +167,9 @@
     (replace-in m kss kst)))
 
 (defn remove-nils
-  "Remove all keys mapped to value nil."
+  "Return same map, but without keys pointing to nil values"
   [m]
-  (apply dissoc m (filter #(nil? (get m %)) (keys m))))
+  (into {} (filter (fn [[k v]] (some? v)) m)))
 
 (defn convert-sql
   "Handle removals and replacements in maps."

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -1,21 +1,37 @@
 (ns oph.ehoks.db.dynamodb
-  (:require [taoensso.faraday :as far])
+  (:require [taoensso.faraday :as far]
+            [environ.core :refer [env]])
   (:import (com.amazonaws.auth BasicAWSCredentials AWSStaticCredentialsProvider)
            (com.amazonaws.client.builder AwsClientBuilder$EndpointConfiguration)
            (com.amazonaws.services.dynamodbv2 AmazonDynamoDBClientBuilder)))
 
-(defn get-test-client []
+(defn get-test-client
+  "Local DynamoDB needs a region even when the endpoint has been
+  overridden, because DynamoDB identifies tables by region and account
+  (different regions may have tables with the same name).  Thus we
+  construct a client that uses AWS_REGION for signing API requests even
+  when the API endpoint is in localhost.
+
+  The correct parameters for connecting to the DynamoDB in
+  ../../../../Makefile are:
+  - AWS_REGION=eu-west-1
+  - AWS_ENDPOINT_URL=http://localhost:18000
+  - AWS_ACCESS_KEY_ID=foo
+  - AWS_SECRET_KEY=bar"
+  []
   (let [^AmazonDynamoDBClientBuilder builder
         (doto (AmazonDynamoDBClientBuilder/standard)
           (.setEndpointConfiguration
             (AwsClientBuilder$EndpointConfiguration.
-              "http://localhost:18000" "eu-west-1"))
-          (.setCredentials
-            (AWSStaticCredentialsProvider.
-              (BasicAWSCredentials. "foo" "bar"))))]
+              (env :aws-endpoint-url) (env :aws-region))))]
     (.build builder)))
 
-(def localtesting-opts
-  {:client (get-test-client)})
+(defn get-client
+  "Return a DynamoDB client, based on environment variables, usable for
+  either local testing or real DynamoDB."
+  []
+  (if (and (env :aws-endpoint-url) (env :aws-region))
+    (get-test-client)
+    (.build (AmazonDynamoDBClientBuilder/standard))))
 
-(defn test-faraday [] (far/list-tables localtesting-opts))
+(def faraday-opts (delay {:client (get-client)}))

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -70,7 +70,11 @@
   [table item]
   (let [table-name @(tables table)
         key-names (table-keys table)
-        item-key (zipmap key-names (map item key-names))
+        item-key (zipmap key-names
+                         (map #(or (item %)
+                                   (throw (ex-info "item key missing"
+                                                   {:key-name % :item item})))
+                              key-names))
         rest-item (apply dissoc item key-names)
         attr-names (zipmap (map (partial str "#") (range))
                            (map name (keys rest-item)))
@@ -97,6 +101,9 @@
   (-> {:hoks-id hoks-id :kyselytyypit [kyselytyyppi]}
       (->> (get-for-heratepalvelu-by-hoks-id-and-kyselytyypit! db/spec))
       (first)
+      (not-empty)
+      (or (throw (ex-info "palaute not found"
+                          {:hoks-id hoks-id :kyselytyyppi kyselytyyppi})))
       (remove-nils)
       (update-keys map-keys-to-ddb)
       (dissoc :internal-kyselytyyppi)

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -8,7 +8,8 @@
             [oph.ehoks.db.db-operations.db-helpers :refer [remove-nils]]
             [oph.ehoks.palaute.opiskelija :refer
              [get-for-heratepalvelu-by-hoks-id-and-kyselytyypit!]])
-  (:import (com.amazonaws.auth BasicAWSCredentials AWSStaticCredentialsProvider)
+  (:import (com.amazonaws.auth BasicSessionCredentials
+                               AWSStaticCredentialsProvider)
            (com.amazonaws.client.builder AwsClientBuilder$EndpointConfiguration)
            (com.amazonaws.services.dynamodbv2 AmazonDynamoDBClientBuilder)
            (com.amazonaws.services.dynamodbv2.model AttributeValue)))
@@ -33,6 +34,9 @@
   []
   (let [^AmazonDynamoDBClientBuilder builder
         (doto (AmazonDynamoDBClientBuilder/standard)
+          (.setCredentials
+            (AWSStaticCredentialsProvider.
+              (BasicSessionCredentials. "foo" "bar" "baz")))
           (.setEndpointConfiguration
             (AwsClientBuilder$EndpointConfiguration.
               (env :aws-endpoint-url) (env :aws-region))))]

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.db.dynamodb
   (:require [taoensso.faraday :as far]
-            [environ.core :refer [env]])
+            [environ.core :refer [env]]
+            [oph.ehoks.config :refer [config]])
   (:import (com.amazonaws.auth BasicAWSCredentials AWSStaticCredentialsProvider)
            (com.amazonaws.client.builder AwsClientBuilder$EndpointConfiguration)
            (com.amazonaws.services.dynamodbv2 AmazonDynamoDBClientBuilder)))
@@ -35,3 +36,6 @@
     (.build (AmazonDynamoDBClientBuilder/standard))))
 
 (def faraday-opts (delay {:client (get-client)}))
+(def amis-table (delay (keyword (:heratepalvelu-amis-table config))))
+(def jakso-table (delay (keyword (:heratepalvelu-jakso-table config))))
+(def nippu-table (delay (keyword (:heratepalvelu-nippu-table config))))

--- a/src/oph/ehoks/db/sql/opiskelijapalaute.sql
+++ b/src/oph/ehoks/db/sql/opiskelijapalaute.sql
@@ -40,3 +40,9 @@ join hoksit h on (h.id = p.hoks_id)
 where h.oppija_oid = :oppija-oid
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and p.koulutustoimija = :koulutustoimija
+
+-- :name get-for-heratepalvelu-by-hoks-id-and-kyselytyypit! :? :*
+-- :doc get AMIS-palaute in the format for putting into herätepalvelu
+select * from palaute_for_amis_heratepalvelu
+where ehoks_id = :hoks-id
+  and internal_kyselytyyppi in (:v*:kyselytyypit)

--- a/src/oph/ehoks/schema.clj
+++ b/src/oph/ehoks/schema.clj
@@ -49,6 +49,9 @@
               :heratepalvelu-delete-tunnus-queue s/Str
               :heratepalvelu-queue s/Str
               :heratepalvelu-tyoelamapalaute-queue s/Str
+              :heratepalvelu-amis-table s/Str
+              :heratepalvelu-jakso-table s/Str
+              :heratepalvelu-nippu-table s/Str
               :send-herate-messages? s/Bool
               :audit? s/Bool
               :db-type s/Str

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -450,11 +450,12 @@
                                {alkupvm-loppu :- LocalDate (LocalDate/now)}
                                {limit :- s/Int 2000}
                                {from-id :- s/Int 0}]
-                :return {:last-id s/Int
-                         :paattokysely-total-count s/Int
-                         :o-s-pvm-ilman-vahvistuspvm-count s/Int
-                         :vahvistuspvm-ilman-o-s-pvm-count s/Int
-                         :vahvistuspvm-ja-o-s-pvm s/Int}
+                :return (restful/response
+                          {:last-id s/Int
+                           :paattokysely-total-count s/Int
+                           :o-s-pvm-ilman-vahvistuspvm-count s/Int
+                           :vahvistuspvm-ilman-o-s-pvm-count s/Int
+                           :vahvistuspvm-ja-o-s-pvm s/Int})
                 (let [data (db-hoks/select-kyselylinkit-by-date-and-type-temp
                              alkupvm alkupvm-loppu from-id limit)
                       last-id (:hoks-id (last data))
@@ -499,9 +500,9 @@
                 true."
                 :query-params [{limit :- s/Int 2000}
                                {from-id :- s/Int 0}]
-                :return {:count s/Int
-                         :ids [s/Int]
-                         :last-id s/Int}
+                :return (restful/response {:count s/Int
+                                           :ids [s/Int]
+                                           :last-id s/Int})
                 (let [hoksit (db-hoks/select-hokses-greater-than-id
                                from-id
                                limit
@@ -584,7 +585,7 @@
                         :path-params [hoks-id :- s/Int]
                         :summary "Hoksin tiedot.
                                 Vaatii manuaalisyöttäjän oikeudet"
-                        :return hoks-schema/HOKS
+                        :return (restful/response hoks-schema/HOKS)
                         (get-hoks hoks-id request))
 
                       (c-api/POST "/:hoks-id/resend-palaute" request
@@ -592,7 +593,7 @@
                                   uudelleen lähetykselle"
                         :path-params [hoks-id :- s/Int]
                         :body [data hoks-schema/palaute-resend]
-                        :return {:sahkoposti s/Str}
+                        :return (restful/response {:sahkoposti s/Str})
                         (let [kyselylinkit
                               (heratepalvelu/get-oppija-kyselylinkit
                                 oppija-oid)
@@ -666,7 +667,7 @@
                           :summary "Asettaa HOKSin
                               poistetuksi(shallow delete) id:n perusteella."
                           :body [data hoks-schema/shallow-delete-hoks]
-                          :return {:success s/Int}
+                          :return (restful/response {:success s/Int})
                           (shallow-delete-hoks-handler! request hoks-id data)))
 
                       (route-middleware
@@ -675,7 +676,7 @@
                         (c-api/GET "/" []
                           :summary "Kaikki hoksit (perustiedot).
                         Tarvitsee OPH-pääkäyttäjän oikeudet"
-                          :return [s/Any]
+                          :return (restful/response [s/Any])
                           (restful/ok (db-hoks/select-hoksit))))))
 
                   (route-middleware

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -16,6 +16,21 @@
 (use-fixtures :once test-utils/migrate-database)
 (use-fixtures :each test-utils/empty-database-after-test)
 
+(deftest amis-field-mapping
+  (testing "map-keys-to-ddb maps correctly"
+    (is (= (ddb/map-keys-to-ddb :foo) :foo))
+    (is (= (ddb/map-keys-to-ddb :toimija-oppija) :toimija_oppija))
+    (is (= (ddb/map-keys-to-ddb :sahkoposti) :sahkoposti))))
+
+(deftest missing-sync-test
+  (testing "sync-item! fails when not enough information is available
+  for identifying the item"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"item key missing"
+                          (ddb/sync-item! :amis {}))))
+  (testing "sync-amis-herate! fails when there is no information in db"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"palaute not found"
+                          (ddb/sync-amis-herate! 54343 "aloittaneet")))))
+
 (def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
                 :oppija-oid "1.2.246.562.24.12312312319"
                 :ensikertainen-hyvaksyminen (LocalDate/now)

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -1,0 +1,47 @@
+(ns oph.ehoks.db.dynamodb-test
+  (:require [clojure.test :refer :all]
+            [taoensso.faraday :as far]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.external.koski-test :as koski-test]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.oppijaindex :as oi]
+            [oph.ehoks.db.dynamodb :as ddb]
+            [oph.ehoks.db.db-operations.db-helpers :as db-ops]
+            [oph.ehoks.palaute.opiskelija :refer
+             [get-for-heratepalvelu-by-hoks-id-and-kyselytyypit!]]
+            [oph.ehoks.test-utils :as test-utils])
+  (:import (java.time LocalDate)))
+
+(use-fixtures :once test-utils/migrate-database)
+(use-fixtures :each test-utils/empty-database-after-test)
+
+(def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
+                :oppija-oid "1.2.246.562.24.12312312319"
+                :ensikertainen-hyvaksyminen (LocalDate/now)
+                :osaamisen-hankkimisen-tarve true
+                :sahkoposti "irma.isomerkki@esimerkki.com"})
+
+(deftest sync-herate-to-dynamodb
+  (with-redefs [koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw]
+
+    (testing "When HOKS is saved, appropriate aloituspalaute is saved
+    into database.  If this palaute is synced into herätepalvelu,
+    the same values can be found there."
+      (db-ops/insert-one! :oppijat {:oid (:oppija-oid hoks-data)})
+      (oi/add-opiskeluoikeus!
+        (:opiskeluoikeus-oid hoks-data)
+        (:oppija-oid hoks-data))
+      (let [saved-hoks (hoks/save! hoks-data)
+            hoks (hoks/get-by-id (:id saved-hoks))]
+        (is (= (:sahkoposti hoks) "irma.isomerkki@esimerkki.com"))
+        (ddb/sync-amis-herate! (:id saved-hoks) "aloittaneet")
+        (let [ddb-item
+              (->> {:tyyppi_kausi
+                    (str "aloittaneet/" (palaute/rahoituskausi (LocalDate/now)))
+                    :toimija_oppija
+                    "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"}
+                   (far/get-item @ddb/faraday-opts @(ddb/tables :amis)))]
+          (is (= (:sahkoposti ddb-item) "irma.isomerkki@esimerkki.com"))
+          (is (= (:herate-source ddb-item) "sqs_viesti_ehoksista")))))))

--- a/test/oph/ehoks/external/koski_test.clj
+++ b/test/oph/ehoks/external/koski_test.clj
@@ -29,11 +29,12 @@
   [oid]
   (case oid
     "1.2.246.562.15.10000000009"
-    {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
+    {:oid "1.2.246.562.15.10000000009"
+     :suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
      :koulutustoimija {:oid "1.2.246.562.10.10000000009"}}
     "1.246.562.15.12345678911" {}
-    "1.246.562.15.12345678910" (throw (ex-info "Internal server error"
-                                               {:status 500}))
+    "1.246.562.15.12345678910"
+    (throw (ex-info "Internal server error" {:status 500}))
     "1.2.246.562.15.12345678903" {}
     "1.2.246.562.15.23456789017"
     {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
@@ -41,9 +42,11 @@
     "1.2.246.562.15.34567890123"
     {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
      :koulutustoimija {:oid "1.2.246.562.10.34567890123"}}
-    (throw (ex-info "Asd" {:status 404
-                           :body (str "[{\"key\": \"notFound.opiskeluoikeutta"
-                                      "EiLöydyTaiEiOikeuksia\"}]")}))))
+    (->> {:status 404
+          :body (str "[{\"key\": \"notFound.opiskeluoikeutta"
+                     "EiLöydyTaiEiOikeuksia\"}]")}
+         (ex-info "Asd")
+         (throw))))
 
 (deftest test-get-opiskeluoikeus!
   (with-redefs [k/get-opiskeluoikeus-info-raw mock-get-opiskeluoikeus-raw]


### PR DESCRIPTION
## Kuvaus muutoksista

Tämän PR:n pointtina on ennen kaikkea uusi nimiavaruus `oph.ehoks.db.dynamodb`, jossa on käsittelijät, joilla voi synkata tietoja palaute-backendin tietokannasta herätepalvelun dynamodb-tauluihin.

https://jira.eduuni.fi/browse/EH-1584

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
