### PR TITLE
EH-1751: remove unused trigram index on oppijat.nimi

### DIFF
--- a/src/db/migration/V1_1731917685939__remove_trigram_index.sql
+++ b/src/db/migration/V1_1731917685939__remove_trigram_index.sql
@@ -1,0 +1,4 @@
+
+DROP INDEX oppijat_nimi_idx;
+-- DROP EXTENSION pg_trgm;  -- probably doesn't work due to privileges
+


### PR DESCRIPTION
## Kuvaus muutoksista

This is cleaning up after EH-974 and its rollback in c8f7fce595c.

https://jira.eduuni.fi/browse/EH-1751

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
