### PR TITLE
EH-1689: fix validators failing when there is no current opiskeluoikeus

### DIFF
--- a/src/oph/ehoks/middleware.clj
+++ b/src/oph/ehoks/middleware.clj
@@ -123,7 +123,8 @@
   []
   (when (= :none *current-opiskeluoikeus*)
     (throw (ex-info "get-current-opiskeluoikeus outside wrap-opiskeluoikeus"
-                    {:error-type :internal})))
+                    {:type ::not-in-wrap-opiskeluoikeus
+                     :error-type :internal})))
   *current-opiskeluoikeus*)
 
 (defn wrap-opiskeluoikeus


### PR DESCRIPTION
## Kuvaus muutoksista

The failures usually realise in API endpoints that return and validate HOKSes.  This is because the current opiskeluoikeus is usually fetched only in endpoints that need to validate new data.  The failing validations cause a lot of false alarms in logs, and are so numerous that they actually make it harder to use the logs.

https://jira.eduuni.fi/browse/EH-1689

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
