### PR TITLE
EH-1585: Prevent updating tep-kasitelty if no handling was actually done

### DIFF
--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -314,9 +314,11 @@
           ; Aseta tep_kasitelty arvoon true jotta herätepalvelu ei yritä
           ; tehdä vastaavaa operaatiota siirtymävaiheen/asennuksien aikana.
           ; FIXME poista tep_kasitelty-logiikka siirtymävaiheen jälkeen?
-          (assert
-            (palaute/update-tep-kasitelty!
-              tx {:tep-kasitelty true :id (:hankkimistapa-id tep-palaute)}))
+          (if-not tunnus
+            (log/warn "No vastaajatunnus got from arvo, so not marking handled")
+            (assert
+              (palaute/update-tep-kasitelty!
+                tx {:tep-kasitelty true :id (:hankkimistapa-id tep-palaute)})))
           (catch ExceptionInfo e
             (log/errorf e
                         (str "Error updating palaute %d, trying to remove "


### PR DESCRIPTION
## Kuvaus muutoksista

Tämän muutoksen pointti on huolehtia, ettei EH-1585:n koodi muuttele muuta kuin palautetauluja, ennen kuin se on oikeasti käytössä.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
