### PR TITLE
EH-1704: fix palaute logic (vol 2)

### DIFF
--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -1,8 +1,7 @@
 (ns oph.ehoks.hoks.schema
   (:require [oph.ehoks.hoks.osaamisen-hankkimistapa :as oht]
             [oph.ehoks.middleware :as mw :refer [get-current-opiskeluoikeus]]
-            [oph.ehoks.palaute.opiskelija
-             :refer [kuuluu-palautteen-kohderyhmaan?]]
+            [oph.ehoks.palaute :refer [kuuluu-palautteen-kohderyhmaan?]]
             [oph.ehoks.opiskeluoikeus :as opiskeluoikeus]
             [oph.ehoks.schema-tools :refer [describe modify]]
             [oph.ehoks.schema.generator :as g]
@@ -237,6 +236,9 @@
   "Varmistaa, että jakson osa-aikaisuustieto on välillä 1-100, mikäli
   työpaikkajakson loppupäivä on 1.7.2023 tai sen jälkeen."
   [oht]
+  ;; FIXME: tämän pitäisi ehkä käyttää suoraan
+  ;; initial-palaute-state-and-reason-if-not-kohderyhma, jossa on paljon
+  ;; enemmän sääntöjä.
   (or (not (kuuluu-palautteen-kohderyhmaan? (get-current-opiskeluoikeus)))
       (oht/has-required-osa-aikaisuustieto? oht)))
 

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -122,6 +122,15 @@
         (str year "-" (inc year))
         (str (dec year) "-" year)))))
 
+(defn kuuluu-palautteen-kohderyhmaan?
+  "Kuuluuko opiskeluoikeus palautteen kohderyhmään?  Tällä hetkellä
+  vain katsoo, onko kyseessä TELMA-opiskeluoikeus, joka ei ole tutkintoon
+  tähtäävä koulutus (ks. OY-4433).  Muita mahdollisia kriteereitä
+  ovat tulevaisuudessa koulutuksen rahoitus ja muut kriteerit, joista
+  voidaan katsoa, onko koulutus tutkintoon tähtäävä."
+  [opiskeluoikeus]
+  (every? (complement suoritus/telma?) (:suoritukset opiskeluoikeus)))
+
 (defn initial-palaute-state-and-reason-if-not-kohderyhma
   "Partial function; returns initial state, field causing it, and why the
   field causes the initial state - but only if the palaute is not to be
@@ -139,6 +148,9 @@
       [:ei-laheteta herate-date-field :eri-rahoituskaudella]
 
       (not-any? suoritus/ammatillinen? (:suoritukset opiskeluoikeus))
+      [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen]
+
+      (not (kuuluu-palautteen-kohderyhmaan? opiskeluoikeus))
       [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen]
 
       (opiskeluoikeus/in-terminal-state? opiskeluoikeus herate-date)

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -101,28 +101,14 @@
         normal (.plusDays alkupvm 29)]
     (if (.isBefore last normal) last normal)))
 
-(defn get-opiskeluoikeusjakso-for-date
-  "Hakee opiskeluoikeudesta jakson, joka on voimassa tiettynä päivänä."
-  [opiskeluoikeus vahvistus-pvm mode]
-  (let [offset (if (= mode :one-day-offset) 1 0)
-        jaksot (sort-by :alku (:opiskeluoikeusjaksot (:tila opiskeluoikeus)))]
-    (reduce (fn [res next]
-              (if (>= (compare vahvistus-pvm (:alku next)) offset)
-                next
-                (reduced res)))
-            (first jaksot)
-            jaksot)))
-
-(def feedback-collecting-preventing-codes #{"6" "14" "15"})
-
 (defn feedback-collecting-prevented?
   "Jätetäänkö palaute keräämättä sen vuoksi, että opiskelijan opiskelu on
   tällä hetkellä rahoitettu muilla rahoituslähteillä?"
   [opiskeluoikeus heratepvm]
   (-> opiskeluoikeus
-      (get-opiskeluoikeusjakso-for-date (str heratepvm) :normal)
+      (opiskeluoikeus/get-opiskeluoikeusjakso-for-date (str heratepvm) :normal)
       (get-in [:opintojenRahoitus :koodiarvo])
-      (feedback-collecting-preventing-codes)
+      #{"6" "14" "15"}
       (some?)))
 
 (defn rahoituskausi

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -106,7 +106,7 @@
   tällä hetkellä rahoitettu muilla rahoituslähteillä?"
   [opiskeluoikeus heratepvm]
   (-> opiskeluoikeus
-      (opiskeluoikeus/get-opiskeluoikeusjakso-for-date (str heratepvm) :normal)
+      (opiskeluoikeus/get-opiskeluoikeusjakso-for-date (str heratepvm))
       (get-in [:opintojenRahoitus :koodiarvo])
       #{"6" "14" "15"}
       (some?)))

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -31,15 +31,6 @@
    "valmistuneet"      "tutkinnon_suorittaneet"
    "osia_suorittaneet" "tutkinnon_osia_suorittaneet"})
 
-(defn kuuluu-palautteen-kohderyhmaan?
-  "Kuuluuko opiskeluoikeus palautteen kohderyhmään?  Tällä hetkellä
-  vain katsoo, onko kyseessä TELMA-opiskeluoikeus, joka ei ole tutkintoon
-  tähtäävä koulutus (ks. OY-4433).  Muita mahdollisia kriteereitä
-  ovat tulevaisuudessa koulutuksen rahoitus ja muut kriteerit, joista
-  voidaan katsoa, onko koulutus tutkintoon tähtäävä."
-  [opiskeluoikeus]
-  (every? (complement suoritus/telma?) (:suoritukset opiskeluoikeus)))
-
 (defn- added?
   [field current-hoks updated-hoks]
   (and (some? current-hoks)

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -35,10 +35,9 @@
   "Takes `hoks` as an input and extracts from it all osaamisen hankkimistavat
   that are tyopaikkajaksos. Returns a lazy sequence."
   [hoks]
-  (->> (concat
-         (:hankittavat-ammat-tutkinnon-osat hoks)
-         (:hankittavat-paikalliset-tutkinnon-osat hoks)
-         (mapcat :osa-alueet (:hankittavat-yhteiset-tutkinnon-osat hoks)))
+  (->> (mapcat :osa-alueet (:hankittavat-yhteiset-tutkinnon-osat hoks))
+       (concat (:hankittavat-ammat-tutkinnon-osat hoks)
+               (:hankittavat-paikalliset-tutkinnon-osat hoks))
        (mapcat :osaamisen-hankkimistavat)
        (filter oht/tyopaikkajakso?)))
 

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -170,6 +170,7 @@
      :hoks-id                        (:id hoks)
      :jakson-yksiloiva-tunniste      (:yksiloiva-tunniste jakso)
      :heratepvm                      heratepvm
+     :suorituskieli                  "fi"
      :tutkintotunnus                 351407
      :tutkintonimike                 "(\"12345\",\"23456\")"
      :voimassa-alkupvm               voimassa-alkupvm
@@ -192,13 +193,15 @@
                     "tapahtuma info to `palaute_tapahtumat` table.")
         (tep/initiate-if-needed!
           test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
-        (is (= (-> (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
-                     db/spec
-                     {:hoks-id            (:id hoks-test/hoks-1)
-                      :yksiloiva-tunniste (:yksiloiva-tunniste test-jakso)})
-                   (dissoc :id :created-at :updated-at)
-                   (->> (remove-vals nil?)))
-               (build-expected-herate test-jakso hoks-test/hoks-1)))
+        (let [real (-> (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
+                         db/spec
+                         {:hoks-id            (:id hoks-test/hoks-1)
+                          :yksiloiva-tunniste (:yksiloiva-tunniste test-jakso)})
+                       (dissoc :id :created-at :updated-at)
+                       (->> (remove-vals nil?)))
+              expected (build-expected-herate test-jakso hoks-test/hoks-1)]
+          (is (= real expected)
+              ["diff: " (clojure.data/diff real expected)]))
         (let [tapahtumat (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                            db/spec
                            {:hoks-id      (:id hoks-test/hoks-1)
@@ -234,13 +237,15 @@
                   "tyopaikkajakso in HOKS.")
       (tep/initiate-all-uninitiated! hoks-test/hoks-1 oo-test/opiskeluoikeus-1)
       (doseq [jakso (tep/tyopaikkajaksot hoks-test/hoks-1)]
-        (is (= (-> (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
-                     db/spec
-                     {:hoks-id            (:id hoks-test/hoks-1)
-                      :yksiloiva-tunniste (:yksiloiva-tunniste jakso)})
-                   (dissoc :id :created-at :updated-at)
-                   (->> (remove-vals nil?)))
-               (build-expected-herate jakso hoks-test/hoks-1)))))))
+        (let [real (-> (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
+                         db/spec
+                         {:hoks-id            (:id hoks-test/hoks-1)
+                          :yksiloiva-tunniste (:yksiloiva-tunniste jakso)})
+                       (dissoc :id :created-at :updated-at)
+                       (->> (remove-vals nil?)))
+              expected (build-expected-herate jakso hoks-test/hoks-1)]
+          (is (= real expected)
+              ["diff: " (clojure.data/diff real expected)]))))))
 
 (defn kasittelemattomat-palauteet []
   (db-helpers/query

--- a/test/oph/ehoks/palaute_test.clj
+++ b/test/oph/ehoks/palaute_test.clj
@@ -111,7 +111,7 @@
                                  (construct-opiskeluoikeus)
                                  (palaute/feedback-collecting-prevented? date)
                                  (= result))
-      [["2020-06-20" "lasna" 14]] "2019-01-01" true
+      [["2020-06-20" "lasna" 14]] "2019-01-01" false
       [["2021-03-15" "valmistunut" 2]
        ["2020-03-15" "lasna" 14]
        ["2019-09-01" "lasna" 14]] "2020-07-01" true
@@ -120,4 +120,4 @@
        ["2019-09-01" "lasna" 14]] "2019-12-01" true
       [["2021-03-15" "valmistunut" 2]
        ["2020-03-15" "lasna" 14]
-       ["2019-09-01" "lasna" 14]] "2019-07-01" true)))
+       ["2019-09-01" "lasna" 14]] "2021-07-01" false)))


### PR DESCRIPTION
## Kuvaus muutoksista

Some more fixes from EH-1704:
- fix in-terminal-state? to be according to its specification
- remove discrepancies between amis and tep palaute creation, so that both have all fields filled in (with the same logic).

https://jira.eduuni.fi/browse/EH-1704
https://jira.eduuni.fi/browse/EH-1443
https://jira.eduuni.fi/browse/OY-4433

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
