### PR TITLE
More info to log messages

### DIFF
--- a/src/oph/ehoks/common/api.clj
+++ b/src/oph/ehoks/common/api.clj
@@ -1,6 +1,9 @@
 (ns oph.ehoks.common.api
   (:require [compojure.api.exception :as c-ex]
             [oph.ehoks.config :refer [config]]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.external.cas :as cas]
+            [oph.ehoks.external.koodisto :as koodisto]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.oppijanumerorekisteri :as onr]
             [oph.ehoks.external.organisaatio :as organisaatio]
@@ -71,11 +74,12 @@
    ;; We don't need to do audit logging in the handlers below because
    ;; exceptions thrown go through `audit/wrap-logger` middleware.
    ::organisaatio/organisation-not-found bad-request-handler
-   :disallowed-update                    bad-request-handler
+   ::hoks/disallowed-update              bad-request-handler
    :opiskeluoikeus-already-exists        bad-request-handler
    ::koski/opiskeluoikeus-not-found      bad-request-handler
    ::onr/oppija-not-found                bad-request-handler
    ::oi/opiskeluoikeus-not-found         bad-request-handler
+   ::oi/invalid-opiskeluoikeus           bad-request-handler
    :shared-link-validation-error         bad-request-handler
    :shared-link-expired                  (c-ex/with-logging
                                            (custom-ex-handler response/gone
@@ -85,8 +89,8 @@
                                            (custom-ex-handler response/locked
                                                               :message)
                                            :warn)
-   :not-found                            not-found-handler
-   :unauthorized                         unauthorized-handler
+   ::koodisto/code-element-not-found     not-found-handler
+   ::cas/unauthorized                    unauthorized-handler
 
    ::c-ex/default                        c-ex/safe-handler})
 

--- a/src/oph/ehoks/external/cas.clj
+++ b/src/oph/ehoks/external/cas.clj
@@ -77,10 +77,10 @@
                            (get-service-ticket (:url @grant-ticket) service)
                            (catch Exception ex
                              (throw (ex-info "Error getting Service Ticket"
-                                             {:type :unauthorized}
+                                             {:type ::unauthorized}
                                              ex)))))
                        (throw (ex-info "Error getting Service Ticket"
-                                       {:type :unauthorized}
+                                       {:type ::unauthorized}
                                        e)))))]
       (-> data
           (assoc-in [:headers "accept"] "*/*")

--- a/src/oph/ehoks/external/koodisto.clj
+++ b/src/oph/ehoks/external/koodisto.clj
@@ -38,7 +38,7 @@
       (throw
         (if (= (:body (ex-data e)) "error.codeelement.not.found")
           (ex-info "Code Element not found"
-                   {:type :not-found
+                   {:type ::code-element-not-found
                     :url url}
                    e)
           e)))))

--- a/src/oph/ehoks/external/koski.clj
+++ b/src/oph/ehoks/external/koski.clj
@@ -97,7 +97,11 @@
         (when-not (and (= (:status (ex-data e)) status/not-found)
                        (= koski-virhekoodi
                           "notFound.opiskeluoikeuttaEiLöydyTaiEiOikeuksia"))
-          (throw (ex-info "Error while fetching opiskeluoikeus from Koski"
+          (throw (ex-info (format
+                            (str "Error while fetching opiskeluoikeus `%s` "
+                                 "from Koski. Koski-virhekoodi is `%s`.")
+                            oid
+                            koski-virhekoodi)
                           {:type              ::opiskeluoikeus-fetching-error
                            :opiskeluoikeus-oid oid
                            :koski-virhekoodi   koski-virhekoodi}

--- a/src/oph/ehoks/external/oppijanumerorekisteri.clj
+++ b/src/oph/ehoks/external/oppijanumerorekisteri.clj
@@ -24,7 +24,9 @@
        (catch ExceptionInfo e
          (when-not (= (:status (ex-data e)) 404)
            (throw
-             (ex-info "Error while fetching oppija from Oppijanumerorekisteri"
+             (ex-info (format (str "Error while fetching oppija `%s` from "
+                                   "Oppijanumerorekisteri")
+                              oid)
                       {:type       ::oppija-fetching-error
                        :oppija-oid oid}
                       e))))))

--- a/src/oph/ehoks/external/organisaatio.clj
+++ b/src/oph/ehoks/external/organisaatio.clj
@@ -22,8 +22,9 @@
     (catch ExceptionInfo e
       (log/warn e "Error while fetching" oid "from organisaatiopalvelu")
       (when-not (= (:status (ex-data e)) status/not-found)
-        (throw (ex-info (str "Error while fetching organisation from "
-                             "Organisaatiopalvelu")
+        (throw (ex-info (format (str "Error while fetching organisation `%s` "
+                                     "from Organisaatiopalvelu.")
+                                oid)
                         {:type             ::organisation-fetching-error
                          :organisation-oid oid}
                         e))))))

--- a/src/oph/ehoks/hoks.clj
+++ b/src/oph/ehoks/hoks.clj
@@ -325,13 +325,18 @@
         new-opiskeluoikeus-oid (:opiskeluoikeus-oid new-hoks)
         old-opiskeluoikeus-oid (:opiskeluoikeus-oid old-hoks)]
     (when-not (opiskeluoikeus/still-active? new-opiskeluoikeus-oid)
-      (throw (ex-info (format "Opiskeluoikeus `%s` is no longer active"
+      (throw (ex-info (format "Opiskeluoikeus `%s` is no longer active."
                               new-opiskeluoikeus-oid)
                       {:type               ::disallowed-update
                        :opiskeluoikeus-oid new-opiskeluoikeus-oid})))
     (when (and (some? new-opiskeluoikeus-oid)
                (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
-      (throw (ex-info "Updating `opiskeluoikeus-oid` in HOKS is not allowed!"
+      (throw (ex-info (format
+                        (str "Tried to update `opiskeluoikeus-oid` from `%s` "
+                             "to `%s` but updating `opiskeluoikeus-oid` in "
+                             "HOKS is not allowed!")
+                        old-opiskeluoikeus-oid
+                        new-opiskeluoikeus-oid)
                       {:type                   ::disallowed-update
                        :old-opiskeluoikeus-oid old-opiskeluoikeus-oid
                        :new-opiskeluoikeus-oid new-opiskeluoikeus-oid})))
@@ -342,8 +347,12 @@
                            :oidHenkilo)]
         (when (not= master-oid new-oppija-oid)
           (throw (ex-info
-                   (str "Updating `oppija-oid` in HOKS is only allowed with "
-                        "latest master oppija oid!")
+                   (format
+                     (str "Tried to update `oppija-oid` from `%s` to `%s` but "
+                          "updating `oppija-oid` in HOKS is only allowed with "
+                          "latest master oppija oid!")
+                     old-oppija-oid
+                     new-oppija-oid)
                    {:type           ::disallowed-update
                     :old-oppija-oid old-oppija-oid
                     :new-oppija-oid new-oppija-oid})))))))

--- a/src/oph/ehoks/hoks.clj
+++ b/src/oph/ehoks/hoks.clj
@@ -127,7 +127,7 @@
         (if (= :organisaatio/organisation-not-found (:type (ex-data e)))
           (throw (ex-info (str "HOKS contains an unknown organisation"
                                (:organisation-oid (ex-data e)))
-                          (assoc (ex-data e) :type :disallowed-update)))
+                          (assoc (ex-data e) :type ::disallowed-update)))
           (log/error e "exception in heräte initiation with" (ex-data e))))
       (catch Exception e
         (log/error e "exception in heräte initiation")))
@@ -327,12 +327,12 @@
     (when-not (opiskeluoikeus/still-active? new-opiskeluoikeus-oid)
       (throw (ex-info (format "Opiskeluoikeus `%s` is no longer active"
                               new-opiskeluoikeus-oid)
-                      {:type               :disallowed-update
+                      {:type               ::disallowed-update
                        :opiskeluoikeus-oid new-opiskeluoikeus-oid})))
     (when (and (some? new-opiskeluoikeus-oid)
                (not= new-opiskeluoikeus-oid old-opiskeluoikeus-oid))
       (throw (ex-info "Updating `opiskeluoikeus-oid` in HOKS is not allowed!"
-                      {:type                   :disallowed-update
+                      {:type                   ::disallowed-update
                        :old-opiskeluoikeus-oid old-opiskeluoikeus-oid
                        :new-opiskeluoikeus-oid new-opiskeluoikeus-oid})))
     (when (oppija-oid-changed? new-oppija-oid old-oppija-oid)
@@ -344,7 +344,7 @@
           (throw (ex-info
                    (str "Updating `oppija-oid` in HOKS is only allowed with "
                         "latest master oppija oid!")
-                   {:type           :disallowed-update
+                   {:type           ::disallowed-update
                     :old-oppija-oid old-oppija-oid
                     :new-oppija-oid new-oppija-oid})))))))
 
@@ -359,14 +359,14 @@
       (-> (format "Opiskeluoikeus `%s` does not match any held by oppija `%s`"
                   opiskeluoikeus-oid
                   oppija-oid)
-          (ex-info {:type               :disallowed-update
+          (ex-info {:type               ::disallowed-update
                     :opiskeluoikeus-oid opiskeluoikeus-oid
                     :oppija-oid         oppija-oid})
           throw))
     (when-not (opiskeluoikeus/still-active? hoks opiskeluoikeudet)
       (throw (ex-info (format "Opiskeluoikeus `%s` is no longer active"
                               opiskeluoikeus-oid)
-                      {:type               :disallowed-update
+                      {:type               ::disallowed-update
                        :opiskeluoikeus-oid opiskeluoikeus-oid})))
     (save! hoks)))
 

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -192,9 +192,11 @@
   [oid oppija-oid]
   (let [opiskeluoikeus (k/get-existing-opiskeluoikeus! oid)]
     (when (opiskeluoikeus/linked-to-another? opiskeluoikeus)
-      (throw (ex-info "Opiskeluoikeus sisältyy toiseen opiskeluoikeuteen"
-                      {:type               ::invalid-opiskeluoikeus
-                       :opiskeluoikeus-oid oid})))
+      (throw (ex-info
+               (format "Opiskeluoikeus `%s` sisältyy toiseen opiskeluoikeuteen."
+                       oid)
+               {:type               ::invalid-opiskeluoikeus
+                :opiskeluoikeus-oid oid})))
     (when (> (count (:suoritukset opiskeluoikeus)) 1)
       (log/warnf
         "Opiskeluoikeus %s has multiple suoritukset. First is used for tutkinto"

--- a/src/oph/ehoks/oppijaindex.clj
+++ b/src/oph/ehoks/oppijaindex.clj
@@ -193,7 +193,7 @@
   (let [opiskeluoikeus (k/get-existing-opiskeluoikeus! oid)]
     (when (opiskeluoikeus/linked-to-another? opiskeluoikeus)
       (throw (ex-info "Opiskeluoikeus sisältyy toiseen opiskeluoikeuteen"
-                      {:type               :disallowed-update
+                      {:type               ::invalid-opiskeluoikeus
                        :opiskeluoikeus-oid oid})))
     (when (> (count (:suoritukset opiskeluoikeus)) 1)
       (log/warnf

--- a/test/oph/ehoks/external/cas_test.clj
+++ b/test/oph/ehoks/external/cas_test.clj
@@ -132,7 +132,7 @@
                      nil
                      (catch Exception e
                        e))]
-        (is (= :unauthorized (:type (ex-data result)))))
+        (is (= ::c/unauthorized (:type (ex-data result)))))
       (is (= @get-st-call-count 2))))
   (testing "Add service ticket immediately throws when get ST returns 500"
     (let [get-st-call-count (atom 0)]
@@ -148,7 +148,7 @@
                      nil
                      (catch Exception e
                        e))]
-        (is (= :unauthorized (:type (ex-data result)))))
+        (is (= ::c/unauthorized (:type (ex-data result)))))
       ; not trying to retry in this case
       (is (= @get-st-call-count 1)))))
 

--- a/test/oph/ehoks/external/koski_test.clj
+++ b/test/oph/ehoks/external/koski_test.clj
@@ -35,7 +35,10 @@
      :koulutustoimija {:oid "1.2.246.562.10.10000000009"}}
     "1.246.562.15.12345678911" {}
     "1.246.562.15.12345678910"
-    (throw (ex-info "Internal server error" {:status 500}))
+    (throw (ex-info
+             "Bad request"
+             {:status 400
+              :body   (str "[{\"key\": \"badRequest.format.number\"}]")}))
     "1.2.246.562.15.12345678903" {}
     "1.2.246.562.15.23456789017"
     {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
@@ -58,7 +61,10 @@
     (testing "The function throws on exceptional status codes."
       (is (thrown-with-msg?
             ExceptionInfo
-            #"Error while fetching opiskeluoikeus from Koski"
+            (re-pattern
+              (str "Error while fetching opiskeluoikeus "
+                   "`1.246.562.15.12345678910` from Koski. "
+                   "Koski-virhekoodi is `badRequest.format.number`."))
             (k/get-opiskeluoikeus! "1.246.562.15.12345678910"))))))
 
 (deftest test-get-existing-opiskeluoikeus!
@@ -72,8 +78,12 @@
     (testing "The function throws on exceptional status codes."
       (is (thrown-with-msg?
             ExceptionInfo
-            #"Error while fetching opiskeluoikeus from Koski"
+            (re-pattern
+              (str "Error while fetching opiskeluoikeus "
+                   "`1.246.562.15.12345678910` from Koski. "
+                   "Koski-virhekoodi is `badRequest.format.number`."))
             (k/get-opiskeluoikeus! "1.246.562.15.12345678910"))))))
+
 (deftest test-get-oppija-opiskeluoikeudet
   (testing "Get opiskeluoikeudet for oppija"
     (client/set-post!

--- a/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/invalid_hoks_handler_test.clj
@@ -222,7 +222,10 @@
       (is (= (:status put-response) 400))
       (is (= (test-utils/parse-body (:body put-response))
              {:error
-              "Updating `opiskeluoikeus-oid` in HOKS is not allowed!"})))))
+              (str "Tried to update `opiskeluoikeus-oid` from "
+                   "`1.2.246.562.15.10000000009` to "
+                   "`1.2.246.562.15.20000000008` but updating "
+                   "`opiskeluoikeus-oid` in HOKS is not allowed!")})))))
 
 (deftest prevent-updating-oppija-oid
   (testing "Prevent PUT HOKS with existing opiskeluoikeus"
@@ -243,9 +246,11 @@
       (is (= (:status post-response) 200))
       (is (= (:status put-response) 400))
       (is (= (test-utils/parse-body (:body put-response))
-             {:error
-              (str "Updating `oppija-oid` in HOKS is only allowed with "
-                   "latest master oppija oid!")})))))
+             {:error (str "Tried to update `oppija-oid` from "
+                          "`1.2.246.562.24.12312312319` to "
+                          "`1.2.246.562.24.12312312322` but updating "
+                          "`oppija-oid` in HOKS is only allowed with latest "
+                          "master oppija oid!")})))))
 
 (deftest prevent-invalid-osaamisen-hankkimistapa
   (testing "Start and end dates of OHT are checked"

--- a/test/oph/ehoks/oppijaindex_test.clj
+++ b/test/oph/ehoks/oppijaindex_test.clj
@@ -655,7 +655,8 @@
       (t/is
         (thrown-with-msg?
           ExceptionInfo
-          #"Opiskeluoikeus sisältyy toiseen opiskeluoikeuteen"
+          (re-pattern (str "Opiskeluoikeus `1.2.246.562.15.50000000005` "
+                           "sisältyy toiseen opiskeluoikeuteen."))
           (sut/add-opiskeluoikeus!
             "1.2.246.562.15.50000000005" "1.2.246.562.24.11111111110")))
       (t/is

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -1049,7 +1049,10 @@
         (t/is (= (:status patch-response) 400))
         (t/is (= (test-utils/parse-body (:body patch-response))
                  {:error
-                  "Updating `opiskeluoikeus-oid` in HOKS is not allowed!"}))))))
+                  (str "Tried to update `opiskeluoikeus-oid` from "
+                       "`1.2.246.562.15.76000000018` to "
+                       "`1.2.246.562.15.76000000000` but updating "
+                       "`opiskeluoikeus-oid` in HOKS is not allowed!")}))))))
 
 (t/deftest prevent-patch-hoks-with-updated-oppija-oid
   (t/testing "PATCH hoks virkailija"
@@ -1072,9 +1075,11 @@
               virkailija-for-test)]
         (t/is (= (:status patch-response) 400))
         (t/is (= (test-utils/parse-body (:body patch-response))
-                 {:error
-                  (str "Updating `oppija-oid` in HOKS is only allowed with "
-                       "latest master oppija oid!")}))))))
+                 {:error (str "Tried to update `oppija-oid` from "
+                              "`1.2.246.562.24.44000000008` to "
+                              "`1.2.246.562.24.12000000014` but updating "
+                              "`oppija-oid` in HOKS is only allowed with "
+                              "latest master oppija oid!")}))))))
 
 (def hoks-data
   {:opiskeluoikeus-oid "1.2.246.562.15.76000000018"
@@ -1226,7 +1231,10 @@
         (t/is (= (:status put-response) 400))
         (t/is (= put-body
                  {:error
-                  "Updating `opiskeluoikeus-oid` in HOKS is not allowed!"}))))))
+                  (str "Tried to update `opiskeluoikeus-oid` from "
+                       "`1.2.246.562.15.76000000018` to "
+                       "`1.2.246.562.15.76000000000` but updating "
+                       "`opiskeluoikeus-oid` in HOKS is not allowed!")}))))))
 
 (t/deftest test-put-prevent-updating-oppija-oid
   (t/testing "PUT hoks virkailija"
@@ -1267,9 +1275,11 @@
             put-body (test-utils/parse-body (:body put-response))]
         (t/is (= (:status put-response) 400))
         (t/is (= put-body
-                 {:error
-                  (str "Updating `oppija-oid` in HOKS is only allowed with "
-                       "latest master oppija oid!")}))))))
+                 {:error (str "Tried to update `oppija-oid` from "
+                              "`1.2.246.562.24.44000000008` to "
+                              "`1.2.246.562.24.45000000007` but updating "
+                              "`oppija-oid` in HOKS is only allowed with "
+                              "latest master oppija oid!")}))))))
 
 (t/deftest test-allow-updating-oppija-oid
   (t/testing "Allows changing a slave oppija-oid to master"


### PR DESCRIPTION
## Kuvaus muutoksista

Selvittelen https://jira.eduuni.fi/browse/EH-1703 ongelmaa. Huomasin, että AMISTimedOperationsHandler-lambdan triggeröimässä opiskelijapalauteherätteiden uudelleenlähetyksessä `palaute/opiskelija.clj` opiskeluoikeuden hakeminen Koskesta epäonnistuu syystä X, ja tämä mitä varmimmin saa koko lambdan ajon epäonnistumaan (molempien ongelmien alkamisajankohta, 12.8. klo 8:30, täsmää).

Tein tämän pienen muutoksen tukemaan ongelman selvittelyä, mutta auttaa tottakai vastaisuudessakin vastaavanlaisissa tilanteissa. Muutoksen kautta saisi lokeille poikkeuksen viestin lisäksi näkymään `ex-data`-tiedot poikkeuksen ollessa tyyppiä `ExceptionInfo`.

https://jira.eduuni.fi/browse/EH-1703

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
