### PR TITLE
EH-1716: add tests for palaute state changes in upserts

### DIFF
--- a/resources/dev/demo-data/hoksit.json
+++ b/resources/dev/demo-data/hoksit.json
@@ -213,6 +213,7 @@
       ],
       "osaamisen-hankkimistavat": [
         {
+	  "yksiloiva-tunniste": "oht1",
           "osaamisen-hankkimistapa-koodi-uri": "osaamisenhankkimistapa_koulutussopimus",
           "hankkijan-edustaja": {
             "nimi": "Hanken, Hank",
@@ -295,6 +296,7 @@
       ],
       "osaamisen-hankkimistavat": [
         {
+	  "yksiloiva-tunniste": "oht2",
           "tyopaikalla-jarjestettava-koulutus": {
             "vastuullinen-tyopaikka-ohjaaja": {
               "nimi": "Vastuullinen, Vesku",
@@ -390,6 +392,7 @@
       ],
       "osaamisen-hankkimistavat": [
         {
+	  "yksiloiva-tunniste": "oht3",
           "tyopaikalla-jarjestettava-koulutus": {
             "vastuullinen-tyopaikka-ohjaaja": {
               "nimi": "Vastuussa, Veera",
@@ -515,6 +518,7 @@
       ],
       "osaamisen-hankkimistavat": [
         {
+	  "yksiloiva-tunniste": "oht4",
           "tyopaikalla-jarjestettava-koulutus": {
             "vastuullinen-tyopaikka-ohjaaja": {
               "nimi": "Vastuussa, Veera",
@@ -554,6 +558,7 @@
           "osa-aikaisuustieto": 5
         },
         {
+	  "yksiloiva-tunniste": "oht5",
           "osaamisen-hankkimistapa-koodi-uri": "osaamisenhankkimistapa_muu",
           "osaamisen-hankkimistapa-koodi-versio": 1,
           "muut-oppimisymparistot": [
@@ -610,6 +615,7 @@
           "koulutuksen-jarjestaja-oid": "1.2.246.562.10.10054425555",
           "osaamisen-hankkimistavat": [
             {
+	      "yksiloiva-tunniste": "oht6",
               "tyopaikalla-jarjestettava-koulutus": {
                 "vastuullinen-tyopaikka-ohjaaja": {
                   "nimi": "Ohjaaja, Osa",
@@ -624,6 +630,7 @@
               },
               "osaamisen-hankkimistapa-koodi-uri": "osaamisenhankkimistapa_koulutussopimus",
               "osaamisen-hankkimistapa-koodi-versio": 1,
+	      "osa-aikaisuustieto": 80,
               "hankkijan-edustaja": {
                 "nimi": "Hankkija, Heikki",
                 "rooli": "Jonkinlainen hankkija",
@@ -696,6 +703,7 @@
           ],
           "osaamisen-hankkimistavat": [
             {
+	      "yksiloiva-tunniste": "oht7",
               "tyopaikalla-jarjestettava-koulutus": {
                 "vastuullinen-tyopaikka-ohjaaja": {
                   "nimi": "Vastuussa, Veera",
@@ -777,6 +785,7 @@
           ],
           "osaamisen-hankkimistavat": [
             {
+	      "yksiloiva-tunniste": "oht8",
               "tyopaikalla-jarjestettava-koulutus": {
                 "vastuullinen-tyopaikka-ohjaaja": {
                   "nimi": "Vastuussa, Veera",

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -81,7 +81,7 @@ where h.oppija_oid = :oppija-oid
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and p.koulutustoimija = :koulutustoimija
 
--- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :1
+-- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :*
 -- :doc Get palaute information for työpaikkajakso by HOKS ID and yksiloiva
 --      tunniste.
 select * from palautteet

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -79,7 +79,7 @@ from palautteet p
 join hoksit h on (h.id = p.hoks_id)
 where h.oppija_oid = :oppija-oid
   and p.kyselytyyppi in (:v*:kyselytyypit)
-  and p.koulutustoimija = :koulutustoimija
+  and (p.koulutustoimija = :koulutustoimija or (:koulutustoimija)::text is null)
 
 -- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :*
 -- :doc Get palaute information for työpaikkajakso by HOKS ID and yksiloiva

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -55,7 +55,7 @@
         [:ei-laheteta :tuva-opiskeluoikeus-oid :tuva-opiskeluoikeus]
 
         :else
-        [:odottaa-kasittelya nil :hoks-tallennettu]))))
+        [:odottaa-kasittelya herate-basis :hoks-tallennettu]))))
 
 (def kysely-kasittely-field-mapping
   {:aloituskysely :aloitusherate_kasitelty

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -91,7 +91,7 @@
       [:ei-laheteta :tuva-opiskeluoikeus-oid :tuva-opiskeluoikeus]
 
       :else
-      [:odottaa-kasittelya nil :hoks-tallennettu])))
+      [:odottaa-kasittelya :loppu :hoks-tallennettu])))
 
 (defn initiate-if-needed!
   [jakso hoks opiskeluoikeus]

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -727,6 +727,13 @@
           (hoks/update!
             (:id saved-hoks)
             hoks-osaaminen-saavutettu-ei-osaamisen-hankkimisen-tarvetta)
+          (eq (set (map (juxt :tila :kyselytyyppi)
+                        (palaute/get-by-hoks-id-and-kyselytyypit!
+                          db/spec
+                          {:hoks-id (:id saved-hoks)
+                           :kyselytyypit ["aloittaneet" "valmistuneet"]})))
+              #{["ei_laheteta" "aloittaneet"]
+                ["ei_laheteta" "valmistuneet"]})
           (is (= @sqs-call-counter 0)))))))
 
 (deftest form-opiskelijapalaute-in-hoks-replace

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -638,6 +638,17 @@
                 (assoc :osaamisen-saavuttamisen-pvm (LocalDate/of 2022 11 1))
                 (assoc :osaamisen-hankkimisen-tarve true)
                 (update
+                  :hankittavat-paikalliset-tutkinnon-osat
+                  (fn [hptos]
+                    (map (fn [hpto]
+                           (update
+                             hpto :osaamisen-hankkimistavat
+                             (fn [ohts]
+                               (map #(assoc % :keskeytymisajanjaksot
+                                            [{:alku (LocalDate/of 2019 2 15)}])
+                                    ohts))))
+                         hptos)))
+                (update
                   :hankittavat-ammat-tutkinnon-osat
                   (fn [hatos]
                     (map (fn [hato]
@@ -655,7 +666,7 @@
                           {:hoks-id (:id hoks-db)
                            :kyselytyypit ["aloittaneet" "valmistuneet"
                                           "tyopaikkajakson_suorittaneet"]})))
-              #{["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"
+              #{["ei_laheteta" "tyopaikkajakson_suorittaneet"
                  "abcd" (LocalDate/parse "2019-02-16")]
                 ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"
                  "1234567890" (LocalDate/parse "2019-07-16")]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -119,14 +119,16 @@
        "initiate aloituskysely if `osaamisen-hankkimisen-tarve` is `true`."
         (is (= (op/initial-palaute-state-and-reason
                  :aloituskysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
-               [:odottaa-kasittelya nil :hoks-tallennettu])))
+               [:odottaa-kasittelya :ensikertainen-hyvaksyminen
+                :hoks-tallennettu])))
 
       (testing
        (str "initiate paattokysely if `osaamisen-hankkimisen-tarve` is "
             "`true` and `osaamisen-saavuttamisen-pvm` is not missing.")
         (is (= (op/initial-palaute-state-and-reason
                  :paattokysely hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
-               [:odottaa-kasittelya nil :hoks-tallennettu]))))))
+               [:odottaa-kasittelya :osaamisen-saavuttamisen-pvm
+                :hoks-tallennettu]))))))
 
 (defn expected-msg
   [kysely hoks]

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -158,7 +158,7 @@
       (testing "initiate kysely if when all of the checks are OK."
         (is (= (tep/initial-palaute-state-and-reason
                  test-jakso hoks-test/hoks-1 oo-test/opiskeluoikeus-1 [])
-               [:odottaa-kasittelya nil :hoks-tallennettu]))))))
+               [:odottaa-kasittelya :loppu :hoks-tallennettu]))))))
 
 (defn- build-expected-herate
   [jakso hoks]
@@ -215,7 +215,7 @@
                   :heratepvm    (LocalDate/of 2023 12 15)
                   :tyyppi       "hoks_tallennus"
                   :syy          "hoks_tallennettu"
-                  :lisatiedot   {}}))))
+                  :lisatiedot   {:loppu "2023-12-15"}}))))
       (testing
        "doesn't initiate tyoelamapalaute if it has already been initiated"
         (with-log

--- a/test/oph/ehoks/test_utils.clj
+++ b/test/oph/ehoks/test_utils.clj
@@ -356,7 +356,7 @@
       (reduce (fn [res val]
                 (conj res [(first val) (dissoc-module-ids (second val))]))
               {}
-              (dissoc data :module-id :yksiloiva-tunniste))
+              (dissoc data :module-id))
       (map #(dissoc-module-ids %) data))
     data))
 

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -799,7 +799,8 @@
        :rooli "Opettaja"
        :oppilaitos-oid "1.2.246.562.10.54452422428"}
       :alku "2023-01-11"
-      :loppu "2023-03-14"}]
+      :loppu "2023-03-14"
+      :yksiloiva-tunniste "testi-toinen-yks-tunn"}]
     :koulutuksen-jarjestaja-oid "1.2.246.562.10.54411232223"}])
 
 (t/deftest test-virkailija-create-hoks
@@ -809,7 +810,9 @@
       (let [post-response
             (post-new-hoks
               "1.2.246.562.15.76000000018" "1.2.246.562.10.12000000013"
-              {:hankittavat-ammat-tutkinnon-osat hato-data})]
+              {:hankittavat-ammat-tutkinnon-osat
+               (update-in hato-data [0 :osaamisen-hankkimistavat 1]
+                          dissoc :yksiloiva-tunniste)})]
         (t/is (= (:status post-response) 200))
         (let [get-response (get-created-hoks post-response)
               body (test-utils/parse-body (:body get-response))]
@@ -1129,7 +1132,8 @@
                     :ensikertainen-hyvaksyminen "2018-12-17"
                     :paivitetty "2019-01-02T10:20:30.001Z"
                     :hankittavat-ammat-tutkinnon-osat
-                    hato-data))
+                    (update-in hato-data [0 :osaamisen-hankkimistavat 1]
+                               dissoc :yksiloiva-tunniste)))
                 virkailija-for-test)
               get-response
               (with-test-virkailija
@@ -1152,6 +1156,12 @@
                 (get-in body [:data :hankittavat-ammat-tutkinnon-osat]))
               (test-utils/dissoc-module-ids
                 (-> hato-data
+                    (assoc-in [0 :osaamisen-hankkimistavat 1
+                               :yksiloiva-tunniste]
+                              (get-in body [:data
+                                            :hankittavat-ammat-tutkinnon-osat 0
+                                            :osaamisen-hankkimistavat 1
+                                            :yksiloiva-tunniste]))
                     (update-in [0
                                 :osaamisen-hankkimistavat
                                 0


### PR DESCRIPTION
## Kuvaus muutoksista

Luodaan testit seuraaville asioille:
- palautteet ja palautetapahtumat muodostuvat oikein HOKSin tallennuksen yhteydessä (osittain päällekkäisiä palautetestien kanssa)
- HOKSin päivittäminen palautteenkeruun kannalta olennaisista kohdista myös muuttaa palautteiden tietoja
- HOKSin päivitykset eivät tuota lisäpalauterivejä vaan päivittävät vanhoja
- Jo lähetettyjä palautteita ei päivitetä, vaan ne joko estävät palautteen keruun uusilla tiedoilla kokonaan, tai aiheuttavat uuden palautteenkeruun (mikäli vanha ja uusi amispalaute ovat eri rahoituskausilla) 
- Lisäksi PR:ssä on korjattu yksi bugi, joka esti jo luotuja työelämäpalautteita päivittymästä oikein.

https://jira.eduuni.fi/browse/EH-1716

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
