### PR TITLE
EH-1704: fixes to tyoelamapalaute logic

### DIFF
--- a/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
+++ b/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
@@ -1,12 +1,24 @@
 (ns oph.ehoks.hoks.osaamisen-hankkimistapa
   (:import [java.time LocalDate]))
 
+(def tyopaikkajakso-type?
+  #{"osaamisenhankkimistapa_koulutussopimus"
+    "osaamisenhankkimistapa_oppisopimus"})
+
 (defn tyopaikkajakso?
-  "Onko osaamisen hankkimistapa työpaikkajakso?"
+  "Whether osaamisen hankkimistapa `oht` is tyopaikkajakso."
   [oht]
-  (#{"osaamisenhankkimistapa_koulutussopimus"
-     "osaamisenhankkimistapa_oppisopimus"}
-    (:osaamisen-hankkimistapa-koodi-uri oht)))
+  (tyopaikkajakso-type? (:osaamisen-hankkimistapa-koodi-uri oht)))
+
+(defn palautteenkeruu-allowed-tyopaikkajakso?
+  "Whether oht is a työpaikkajakso from which we can collect feedback."
+  [oht]
+  (and (tyopaikkajakso? oht)
+       (every?
+         #(get-in oht %)
+         [[:tyopaikalla-jarjestettava-koulutus :vastuullinen-tyopaikka-ohjaaja]
+          [:tyopaikalla-jarjestettava-koulutus :tyopaikan-nimi]
+          [:tyopaikalla-jarjestettava-koulutus :tyopaikan-y-tunnus]])))
 
 (defn- should-check-hankkimistapa-y-tunnus?
   "Tarkistaa, loppuuko osaamisen hankkimistapa käyttöönottopäivämäärän jälkeen."
@@ -20,3 +32,12 @@
        (should-check-hankkimistapa-y-tunnus? oht)
        (:tyopaikalla-jarjestettava-koulutus oht)
        (-> oht :tyopaikalla-jarjestettava-koulutus :tyopaikan-y-tunnus nil?)))
+
+(defn has-required-osa-aikaisuustieto?
+  "Onko jaksossa osa-aikaisuustieto, jos pitäisi olla?"
+  [oht]
+  (let [osa-aikaisuustieto (:osa-aikaisuustieto oht)]
+    (or (not (.isAfter ^LocalDate (:loppu oht) (LocalDate/of 2023 6 30)))
+        (not (tyopaikkajakso? oht))
+        (and (some? osa-aikaisuustieto)
+             (<= 1 osa-aikaisuustieto 100)))))

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -237,14 +237,8 @@
   "Varmistaa, että jakson osa-aikaisuustieto on välillä 1-100, mikäli
   työpaikkajakson loppupäivä on 1.7.2023 tai sen jälkeen."
   [oht]
-  (let [osa-aikaisuustieto (:osa-aikaisuustieto oht)]
-    (if (and (.isAfter ^LocalDate (:loppu oht) (LocalDate/of 2023 6 30))
-             (oht/tyopaikkajakso? oht)
-             (kuuluu-palautteen-kohderyhmaan? (get-current-opiskeluoikeus)))
-      (and (some? osa-aikaisuustieto)
-           (<= osa-aikaisuustieto 100)
-           (>= osa-aikaisuustieto 1))
-      true)))
+  (or (not (kuuluu-palautteen-kohderyhmaan? (get-current-opiskeluoikeus)))
+      (oht/has-required-osa-aikaisuustieto? oht)))
 
 (defn- oppisopimus-has-perusta?
   "Varmistaa, että osaamisen hankkimistavassa on oppisopimuksen perusta, jos

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -94,12 +94,10 @@
 (defn vastaamisajan-loppupvm
   "Laskee vastausajan loppupäivämäärän: 30 päivän päästä (inklusiivisesti),
   mutta ei myöhempi kuin 60 päivää (inklusiivisesti) herätepäivän jälkeen."
-  [^LocalDate herate ^LocalDate alku]
-  (let [last   (.plusDays herate 59)
-        normal (.plusDays alku 29)]
-    (if (.isBefore last normal)
-      last
-      normal)))
+  [^LocalDate heratepvm ^LocalDate alkupvm]
+  (let [last   (.plusDays heratepvm 59)
+        normal (.plusDays alkupvm 29)]
+    (if (.isBefore last normal) last normal)))
 
 (defn get-opiskeluoikeusjakso-for-date
   "Hakee opiskeluoikeudesta jakson, joka on voimassa tiettynä päivänä."

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -6,6 +6,8 @@
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.organisaatio :as organisaatio]
             [oph.ehoks.oppijaindex :as oppijaindex]
+            [oph.ehoks.opiskeluoikeus :as opiskeluoikeus]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute.tapahtuma :as palautetapahtuma]
             [oph.ehoks.utils.date :as date])
   (:import [java.time LocalDate]))
@@ -133,3 +135,34 @@
       (if (> month 6)
         (str year "-" (inc year))
         (str (dec year) "-" year)))))
+
+(defn initial-palaute-state-and-reason-if-not-kohderyhma
+  "Partial function; returns initial state, field causing it, and why the
+  field causes the initial state - but only if the palaute is not to be
+  collected because it's not part of kohderyhmä; otherwise returns nil."
+  [herate-date-field hoks-or-jakso opiskeluoikeus]
+  (let [herate-date (get hoks-or-jakso herate-date-field)]
+    (cond
+      (not opiskeluoikeus)
+      [nil :opiskeluoikeus-oid :ei-loydy]
+
+      (not herate-date)
+      [nil herate-date-field :ei-ole]
+
+      (not (valid-herate-date? herate-date))
+      [:ei-laheteta herate-date-field :eri-rahoituskaudella]
+
+      (not-any? suoritus/ammatillinen? (:suoritukset opiskeluoikeus))
+      [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen]
+
+      (opiskeluoikeus/in-terminal-state? opiskeluoikeus herate-date)
+      [:ei-laheteta :opiskeluoikeus-oid :opiskelu-paattynyt]
+
+      (feedback-collecting-prevented? opiskeluoikeus herate-date)
+      [:ei-laheteta :opiskeluoikeus-oid :ulkoisesti-rahoitettu]
+
+      (opiskeluoikeus/tuva? opiskeluoikeus)
+      [:ei-laheteta :opiskeluoikeus-oid :tuva-opiskeluoikeus]
+
+      (opiskeluoikeus/linked-to-another? opiskeluoikeus)
+      [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus])))

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -42,7 +42,7 @@
          (:hankittavat-paikalliset-tutkinnon-osat hoks)
          (mapcat :osa-alueet (:hankittavat-yhteiset-tutkinnon-osat hoks)))
        (mapcat :osaamisen-hankkimistavat)
-       (filter oht/palautteenkeruu-allowed-tyopaikkajakso?)))
+       (filter oht/tyopaikkajakso?)))
 
 (defn next-niputus-date
   "Palauttaa seuraavan niputuspäivämäärän annetun päivämäärän jälkeen.
@@ -79,6 +79,9 @@
     (cond
       (palaute/already-initiated? existing-herate)
       [nil :yksiloiva-tunniste :jo-lahetetty]
+
+      (not (oht/palautteenkeruu-allowed-tyopaikkajakso? jakso))
+      [:ei-laheteta :tyopaikalla-jarjestettava-koulutus :puuttuva-yhteystieto]
 
       (opiskeluoikeus/in-terminal-state? opiskeluoikeus (:loppu jakso))
       [:ei-laheteta :opiskeluoikeus-oid :opiskelu-paattynyt]

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -3,7 +3,6 @@
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as string]
-            [hugsql.core :as hugsql]
             [medley.core :refer [find-first]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.db-helpers :as db-helpers]
@@ -118,7 +117,7 @@
               koulutustoimija  (palaute/koulutustoimija-oid! opiskeluoikeus)
               toimipiste-oid   (palaute/toimipiste-oid! suoritus)
               heratepvm        (:loppu jakso)
-              other-info       (select-keys hoks [field])]
+              other-info       (select-keys (merge jakso hoks) [field])]
           (palaute/upsert!
             tx
             {:kyselytyyppi       "tyopaikkajakson_suorittaneet"

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -183,9 +183,7 @@
   "Takes a `hoks` and `opiskeluoikeus` and initiates tyoelamapalaute for all
   tyopaikkajaksos in HOKS for which palaute has not been already initiated."
   [hoks opiskeluoikeus]
-  (->> (tyopaikkajaksot hoks)
-       (map #(initiate-if-needed! % hoks opiskeluoikeus))
-       doall))
+  (run! #(initiate-if-needed! % hoks opiskeluoikeus) (tyopaikkajaksot hoks)))
 
 (defn- deaccent-string
   "Poistaa diakriittiset merkit stringistä ja palauttaa muokatun stringin."

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -71,12 +71,6 @@
         (LocalDate/of (inc year) 1 1)
         (LocalDate/of year (inc month) 1)))))
 
-(defn voimassa-loppupvm
-  "Given `voimassa-alkupvm`, calculates `voimassa-loppupvm`, which is currently
-  60 days after `voimassa-alkupvm`."
-  [^LocalDate voimassa-alkupvm]
-  (.plusDays voimassa-alkupvm 60))
-
 (defn osa-aikaisuus-missing?
   "Puuttuuko tieto osa-aikaisuudesta jaksosta, jossa sen pitäisi olla?"
   [jakso]
@@ -157,6 +151,7 @@
                                            (:suoritukset opiskeluoikeus))
               koulutustoimija  (palaute/koulutustoimija-oid! opiskeluoikeus)
               toimipiste-oid   (palaute/toimipiste-oid! suoritus)
+              heratepvm        (:loppu jakso)
               other-info       (select-keys hoks [field])]
           (palaute/upsert!
             tx
@@ -164,9 +159,10 @@
              :tila               "odottaa_kasittelya"
              :hoks-id            (:id hoks)
              :yksiloiva-tunniste (:yksiloiva-tunniste jakso)
-             :heratepvm          (:loppu jakso)
+             :heratepvm          heratepvm
              :voimassa-alkupvm   voimassa-alkupvm
-             :voimassa-loppupvm  (voimassa-loppupvm voimassa-alkupvm)
+             :voimassa-loppupvm  (palaute/vastaamisajan-loppupvm
+                                   heratepvm voimassa-alkupvm)
              :koulutustoimija    koulutustoimija
              :toimipiste-oid     toimipiste-oid
              :tutkintonimike     (suoritus/tutkintonimike suoritus)

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -122,13 +122,10 @@
           [init-state field reason]
           (initial-palaute-state-and-reason
             jakso hoks opiskeluoikeus existing-heratteet)]
-      (log/infof (str "Initial state for jakso `%s` of HOKS `%d` will be `%s` "
-                      "because of `%s` in `%s`.")
-                 (:yksiloiva-tunniste jakso)
-                 (:id hoks)
-                 (or init-state :ei-luoda-ollenkaan)
-                 reason
-                 field)
+      (log/info "Initial state for jakso" (:yksiloiva-tunniste jakso)
+                "of HOKS" (:id hoks) "will be"
+                (or init-state :ei-luoda-ollenkaan)
+                "because of" reason "in" field)
       (when init-state
         (let [voimassa-alkupvm (next-niputus-date (:loppu jakso))
               suoritus         (find-first suoritus/ammatillinen?

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -75,9 +75,9 @@
   decision was based on, and the reason for picking that state."
   ([jakso hoks opiskeluoikeus]
     (initial-palaute-state-and-reason jakso hoks opiskeluoikeus nil))
-  ([jakso hoks opiskeluoikeus existing-herate]
+  ([jakso hoks opiskeluoikeus existing-heratteet]
     (cond
-      (palaute/already-initiated? existing-herate)
+      (palaute/already-initiated? existing-heratteet)
       [nil :yksiloiva-tunniste :jo-lahetetty]
 
       (not (oht/palautteenkeruu-allowed-tyopaikkajakso? jakso))
@@ -114,13 +114,14 @@
   [jakso hoks opiskeluoikeus]
   (jdbc/with-db-transaction
     [tx db/spec]
-    (let [existing-herate (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
-                            tx
-                            {:hoks-id            (:id hoks)
-                             :yksiloiva-tunniste (:yksiloiva-tunniste jakso)})
+    (let [existing-heratteet  ; always 0 or 1 herate
+          (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
+            tx
+            {:hoks-id            (:id hoks)
+             :yksiloiva-tunniste (:yksiloiva-tunniste jakso)})
           [init-state field reason]
           (initial-palaute-state-and-reason
-            jakso hoks opiskeluoikeus existing-herate)]
+            jakso hoks opiskeluoikeus existing-heratteet)]
       (log/infof (str "Initial state for jakso `%s` of HOKS `%d` will be `%s` "
                       "because of `%s` in `%s`.")
                  (:yksiloiva-tunniste jakso)
@@ -151,7 +152,7 @@
              :tutkintonimike     (suoritus/tutkintonimike suoritus)
              :tutkintotunnus     (suoritus/tutkintotunnus suoritus)
              :herate-source      "ehoks_update"}
-            [existing-herate]
+            existing-heratteet
             reason
             other-info))))))
 

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -10,6 +10,11 @@
   [^LocalDate one-date ^LocalDate other-date]
   (.isAfter one-date other-date))
 
+(defn is-same-or-before
+  "Käännetty .isAfter"
+  [^LocalDate one-date ^LocalDate other-date]
+  (not (is-after one-date other-date)))
+
 (defn is-before
   "Wrapper .isBefore-metodin ympäri, jolla on tyyppianotaatiot."
   [^LocalDate one-date ^LocalDate other-date]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -33,7 +33,7 @@
                      [:aloituskysely :paattokysely])]
       (let [state-and-reason
             (op/initial-palaute-state-and-reason
-              kysely hoks opiskeluoikeus nil)]
+              kysely hoks opiskeluoikeus [])]
         (is (contains? #{:ei-laheteta nil} (first state-and-reason)))
         (is (= (last state-and-reason) reason))))))
 
@@ -118,14 +118,14 @@
       (testing
        "initiate aloituskysely if `osaamisen-hankkimisen-tarve` is `true`."
         (is (= (op/initial-palaute-state-and-reason
-                 :aloituskysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
+                 :aloituskysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                [:odottaa-kasittelya nil :hoks-tallennettu])))
 
       (testing
        (str "initiate paattokysely if `osaamisen-hankkimisen-tarve` is "
             "`true` and `osaamisen-saavuttamisen-pvm` is not missing.")
         (is (= (op/initial-palaute-state-and-reason
-                 :paattokysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
+                 :paattokysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                [:odottaa-kasittelya nil :hoks-tallennettu]))))))
 
 (defn expected-msg

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -97,25 +97,23 @@
       (testing "don't initiate kysely if"
         (testing "there is already herate for tyopaikkajakso."
           (is (= (tep/initial-palaute-state-and-reason
-                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-5
-                   {:yksiloiva-tunniste "asd"})
+                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1
+                   [{:yksiloiva-tunniste "asd"}])
                  [nil :yksiloiva-tunniste :jo-lahetetty])))
         (testing "opiskeluoikeus is in terminal state."
           (is (= (tep/initial-palaute-state-and-reason
-                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-5)
+                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-5 [])
                  [:ei-laheteta :opiskeluoikeus-oid :opiskelu-paattynyt])))
         (testing "osa-aikaisuus is missing from työpaikkajakso"
           (is (= (tep/initial-palaute-state-and-reason
                    (dissoc test-jakso :osa-aikaisuustieto)
-                   hoks-test/hoks-1
-                   oo-test/opiskeluoikeus-1)
+                   hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                  [:ei-laheteta :osa-aikaisuustieto :ei-ole])))
         (testing "workplace information is missing from työpaikkajakso"
           (is (= (tep/initial-palaute-state-and-reason
                    (update test-jakso :tyopaikalla-jarjestettava-koulutus
                            dissoc :tyopaikan-y-tunnus)
-                   hoks-test/hoks-1
-                   oo-test/opiskeluoikeus-1)
+                   hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                  [:ei-laheteta :tyopaikalla-jarjestettava-koulutus
                   :puuttuva-yhteystieto])))
         (testing "työpaikkajakso is interrupted on it's end date"
@@ -124,16 +122,15 @@
                              [:keskeytymisajanjaksot 1]
                              {:alku  (LocalDate/of 2023 12 1)
                               :loppu (LocalDate/of 2023 12 15)})
-                   hoks-test/hoks-1
-                   oo-test/opiskeluoikeus-1)
+                   hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                  [:ei-laheteta :keskeytymisajanjaksot :jakso-keskeytynyt])))
         (testing "opiskeluoikeus doesn't have any ammatillinen suoritus"
           (is (= (tep/initial-palaute-state-and-reason
-                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-2)
+                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-2 [])
                  [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen])))
         (testing "there is a feedback preventing code in opiskeluoikeusjakso."
           (is (= (tep/initial-palaute-state-and-reason
-                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-4)
+                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-4 [])
                  [:ei-laheteta :opiskeluoikeus-oid :ulkoisesti-rahoitettu])))
         (testing "HOKS is a TUVA-HOKS or a HOKS related to TUVA-HOKS."
           (doseq [test-hoks [(assoc hoks-test/hoks-1
@@ -143,7 +140,7 @@
                                     :tuva-opiskeluoikeus-oid
                                     "1.2.246.562.15.88406700034")]]
             (is (= (tep/initial-palaute-state-and-reason
-                     test-jakso test-hoks oo-test/opiskeluoikeus-1)
+                     test-jakso test-hoks oo-test/opiskeluoikeus-1 [])
                    [:ei-laheteta
                     :tuva-opiskeluoikeus-oid
                     :tuva-opiskeluoikeus]))))
@@ -152,15 +149,16 @@
                    test-jakso
                    hoks-test/hoks-1
                    (assoc-in oo-test/opiskeluoikeus-1
-                             [:tyyppi :koodiarvo] "tuva"))
+                             [:tyyppi :koodiarvo] "tuva")
+                   [])
                  [:ei-laheteta :opiskeluoikeus-oid :tuva-opiskeluoikeus])))
         (testing "opiskeluoikeus is linked to another opiskeluoikeus"
           (is (= (tep/initial-palaute-state-and-reason
-                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-3)
+                   test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-3 [])
                  [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus]))))
       (testing "initiate kysely if when all of the checks are OK."
         (is (= (tep/initial-palaute-state-and-reason
-                 test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
+                 test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
                [:odottaa-kasittelya nil :hoks-tallennettu]))))))
 
 (defn- build-expected-herate
@@ -222,7 +220,7 @@
             test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
           (is (logged? 'oph.ehoks.palaute.tyoelama
                        :info
-                       #"`:jo-lahetetty`")))))))
+                       #":jo-lahetetty")))))))
 
 (deftest test-initiate-all-uninitiated!
   (with-redefs [date/now (constantly (LocalDate/of 2023 10 18))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -36,6 +36,7 @@
    :alku (LocalDate/of 2023 9 9)
    :loppu (LocalDate/of 2023 12 15)
    :osa-aikaisuustieto 100
+   :osaamisen-hankkimistapa-koodi-uri "osaamisenhankkimistapa_oppisopimus"
    :oppija-oid "123.456.789"
    :tyyppi "test-tyyppi"
    :tutkinnonosa-id "test-tutkinnonosa-id"
@@ -52,18 +53,6 @@
       "2021-12-27" "2022-01-01"
       "2021-04-25" "2021-05-01"
       "2022-06-24" "2022-07-01")))
-
-(deftest test-osa-aikaisuus-missing?
-  (testing "The function returns"
-    (testing "`true` when osa-aikaisuus is missing."
-      (are [jakso] (true? (tep/osa-aikaisuus-missing? jakso))
-        {:osa-aikaisuustieto nil :loppu (LocalDate/of 2023 8 1)}
-        {:loppu (LocalDate/of 2023 8 1)}))
-    (testing "falsey value when osa-aikaisuus is not missing."
-      (are [jakso] (not (tep/osa-aikaisuus-missing? jakso))
-        {:osa-aikaisuustieto nil :loppu (LocalDate/of 2023 6 30)}
-        {:loppu (LocalDate/of 2023 6 30)}
-        {:osa-aikaisuustieto 30 :loppu (LocalDate/of 2023 8 1)}))))
 
 (deftest test-fully-keskeytynyt?
   (testing "fully-keskeytynyt?"
@@ -199,7 +188,7 @@
         (let [tapahtumat (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                            db/spec
                            {:hoks-id      (:id hoks-test/hoks-1)
-                            :kyselytyypit tep/kyselytyypit})]
+                            :kyselytyypit ["tyopaikkajakson_suorittaneet"]})]
           (is (= (count tapahtumat) 1))
           (is (= (dissoc (first tapahtumat) :id :created-at :updated-at)
                  {:palaute-id   1

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -78,11 +78,14 @@
                                             :loppu (LocalDate/of 2021 8 4)}]
                    :loppu (LocalDate/of 2021 8 11)}
           herate3 {}
-          herate4 {:keskeytymisajanjaksot [{:alku (LocalDate/of 2021 8 8)}]}]
+          herate4 {:keskeytymisajanjaksot [{:alku (LocalDate/of 2021 8 8)}]
+                   :loppu (LocalDate/of 2021 8 11)}
+          herate5 {:keskeytymisajanjaksot [{:alku (LocalDate/of 2021 8 8)}]}]
       (is (tep/fully-keskeytynyt? herate1))
       (is (not (tep/fully-keskeytynyt? herate2)))
       (is (not (tep/fully-keskeytynyt? herate3)))
-      (is (not (tep/fully-keskeytynyt? herate4))))))
+      (is (tep/fully-keskeytynyt? herate4))
+      (is (not (tep/fully-keskeytynyt? herate5))))))
 
 (deftest test-tyopaikkajaksot
   (testing (str "The function returns osaamisen hankkimistavat with koodi-uri"

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -102,19 +102,17 @@
           (is (= (tep/initial-palaute-state-and-reason
                    test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-5
                    {:yksiloiva-tunniste "asd"})
-                 [nil nil :jaksolle-loytyy-jo-herate])))
+                 [nil :yksiloiva-tunniste :jo-lahetetty])))
         (testing "opiskeluoikeus is in terminal state."
           (is (= (tep/initial-palaute-state-and-reason
                    test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-5)
-                 [:ei-laheteta
-                  :opiskeluoikeus-oid
-                  :opiskeluoikeus-terminaalitilassa])))
+                 [:ei-laheteta :opiskeluoikeus-oid :opiskelu-paattynyt])))
         (testing "osa-aikaisuus is missing from työpaikkajakso"
           (is (= (tep/initial-palaute-state-and-reason
                    (dissoc test-jakso :osa-aikaisuustieto)
                    hoks-test/hoks-1
                    oo-test/opiskeluoikeus-1)
-                 [:ei-laheteta nil :osa-aikaisuus-puuttuu])))
+                 [:ei-laheteta :osa-aikaisuustieto :ei-ole])))
         (testing "työpaikkajakso is interrupted on it's end date"
           (is (= (tep/initial-palaute-state-and-reason
                    (assoc-in test-jakso
@@ -123,7 +121,7 @@
                               :loppu (LocalDate/of 2023 12 15)})
                    hoks-test/hoks-1
                    oo-test/opiskeluoikeus-1)
-                 [:ei-laheteta nil :tyopaikkajakso-keskeytynyt])))
+                 [:ei-laheteta :keskeytymisajanjaksot :jakso-keskeytynyt])))
         (testing "opiskeluoikeus doesn't have any ammatillinen suoritus"
           (is (= (tep/initial-palaute-state-and-reason
                    test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-2)
@@ -131,7 +129,7 @@
         (testing "there is a feedback preventing code in opiskeluoikeusjakso."
           (is (= (tep/initial-palaute-state-and-reason
                    test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-4)
-                 [:ei-laheteta :opiskeluoikeus-oid :rahoitusperuste])))
+                 [:ei-laheteta :opiskeluoikeus-oid :ulkoisesti-rahoitettu])))
         (testing "HOKS is a TUVA-HOKS or a HOKS related to TUVA-HOKS."
           (doseq [test-hoks [(assoc hoks-test/hoks-1
                                     :hankittavat-koulutuksen-osat
@@ -154,12 +152,7 @@
         (testing "opiskeluoikeus is linked to another opiskeluoikeus"
           (is (= (tep/initial-palaute-state-and-reason
                    test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-3)
-                 [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus])))
-        (with-redefs [date/now #(LocalDate/of 2024 6 30)]
-          (testing "jakso is in the past"
-            (is (= (tep/initial-palaute-state-and-reason
-                     test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
-                   [:ei-laheteta :loppu :menneisyydessa])))))
+                 [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus]))))
       (testing "initiate kysely if when all of the checks are OK."
         (is (= (tep/initial-palaute-state-and-reason
                  test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
@@ -222,7 +215,7 @@
             test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
           (is (logged? 'oph.ehoks.palaute.tyoelama
                        :info
-                       #"`:jaksolle-loytyy-jo-herate`")))))))
+                       #"`:jo-lahetetty`")))))))
 
 (deftest test-initiate-all-uninitiated!
   (with-redefs [date/now (constantly (LocalDate/of 2023 10 18))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -160,16 +160,18 @@
 
 (defn- build-expected-herate
   [jakso hoks]
-  (let [voimassa-alkupvm (tep/next-niputus-date (:loppu jakso))]
+  (let [heratepvm (:loppu jakso)
+        voimassa-alkupvm (tep/next-niputus-date heratepvm)]
     {:tila                           "odottaa_kasittelya"
      :kyselytyyppi                   "tyopaikkajakson_suorittaneet"
      :hoks-id                        (:id hoks)
      :jakson-yksiloiva-tunniste      (:yksiloiva-tunniste jakso)
-     :heratepvm                      (:loppu jakso)
+     :heratepvm                      heratepvm
      :tutkintotunnus                 351407
      :tutkintonimike                 "(\"12345\",\"23456\")"
      :voimassa-alkupvm               voimassa-alkupvm
-     :voimassa-loppupvm              (tep/voimassa-loppupvm voimassa-alkupvm)
+     :voimassa-loppupvm              (palaute/vastaamisajan-loppupvm
+                                       heratepvm voimassa-alkupvm)
      :koulutustoimija                "1.2.246.562.10.346830761110"
      :toimipiste-oid                 "1.2.246.562.10.12312312312"
      :herate-source                  "ehoks_update"}))


### PR DESCRIPTION
## Kuvaus muutoksista

Tässä PR:ssä on osa niistä muutoksista, joilla korjataan opiskelija- ja työelämäpalautteen luomislogiikka toimimaan keskenään samalla tavalla.  Niiden herätepalvelu-koodissa on paljon tuplana kirjoitettua logiikkaa, minkä vuoksi myös yhdestä tai toisesta on helposti unohtunut jokin sääntö.  Lisäksi skeematarkistuksissa näytti olevan päällekkäisyyttä palautetarkistusten kanssa, tässä ainakin muutama eliminoitu.

- https://jira.eduuni.fi/browse/EH-1704
- https://jira.eduuni.fi/browse/EH-1583

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
