### PR TITLE
EH-1699: Add `hoks_id` and `yksiloiva_tunniste` to `select_%_tyopaikkajaksot_active_between.sql` queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ psql: stamps/db-running
 	psql -h localhost -U postgres ehoks
 
 .PHONY: test
-test:
+test: stamps/db-schema stamps/local-ddb-schema
 	lein test
 
 .PHONY: stop

--- a/resources/db/heratepalvelu/select_hato_tyoelamajaksot_active_between.sql
+++ b/resources/db/heratepalvelu/select_hato_tyoelamajaksot_active_between.sql
@@ -1,6 +1,8 @@
 SELECT
+  h.id AS hoks_id,
   h.opiskeluoikeus_oid AS opiskeluoikeus_oid,
   oh.id AS hankkimistapa_id,
+  oh.yksiloiva_tunniste AS yksiloiva_tunniste,
   oh.alku AS jakso_alkupvm,
   oh.loppu AS jakso_loppupvm,
   oh.osa_aikaisuustieto AS osa_aikaisuus

--- a/resources/db/heratepalvelu/select_hpto_tyoelamajaksot_active_between.sql
+++ b/resources/db/heratepalvelu/select_hpto_tyoelamajaksot_active_between.sql
@@ -1,6 +1,8 @@
 SELECT
+  h.id AS hoks_id,
   h.opiskeluoikeus_oid AS opiskeluoikeus_oid,
   oh.id AS hankkimistapa_id,
+  oh.yksiloiva_tunniste AS yksiloiva_tunniste,
   oh.alku AS jakso_alkupvm,
   oh.loppu AS jakso_loppupvm,
   oh.osa_aikaisuustieto AS osa_aikaisuus

--- a/resources/db/heratepalvelu/select_hyto_tyoelamajaksot_active_between.sql
+++ b/resources/db/heratepalvelu/select_hyto_tyoelamajaksot_active_between.sql
@@ -1,6 +1,8 @@
 SELECT
+  h.id AS hoks_id,
   h.opiskeluoikeus_oid AS opiskeluoikeus_oid,
   oh.id AS hankkimistapa_id,
+  oh.yksiloiva_tunniste AS yksiloiva_tunniste,
   oh.alku AS jakso_alkupvm,
   oh.loppu AS jakso_loppupvm,
   oh.osa_aikaisuustieto AS osa_aikaisuus


### PR DESCRIPTION
## Kuvaus muutoksista

EH-1699 muutosten myötä, Herätepalvelussa aletaan käyttämään jaksojen yksilöintiin (hoks_id, yksiloiva_tunniste)-kombinaatiota. Tämän mahdollistamiseksi, sekä hoks_id että yksiloiva_tunniste täytyy sisällyttää mukaan `select_%_tyopaikkajaksot_active_between.sql`-kyselyihin.

https://jira.eduuni.fi/browse/EH-1699

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
