### PR TITLE
EH-1712: Sync TPO-nippu to Herätepalvelu

### DIFF
--- a/src/db/migration/V1_1736254830793__add_oppija_oid_to_tep_heratepalvelu_view.sql
+++ b/src/db/migration/V1_1736254830793__add_oppija_oid_to_tep_heratepalvelu_view.sql
@@ -1,0 +1,34 @@
+DROP VIEW palaute_for_tep_heratepalvelu;
+
+CREATE VIEW palaute_for_tep_heratepalvelu AS
+SELECT
+  jakson_yksiloiva_tunniste,
+  kyselytyyppi AS internal_kyselytyyppi,
+  hankkimistapa_id,
+  osaamisen_hankkimistapa_koodi_uri AS hankkimistapa_tyyppi,
+  hoks_id,
+  alkupvm::text AS jakso_alkupvm,
+  loppupvm::text AS jakso_loppupvm,
+  vastuullinen_tyopaikka_ohjaaja_sahkoposti AS ohjaaja_email,
+  vastuullinen_tyopaikka_ohjaaja_nimi AS ohjaaja_nimi,
+  vastuullinen_tyopaikka_ohjaaja_puhelinnumero AS ohjaaja_puhelinnumero,
+  opiskeluoikeus_oid,
+  oppija_oid,
+  oppisopimuksen_perusta_koodi_uri AS oppisopimuksen_perusta,
+  osa_aikaisuustieto AS osa_aikaisuus,
+  CASE tila
+    WHEN 'odottaa_kasittelya' THEN 'ei_niputettu'
+    WHEN 'vastaajatunnus_muodostettu' THEN 'ei_niputettu'
+    ELSE tila::text END AS kasittelytila,
+  CASE WHEN EXTRACT(MONTH FROM heratepvm) <= 6
+    THEN CONCAT(EXTRACT(YEAR FROM heratepvm) - 1, '-',
+                EXTRACT(YEAR FROM heratepvm))
+    ELSE CONCAT(EXTRACT(YEAR FROM heratepvm), '-',
+                EXTRACT(YEAR FROM heratepvm) + 1) END AS rahoituskausi,
+  tutkinnonosa_id,
+  tutkinnon_osa_koodi_uri AS tutkinnonosa_koodi,
+  tutkinnonosa_nimi,
+  tyyppi AS tutkinnonosa_tyyppi,
+  tyopaikan_nimi,
+  tyopaikan_y_tunnus AS tyopaikan_ytunnus
+FROM tep_palaute;

--- a/src/oph/ehoks/db.clj
+++ b/src/oph/ehoks/db.clj
@@ -1,7 +1,7 @@
 (ns oph.ehoks.db
   (:require [hugsql.adapter :refer [result-many result-one]]
             [hugsql.core :as hugsql]
-            [medley.core :refer [map-vals]]
+            [medley.core :refer [map-vals remove-vals]]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.utils :as utils])
   (:import (org.postgresql.jdbc PgArray)))
@@ -25,8 +25,10 @@
 
 (def convert-result
   "Fix the results of hugsql to more clojuresque format."
-  (comp utils/to-dash-keys
-        (partial map-vals pgarray->vec)))
+  (comp #(dissoc % :created-at :updated-at :deleted-at)
+        utils/to-dash-keys
+        (partial map-vals pgarray->vec)
+        (partial remove-vals nil?)))
 
 (defn result-one-snake->kebab
   [this result options]

--- a/src/oph/ehoks/db.clj
+++ b/src/oph/ehoks/db.clj
@@ -23,12 +23,14 @@
   [obj]
   (if (instance? PgArray obj) (vec (.getArray ^PgArray obj)) obj))
 
-(def convert-result
+(defn convert-result
   "Fix the results of hugsql to more clojuresque format."
-  (comp #(dissoc % :created-at :updated-at :deleted-at)
-        utils/to-dash-keys
-        (partial map-vals pgarray->vec)
-        (partial remove-vals nil?)))
+  [result]
+  (as-> result r
+    (remove-vals nil? r)
+    (map-vals pgarray->vec r)
+    (utils/to-dash-keys r)
+    (dissoc r :created-at :updated-at :deleted-at)))
 
 (defn result-one-snake->kebab
   [this result options]

--- a/src/oph/ehoks/db.clj
+++ b/src/oph/ehoks/db.clj
@@ -1,9 +1,9 @@
 (ns oph.ehoks.db
   (:require [hugsql.adapter :refer [result-many result-one]]
             [hugsql.core :as hugsql]
-            [oph.ehoks.utils :as utils]
             [medley.core :refer [map-vals]]
-            [oph.ehoks.config :refer [config]])
+            [oph.ehoks.config :refer [config]]
+            [oph.ehoks.utils :as utils])
   (:import (org.postgresql.jdbc PgArray)))
 
 (def spec

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -1,14 +1,14 @@
 (ns oph.ehoks.db.dynamodb
-  (:require [clojure.string :as str]
+  (:require [clojure.set :refer [rename-keys]]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [environ.core :refer [env]]
-            [medley.core :refer [map-keys]]
-            [oph.ehoks.utils :as utils]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
             [oph.ehoks.palaute :refer
              [get-for-heratepalvelu-by-hoks-id-and-kyselytyypit!]]
             [oph.ehoks.palaute.tapahtuma :as palautetapahtuma]
+            [oph.ehoks.utils :as utils]
             [taoensso.faraday :as far])
   (:import (com.amazonaws.auth AWSStaticCredentialsProvider
                                BasicSessionCredentials)
@@ -63,6 +63,11 @@
   {:amis [:toimija_oppija :tyyppi_kausi]
    :jakso [:hankkimistapa_id]
    :nippu [:ohjaaja_ytunnus_kj_tutkinto :niputuspvm]})
+
+(defn get-item!
+  "A wrapper for `taoensso.faraday/get-item`."
+  [table prim-kvs]
+  (far/get-item @faraday-opts @(tables table) prim-kvs))
 
 (defn sync-item!
   "Does a partial upsert on item in DDB: if the item doesn't exist,
@@ -129,6 +134,36 @@
                                   :body (:body (ex-data e))}})
              (throw e))))))
 
+(def map-jakso-keys-to-ddb
+  (some-fn {:hankkimistapa-id :hankkimistapa_id,
+            :osaamisen-hankkimistapa-koodi-uri :hankkimistapa_tyyppi,
+            :hoks-id :hoks_id,
+            :jakso-alkupvm :jakso_alkupvm,
+            :jakso-loppupvm :jakso_loppupvm,
+            :ohjaaja-email :ohjaaja_email,
+            :ohjaaja-nimi :ohjaaja_nimi,
+            :ohjaaja-puhelinnumero :ohjaaja_puhelinnumero,
+            :ohjaaja-ytunnus-kj-tutkinto :ohjaaja_ytunnus_kj_tutkinto,
+            :opiskeluoikeus-oid :opiskeluoikeus_oid,
+            :oppija-oid :oppija_oid,
+            :oppisopimuksen-perusta-koodi-uri :oppisopimuksen_perusta,
+            :osa-aikaisuustieto :osa_aikaisuus,
+            :request-id :request_id,
+            :toimipiste-oid :toimipiste_oid,
+            :tutkinnonosa-id :tutkinnonosa_id,
+            :tutkinnon-osa-koodi-uri :tutkinnonosa_koodi,
+            :tutkinnonosa-nimi :tutkinnonosa_nimi,
+            :tutkinnonosa-tyyppi :tutkinnonosa_tyyppi,
+            :tyopaikan-nimi :tyopaikan_nimi,
+            :tyopaikan-normalisoitu-nimi :tyopaikan_normalisoitu_nimi,
+            :tyopaikan-y-tunnus :tyopaikan_ytunnus,
+            :vastuullinen-tyopaikka-ohjaaja-nimi :ohjaaja_nimi,
+            :vastuullinen-tyopaikka-ohjaaja-sahkoposti :ohjaaja_email,
+            :vastuullinen-tyopaikka-ohjaaja-puhelinnumero
+            :ohjaaja_puhelinnumero,
+            :viimeinen-vastauspvm :viimeinen_vastauspvm}
+           identity))
+
 (defn sync-jakso-herate!
   "Update the herätepalvelu jaksotunnustable to have the same content
   for given heräte as palaute-backend has in its own database.
@@ -139,8 +174,22 @@
   (if-not (contains? (set (:heratepalvelu-responsibities config))
                      :sync-jakso-heratteet)
     (log/warn "sync-jakso-herate!: configured to not do anything")
-    (->> tep-palaute
-         ;; the only field that has dashes in its name is tpk-niputuspvm
-         utils/to-underscore-keys
-         (map-keys (some-fn {:tpk_niputuspvm :tpk-niputuspvm} identity))
-         (sync-item! :jakso))))
+    (-> tep-palaute
+        utils/to-underscore-keys
+        ;; the only field that has dashes in its name is tpk-niputuspvm
+        (rename-keys {:tpk_niputuspvm :tpk-niputuspvm})
+        (->> (sync-item! :jakso)))))
+
+(defn sync-tpo-nippu-herate!
+  "Update the Herätepalvelu nipputable to have the same content for given heräte
+  as palaute-backend has in its own database."
+  [nippu]
+  (if-not (contains? (set (:heratepalvelu-responsibities config))
+                     :sync-jakso-heratteet)
+    (log/warn "sync-tpo-nippu-herate!: configured to not do anything")
+    (if-let [existing-nippu (get-item! :nippu
+                                       (select-keys
+                                         nippu [:ohjaaja_ytunnus_kj_tutkinto
+                                                :niputuspvm]))]
+      (log/info "Tietokannassa on jo nippu: " existing-nippu)
+      (sync-item! :nippu nippu))))

--- a/src/oph/ehoks/db/sql.clj
+++ b/src/oph/ehoks/db/sql.clj
@@ -1,0 +1,30 @@
+(ns oph.ehoks.db.sql
+  (:require [clojure.string :as str]
+            [hugsql.parameters :refer [identifier-param-quote]]
+            [oph.ehoks.utils :as utils]))
+
+(defn target-columns-for-insert
+  "Takes `params` (a hashmap of parameter data where the keys match parameter
+  placeholder names in SQL) and returns target column list (column names
+  separated by comma) for INSERT command."
+  [params]
+  (str/join "," (map utils/to-underscore-str (keys params))))
+
+(defn values-for-insert
+  "Takes `params` (a hashmap of parameter data where the keys match parameter
+  placeholder names in SQL) and returns values (separated by comma) for INSERT
+  command."
+  [params]
+  (str/join "," (map #(str ":v:" (name %)) (keys params))))
+
+(defn set-clause-for-update
+  "Takes `params` (a hashmap of parameter data where the keys match parameter
+  placeholder names in SQL) and a hashmap of HugSQL-specific `options`. Returns
+  a SET clause (part of UPDATE command) as a string, e.g.,
+  \"set key1 = 1,key2 = 'val2'\" when `params` is {:key1 1 :key2 \"val2\"})`."
+  [params options]
+  (str "set "
+       (str/join "," (for [[field _] params]
+                       (-> (utils/to-underscore-str field)
+                           (identifier-param-quote options)
+                           (str " = :v:" (name field)))))))

--- a/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
+++ b/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
@@ -1,14 +1,8 @@
 -- :name update! :? :1
 -- :doc Update osaamisen hankkimistapa in DB
-/* :require [clojure.string :as string]
-            [hugsql.parameters :refer [identifier-param-quote]] */
-update osaamisen_hankkimistavat set
-/*~
-(string/join ","
-  (for [[field _] params]
-    (str (identifier-param-quote (.replace (name field) \- \_) options)
-      " = :v:" (name field))))
-~*/
+-- :require [oph.ehoks.db.sql :as sql]
+update osaamisen_hankkimistavat
+--~ (sql/set-clause-for-update params options)
 where id = :id
 returning *
 

--- a/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
+++ b/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
@@ -1,0 +1,13 @@
+-- :name update! :? :1
+-- :doc Update osaamisen hankkimistapa in DB
+/* :require [clojure.string :as string]
+            [hugsql.parameters :refer [identifier-param-quote]] */
+update osaamisen_hankkimistavat set
+/*~
+(string/join ","
+  (for [[field _] params]
+    (str (identifier-param-quote (.replace (name field) \- \_) options)
+      " = :v:" (name field))))
+~*/
+where id = :id
+returning *

--- a/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
+++ b/src/oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql
@@ -11,3 +11,8 @@ update osaamisen_hankkimistavat set
 ~*/
 where id = :id
 returning *
+
+-- :name get-keskeytymisajanjaksot! :? :*
+-- :doc Get keskeytymisajanjaksot for osaamisen hankkimistapa
+select * from keskeytymisajanjaksot
+where osaamisen_hankkimistapa_id = :oht-id

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -94,7 +94,7 @@ where h.oppija_oid = :oppija-oid  -- FIXME: should probably have deleted_at cond
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and (p.koulutustoimija = :koulutustoimija or (:koulutustoimija)::text is null)
 
--- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :*
+-- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :1
 -- :doc Get palaute information for työpaikkajakso by HOKS ID and yksiloiva
 --      tunniste.
 select * from palautteet

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -68,6 +68,11 @@ where h.oppija_oid = :oppija-oid  -- FIXME: should probably have deleted_at cond
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and (p.koulutustoimija = :koulutustoimija or (:koulutustoimija)::text is null)
 
+-- :name get-by-id! :? :1
+-- :doc Get palaute by palaute id.
+select * from palautteet
+where id = :id
+
 -- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :1
 -- :doc Get palaute information for työpaikkajakso by HOKS ID and yksiloiva
 --      tunniste.

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -1,25 +1,10 @@
 -- :name insert! :? :1
 -- :doc Insert palaute to DB
+-- :require [clojure.string :as string]
 insert into palautteet (
-  --~ (when (:arvo-tunniste params) "arvo_tunniste,")
-  --~ (when (:hankintakoulutuksen-toteuttaja params) "hankintakoulutuksen_toteuttaja,")
-  --~ (when (:yksiloiva-tunniste params) "jakson_yksiloiva_tunniste,")
-  --~ (when (:kyselylinkki params) "kyselylinkki,")
-  --~ (when (:nippu-id params) "nippu_id,")
-  --~ (when (:suorituskieli params) "suorituskieli,")
-  herate_source, heratepvm, hoks_id, koulutustoimija, kyselytyyppi, tila,
-  toimipiste_oid, tutkintonimike, tutkintotunnus, voimassa_alkupvm,
-  voimassa_loppupvm
+--~ (string/join "," (map #(.replace (name %) \- \_) (keys params)))
 ) values (
-  --~ (when (:arvo-tunniste params) ":arvo-tunniste,")
-  --~ (when (:hankintakoulutuksen-toteuttaja params) ":hankintakoulutuksen-toteuttaja,")
-  --~ (when (:yksiloiva-tunniste params) ":yksiloiva-tunniste,")
-  --~ (when (:kyselylinkki params) ":kyselylinkki,")
-  --~ (when (:nippu-id params) ":nippu-id,")
-  --~ (when (:suorituskieli params) ":suorituskieli,")
-  :herate-source, :heratepvm, :hoks-id, :koulutustoimija, :kyselytyyppi, :tila,
-  :toimipiste-oid, :tutkintonimike, :tutkintotunnus, :voimassa-alkupvm,
-  :voimassa-loppupvm
+--~ (string/join "," (map #(str ":v:" (name %)) (keys params)))
 ) returning *
 
 -- :name get-tep-palautteet-waiting-for-vastaajatunnus! :? :*
@@ -63,22 +48,17 @@ returning *
 
 -- :name update! :? :1
 -- :doc Update palaute in DB
-update palautteet
-set	herate_source = :herate-source,
-	heratepvm = :heratepvm,
-	kyselytyyppi = :kyselytyyppi,
-	tila = :tila,
-	hankintakoulutuksen_toteuttaja = :hankintakoulutuksen-toteuttaja,
-	hoks_id = :hoks-id,
-	koulutustoimija = :koulutustoimija,
-	suorituskieli = :suorituskieli,
-	toimipiste_oid = :toimipiste-oid,
-	tutkintonimike = :tutkintonimike,
-	tutkintotunnus = :tutkintotunnus,
-	voimassa_alkupvm = :voimassa-alkupvm,
-	voimassa_loppupvm = :voimassa-loppupvm
+/* :require [clojure.string :as string]
+            [hugsql.parameters :refer [identifier-param-quote]] */
+update palautteet set
+/*~
+(string/join ","
+  (for [[field _] params]
+    (str (identifier-param-quote (.replace (name field) \- \_) options)
+      " = :v:" (name field))))
+~*/
 where	id = :id
-returning id
+returning *
 
 -- :name get-by-hoks-id-and-kyselytyypit! :? :*
 -- :doc Get opiskelijapalaute information by HOKS ID and kyselytyyppi
@@ -183,10 +163,3 @@ select * from palaute_for_tep_heratepalvelu
 where hoks_id = :hoks-id
   and jakson_yksiloiva_tunniste = :jakson-yksiloiva-tunniste
   and internal_kyselytyyppi = 'tyopaikkajakson_suorittaneet'
-
--- :name update-tep-kasitelty! :? :1
--- :doc Updates tep_kasitelty flag after getting vastaajatunnus from Arvo.
-update osaamisen_hankkimistavat
-set tep_kasitelty = :tep-kasitelty, updated_at = now()
-where id = :id
-returning *

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -1,10 +1,10 @@
 -- :name insert! :? :1
 -- :doc Insert palaute to DB
--- :require [clojure.string :as string]
+-- :require [oph.ehoks.db.sql :as sql]
 insert into palautteet (
---~ (string/join "," (map #(.replace (name %) \- \_) (keys params)))
+--~ (sql/target-columns-for-insert params)
 ) values (
---~ (string/join "," (map #(str ":v:" (name %)) (keys params)))
+--~ (sql/values-for-insert params)
 ) returning *
 
 -- :name get-tep-palautteet-waiting-for-vastaajatunnus! :? :*
@@ -48,15 +48,9 @@ returning *
 
 -- :name update! :? :1
 -- :doc Update palaute in DB
-/* :require [clojure.string :as string]
-            [hugsql.parameters :refer [identifier-param-quote]] */
-update palautteet set
-/*~
-(string/join ","
-  (for [[field _] params]
-    (str (identifier-param-quote (.replace (name field) \- \_) options)
-      " = :v:" (name field))))
-~*/
+-- :require [oph.ehoks.db.sql :as sql]
+update palautteet
+--~ (sql/set-clause-for-update params options)
 where	id = :id
 returning *
 

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -1,10 +1,10 @@
 (ns oph.ehoks.external.arvo
-  (:require [oph.ehoks.external.connection :as c]
-            [oph.ehoks.external.organisaatio :as org]
-            [oph.ehoks.config :refer [config]]
-            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+  (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [clojure.string :as string])
+            [oph.ehoks.config :refer [config]]
+            [oph.ehoks.external.connection :as c]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.utils :as utils])
   (:import (clojure.lang ExceptionInfo)))
 
 (defn call!
@@ -54,18 +54,13 @@
 
 (defn build-jaksotunnus-request-body
   "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
-  [herate
-   tyopaikka-normalisoitu
-   opiskeluoikeus
-   request-id
-   koulutustoimija
-   toimipiste
-   suoritus
-   niputuspvm]
+  [{:keys [opiskeluoikeus suoritus koulutustoimija toimipiste niputuspvm]
+    :as ctx}
+   herate request-id]
   {:koulutustoimija_oid       koulutustoimija
    :tyonantaja                (:tyopaikan-y-tunnus herate)
    :tyopaikka                 (:tyopaikan-nimi herate)
-   :tyopaikka_normalisoitu    tyopaikka-normalisoitu
+   :tyopaikka_normalisoitu    (utils/normalize-string (:tyopaikan-nimi herate))
    :tutkintotunnus            (get-in
                                 suoritus
                                 [:koulutusmoduuli
@@ -96,7 +91,7 @@
                                   (string/split
                                     (:oppisopimuksen-perusta-koodi-uri herate)
                                     #"_")))
-   :vastaamisajan_alkupvm     niputuspvm
+   :vastaamisajan_alkupvm     (str niputuspvm)
    :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
    :toimipiste_oid            toimipiste
    :request_id                request-id})

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -4,7 +4,7 @@
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
-            [oph.ehoks.utils :as utils])
+            [oph.ehoks.utils.string :as u-str])
   (:import (clojure.lang ExceptionInfo)))
 
 (defn call!
@@ -61,7 +61,7 @@
   {:koulutustoimija_oid       koulutustoimija
    :tyonantaja                (:tyopaikan-y-tunnus existing-palaute)
    :tyopaikka                 (:tyopaikan-nimi existing-palaute)
-   :tyopaikka_normalisoitu    (utils/normalize-string
+   :tyopaikka_normalisoitu    (u-str/normalize
                                 (:tyopaikan-nimi existing-palaute))
    :tutkintotunnus            (get-in
                                 suoritus

--- a/src/oph/ehoks/external/aws_sqs.clj
+++ b/src/oph/ehoks/external/aws_sqs.clj
@@ -153,7 +153,7 @@
     (send-message {:kyselylinkki kyselylinkki} delete-tunnus-queue-url)
     (log/error "No AMIS delete tunnus queue!")))
 
-(defn send-tyoelamapalaute-message
+(defn send-tyoelamapalaute-message!
   "Lähettää työelämäpalauteviestin."
   [msg]
   (if (contains? (set (:heratepalvelu-responsibities config))

--- a/src/oph/ehoks/external/koski.clj
+++ b/src/oph/ehoks/external/koski.clj
@@ -93,17 +93,21 @@
   (try
     (get-opiskeluoikeus-info-raw oid)
     (catch ExceptionInfo e
-      (let [koski-virhekoodi (virhekoodi e)]
-        (when-not (and (= (:status (ex-data e)) status/not-found)
+      (let [http-status      (:status (ex-data e))
+            koski-virhekoodi (virhekoodi e)]
+        (when-not (and (= http-status status/not-found)
                        (= koski-virhekoodi
                           "notFound.opiskeluoikeuttaEiLöydyTaiEiOikeuksia"))
           (throw (ex-info (format
                             (str "Error while fetching opiskeluoikeus `%s` "
-                                 "from Koski. Koski-virhekoodi is `%s`.")
+                                 "from Koski. Got response with HTTP status %d "
+                                 "and Koski-virhekoodi `%s`.")
                             oid
+                            http-status
                             koski-virhekoodi)
                           {:type              ::opiskeluoikeus-fetching-error
                            :opiskeluoikeus-oid oid
+                           :http-status        http-status
                            :koski-virhekoodi   koski-virhekoodi}
                           e)))))))
 

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -1,30 +1,27 @@
 (ns oph.ehoks.heratepalvelu
-  (:require [clojure.string :as string]
+  (:require [clojure.set :refer [rename-keys]]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [medley.core :refer [find-first]]
+            [oph.ehoks.config :refer [config]]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
+            [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.external.aws-sqs :as sqs]
-            [oph.ehoks.palaute.opiskelija.kyselylinkki :as kyselylinkki]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.opiskelija :as op]
-            [oph.ehoks.palaute.tyoelama :as tep])
+            [oph.ehoks.palaute.opiskelija.kyselylinkki :as kyselylinkki]
+            [oph.ehoks.palaute.tyoelama.nippu :as nippu]
+            [oph.ehoks.utils :as utils]
+            [oph.ehoks.utils.date :as date])
   (:import (java.time LocalDate)))
 
-(defn send-workplace-periods
+(defn send-workplace-periods!
   "Formats and sends a list of periods to a SQS queue"
   [periods]
   (doseq [period periods]
-    (sqs/send-tyoelamapalaute-message (sqs/build-tyoelamapalaute-msg period))))
-
-(defn process-finished-workplace-periods
-  "Finds all finished workplace periods between dates start and
-  end and sends them to a SQS queue"
-  [start end limit]
-  (let [periods (tep/finished-workplace-periods! start end limit)]
-    (log/infof
-      "Sending %d  (limit %d) finished workplace periods between %s - %s"
-      (count periods) limit start end)
-    (send-workplace-periods periods)
-    periods))
+    (sqs/send-tyoelamapalaute-message! (sqs/build-tyoelamapalaute-msg period))))
 
 (defn get-oppija-kyselylinkit
   "Returns all feedback links for oppija"
@@ -87,3 +84,101 @@
     (db-hoks/select-tyoelamajaksot-active-between "hato" oppija start end)
     (db-hoks/select-tyoelamajaksot-active-between "hpto" oppija start end)
     (db-hoks/select-tyoelamajaksot-active-between "hyto" oppija start end)))
+
+(defn- add-keys
+  [palaute {:keys [opiskeluoikeus niputuspvm vastaamisajan-alkupvm] :as ctx}
+   request-id tunnus]
+  (let [niputuspvm      niputuspvm
+        koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
+        oo-suoritus     (find-first suoritus/ammatillinen?
+                                    (:suoritukset opiskeluoikeus))
+        tutkinto        (get-in oo-suoritus
+                                [:koulutusmoduuli :tunniste :koodiarvo])]
+    (assoc palaute
+           :tallennuspvm (date/now)
+           :alkupvm vastaamisajan-alkupvm
+           :koulutustoimija koulutustoimija
+           :niputuspvm niputuspvm
+           :ohjaaja-ytunnus-kj-tutkinto (nippu/tunniste ctx palaute)
+           :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
+           :osaamisala (str (seq (suoritus/get-osaamisalat
+                                   oo-suoritus (:oid opiskeluoikeus)
+                                   (:heratepvm palaute))))
+           :request-id request-id
+           :toimipiste-oid (str (palaute/toimipiste-oid! oo-suoritus))
+           :tpk-niputuspvm "ei_maaritelty"
+           :tunnus tunnus
+           :tutkinto tutkinto
+           :tutkintonimike (str (seq (map :koodiarvo
+                                          (:tutkintonimike oo-suoritus))))
+           :tyopaikan-normalisoitu-nimi (utils/normalize-string
+                                          (:tyopaikan-nimi palaute))
+           :viimeinen-vastauspvm
+           (str (.plusDays ^LocalDate vastaamisajan-alkupvm 60)))))
+
+; Helper functions that can be mocked in tests
+(def sync-jakso!*     (partial ddb/sync-item! :jakso))
+(def sync-tpo-nippu!* (partial ddb/sync-item! :nippu))
+
+;; FIXME: tältä puuttuu yksikkötesti.
+;; test-create-and-save-arvo-vastaajatunnus-for-all-needed! sisältää
+;; ylimalkaisen testin tälle funktiolle.
+(defn sync-jakso!
+  "Update the herätepalvelu jaksotunnustable to have the same content
+  for given heräte as palaute-backend has in its own database.
+  sync-jakso-herate! only updates fields it 'owns': currently that
+  means that the messaging tracking fields are left intact (because
+  herätepalvelu will update those)."
+  [{:keys [existing-palaute tx] :as ctx} request-id tunnus]
+  {:pre [(some? tunnus)]}
+  (if-not (contains? (set (:heratepalvelu-responsibities config))
+                     :sync-jakso-heratteet)
+    (log/warn "sync-jakso!: configured to not do anything")
+    (let [query (select-keys existing-palaute
+                             [:jakson-yksiloiva-tunniste :hoks-id])]
+      (try (-> (palaute/get-for-heratepalvelu-by-hoks-id-and-yksiloiva-tunniste!
+                 tx query)
+               (first)
+               (not-empty)
+               (or (throw (ex-info "palaute not found" query)))
+               (add-keys ctx request-id tunnus)
+               (dissoc :internal-kyselytyyppi :jakson-yksiloiva-tunniste)
+               (utils/remove-nils)
+               utils/to-underscore-keys
+               ;; the only field that has dashes in its name is tpk-niputuspvm
+               (rename-keys {:tpk_niputuspvm :tpk-niputuspvm})
+               (sync-jakso!*))
+           (catch Exception e
+             (throw (ex-info (format (str "Failed to sync jakso `%s` of HOKS "
+                                          "`%d` to Herätepalvelu")
+                                     (:jakson-yksiloiva-tunniste query)
+                                     (:hoks-id query))
+                             {:type        ::jakso-sync-failed
+                              :arvo-tunnus tunnus}
+                             e)))))))
+
+(defn sync-tpo-nippu!
+  "Update the Herätepalvelu nipputable to have the same content for given heräte
+  as palaute-backend has in its own database."
+  [nippu tunnus]
+  {:pre [(:koulutuksenjarjestaja nippu) (:niputuspvm nippu) (:tutkinto nippu)]}
+  (if-not (contains? (set (:heratepalvelu-responsibities config))
+                     :sync-jakso-heratteet)
+    (log/warn "sync-tpo-nippu!: configured to not do anything")
+    (let [tunnisteet (select-keys nippu [:ohjaaja_ytunnus_kj_tutkinto
+                                         :niputuspvm])]
+      (try
+        (if (ddb/get-item! :nippu tunnisteet)
+          (log/infof "Nippu `%s` already exists" tunnisteet)
+          (sync-tpo-nippu!* nippu))
+        (catch Exception e
+          (throw (ex-info (format (str "Failed to sync TPO-nippu with "
+                                       "tunnisteet %s to Herätepalvelu")
+                                  tunnisteet)
+                          {:type        ::tpo-nippu-sync-failed
+                           :arvo-tunnus tunnus}
+                          e)))))))
+
+(defn delete-jakso-herate!
+  [tep-palaute]
+  (ddb/delete-item! :jakso {:hankkimistapa_id (:hankkimistapa-id tep-palaute)}))

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -1,4 +1,4 @@
-(ns oph.ehoks.heratepalvelu.heratepalvelu
+(ns oph.ehoks.heratepalvelu
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.core :refer [route-middleware]]
             [compojure.api.sweet :as c-api]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
-            [oph.ehoks.heratepalvelu.heratepalvelu :as hp]
+            [oph.ehoks.heratepalvelu :as hp]
             [oph.ehoks.hoks :as hoks]
             [oph.ehoks.hoks.middleware :as m]
             [oph.ehoks.logging.audit :as audit]

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -3,6 +3,7 @@
             [compojure.api.sweet :as c-api]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
             [oph.ehoks.heratepalvelu :as hp]
+            [oph.ehoks.palaute.tyoelama :as tep]
             [oph.ehoks.hoks :as hoks]
             [oph.ehoks.hoks.middleware :as m]
             [oph.ehoks.logging.audit :as audit]
@@ -33,7 +34,7 @@
                        limit :- (s/maybe s/Int)]
         :return (restful/response s/Int)
         (let [l (or limit 10)
-              periods (hp/process-finished-workplace-periods start end l)]
+              periods (tep/process-finished-workplace-periods! start end l)]
           (restful/ok (count periods))))
 
       (c-api/GET "/kasittelemattomat-heratteet" []

--- a/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
+++ b/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
@@ -1,5 +1,8 @@
 (ns oph.ehoks.hoks.osaamisen-hankkimistapa
+  (:require [hugsql.core :as hugsql])
   (:import [java.time LocalDate]))
+
+(hugsql/def-db-fns "oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql")
 
 (def tyopaikkajakso-type?
   #{"osaamisenhankkimistapa_koulutussopimus"

--- a/src/oph/ehoks/oppija/handler.clj
+++ b/src/oph/ehoks/oppija/handler.clj
@@ -11,7 +11,7 @@
             [oph.ehoks.oppija.schema :as oppija-schema]
             [oph.ehoks.hoks :as hoks]
             [oph.ehoks.external.koski :as koski]
-            [oph.ehoks.heratepalvelu.heratepalvelu :as heratepalvelu]
+            [oph.ehoks.heratepalvelu :as heratepalvelu]
             [oph.ehoks.middleware :refer [wrap-authorize]]
             [oph.ehoks.oppija.auth-handler :as auth-handler]
             [oph.ehoks.lokalisointi.handler :as lokalisointi-handler]

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -40,10 +40,12 @@
   "Hakee koulutustoimijan OID:n opiskeluoikeudesta, tai organisaatiopalvelusta
   jos sitä ei löydy opiskeluoikeudesta."
   [opiskeluoikeus]
-  (if-let [koulutustoimija-oid (:oid (:koulutustoimija opiskeluoikeus))]
-    koulutustoimija-oid
-    (:parentOid (organisaatio/get-existing-organisaatio!
-                  (get-in opiskeluoikeus [:oppilaitos :oid])))))
+  (or (:oid (:koulutustoimija opiskeluoikeus))
+      (do
+        (log/info "Ei koulutustoimijaa opiskeluoikeudessa "
+                  (:oid opiskeluoikeus) ", haetaan Organisaatiopalvelusta")
+        (:parentOid (organisaatio/get-organisaatio!
+                      (get-in opiskeluoikeus [:oppilaitos :oid]))))))
 
 (defn toimipiste-oid!
   "Palauttaa toimipisteen OID jos sen organisaatiotyyppi on toimipiste. Tämä

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -90,8 +90,8 @@
    "ammatillinentutkintoosittainen" "osia_suorittaneet"})
 
 (defn kyselytyyppi
-  [tyyppi opiskeluoikeus]
-  (case tyyppi
+  [kyselytyyppi opiskeluoikeus]
+  (case kyselytyyppi
     :aloituskysely "aloittaneet"
     :paattokysely  (-> (find-first suoritus/ammatillinen?
                                    (:suoritukset opiskeluoikeus))

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -90,8 +90,8 @@
    "ammatillinentutkintoosittainen" "osia_suorittaneet"})
 
 (defn kyselytyyppi
-  [kyselytyyppi opiskeluoikeus]
-  (case kyselytyyppi
+  [tyyppi opiskeluoikeus]
+  (case tyyppi
     :aloituskysely "aloittaneet"
     :paattokysely  (-> (find-first suoritus/ammatillinen?
                                    (:suoritukset opiskeluoikeus))

--- a/src/oph/ehoks/palaute/handler.clj
+++ b/src/oph/ehoks/palaute/handler.clj
@@ -65,8 +65,7 @@
               :header-params [caller-id :- s/Str
                               ticket :- s/Str]
               (let [vastaajatunnukset
-                    (tep/create-and-save-arvo-vastaajatunnus-for-all-needed!
-                      {})]
+                    (tep/handle-all-palautteet-waiting-for-vastaajatunnus! {})]
                 (assoc
                   (restful/ok {:vastaajatunnukset vastaajatunnukset})
                   ::audit/target {:vastaajatunnukset vastaajatunnukset})))
@@ -79,8 +78,9 @@
               (if-let [tep-palaute
                        (palaute/get-tep-palaute-waiting-for-vastaajatunnus!
                          db/spec {:palaute-id palaute-id})]
-                (let [vastaajatunnus (tep/create-and-save-arvo-vastaajatunnus!
-                                       tep-palaute)]
+                (let [vastaajatunnus
+                      (tep/handle-palaute-waiting-for-vastaajatunnus!
+                        tep-palaute)]
                   (assoc (restful/ok {:vastaajatunnus vastaajatunnus})
                          ::audit/target {:vastaajatunnus vastaajatunnus
                                          :palaute-id palaute-id}))

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -68,7 +68,14 @@
          (log/spyf :info "existing-heratteet!: before rk filtering: %s")
          (filterv #(= rahoituskausi (palaute/rahoituskausi (:heratepvm %))))
          (log/spyf :info "existing-heratteet!: after rk filtering: %s")
-         (utils/assert-pred #(contains? #{0 1} (count %)))
+         ((fn [existing-palautteet]
+            (when (> (count existing-palautteet) 1)
+              (log/errorf (str "Found more than one existing herate for "
+                               "`%s` of HOKS `%d` in rahoituskausi `%s`.")
+                          kysely-type
+                          (:id hoks)
+                          rahoituskausi))
+            existing-palautteet))
          first)))
 
 (defn build!

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -3,7 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :refer [rename-keys]]
             [clojure.tools.logging :as log]
-            [medley.core :refer [greatest]]
+            [medley.core :refer [find-first greatest]]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
@@ -60,7 +60,7 @@
    :paattokysely :paattoherate_kasitelty})
 
 (defn existing-heratteet!
-  [{:keys [tx hoks koulutustoimija] :as ctx} kysely-type]
+  [tx {:keys [hoks koulutustoimija] :as ctx} kysely-type]
   (let [rahoituskausi (palaute/rahoituskausi
                         (get hoks (herate-date-basis kysely-type)))
         kyselytyypit  (case kysely-type
@@ -76,47 +76,21 @@
       (filterv #(= rahoituskausi (palaute/rahoituskausi (:heratepvm %))))
       (log/spyf :info "existing-heratteet!: after rk filtering: %s"))))
 
-(defn initiate!
-  "Initiates opiskelijapalautekysely (`:aloituskysely` or `:paattokysely`).
-  Currently, stores kysely data to eHOKS DB `palautteet` table and also sends
-  the herate to AWS SQS for Herätepalvelu to process. Returns `true` if kysely
-  was successfully initiated, `nil` or `false` otherwise.
-
-  Supported options in `opts`:
-  `:resend?`  If set to true, don't check if kysely is already
-              intiated, i.e., resend herate straight to Herätepalvelu. Also skip
-              the insertion to eHOKS `palautteet` table. Without this flag, the
-              functionality to resend heratteet to Herätepalvelu wouldn't work.
-              This should be removed once Herätepalvelu functionality has been
-              fully migrated to eHOKS."
-  [{:keys [tx hoks opiskeluoikeus] :as ctx}
-   {:keys [type state] :or {state :odottaa-kasittelya} :as palaute}]
-  {:pre [(#{:aloituskysely :paattokysely} type)]}
-  (let [target-kasittelytila (not= state :odottaa-kasittelya)
-        amisherate-kasittelytila
-        (db-hoks/get-or-create-amisherate-kasittelytila-by-hoks-id! (:id hoks))]
-    (db-hoks/update-amisherate-kasittelytilat!
-      tx {:id (:id amisherate-kasittelytila)
-          (kysely-kasittely-field-mapping type) target-kasittelytila}))
-
-  (let [heratepvm (get hoks (herate-date-basis type))]
-    (palaute/upsert!
-      ctx
-      (assoc palaute
-             :heratepvm heratepvm
-             :alkupvm   (greatest heratepvm (date/now)))
-      (:existing-heratteet palaute))
-    (when (= :odottaa-kasittelya state)
-      (log/info "Making" type "heräte for HOKS" (:id hoks))
-      (sqs/send-amis-palaute-message
-        {:ehoks-id           (:id hoks)
-         :kyselytyyppi       (translate-kyselytyyppi
-                               (palaute/kyselytyyppi palaute opiskeluoikeus))
-         :opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
-         :oppija-oid         (:oppija-oid hoks)
-         :sahkoposti         (:sahkoposti hoks)
-         :puhelinnumero      (:puhelinnumero hoks)
-         :alkupvm            (str heratepvm)}))))
+(defn build!
+  "Builds opiskelijapalaute to be inserted to DB. Uses `palaute/build!` to build
+  an initial `palaute` map, then `assoc`s opiskelijapalaute specific values to
+  that."
+  [{:keys [hoks opiskeluoikeus] :as ctx} tyyppi tila existing-palaute]
+  {:pre [(some? tila)
+         (or (nil? existing-palaute) (palaute/unhandled? existing-palaute))]}
+  (let [heratepvm (get hoks (herate-date-basis tyyppi))
+        alkupvm   (greatest heratepvm (date/now))]
+    (assoc (palaute/build! ctx tila existing-palaute)
+           :kyselytyyppi      (palaute/kyselytyyppi tyyppi opiskeluoikeus)
+           :heratepvm         heratepvm
+           :voimassa-alkupvm  alkupvm
+           :voimassa-loppupvm (palaute/vastaamisajan-loppupvm
+                                heratepvm alkupvm))))
 
 (defn initiate-if-needed!
   "Sends heräte data required for opiskelijapalautekysely (`:aloituskysely` or
@@ -134,24 +108,43 @@
   ([{:keys [hoks opiskeluoikeus] :as ctx} kysely-type opts]
     (jdbc/with-db-transaction
       [tx db/spec]
-      (let [ctx     (assoc ctx
-                           :tx              tx
-                           :koulutustoimija (palaute/koulutustoimija-oid!
+      (let [ctx (assoc ctx :koulutustoimija (palaute/koulutustoimija-oid!
                                               opiskeluoikeus))
-            palaute {:type kysely-type
-                     :existing-heratteet
-                     (when-not (:resend? opts)
-                       (existing-heratteet! ctx kysely-type))}
-            [state field reason]
-            (initial-palaute-state-and-reason
-              ctx kysely-type (:existing-heratteet palaute))
-            tapahtuma {:reason     reason
-                       :other-info (select-keys hoks [field])}]
+            existing-heratteet (when-not (:resend? opts)
+                                 (existing-heratteet! tx ctx kysely-type))
+            [state field reason] (initial-palaute-state-and-reason
+                                   ctx kysely-type existing-heratteet)]
         (log/info "Initial state for" kysely-type "for HOKS" (:id hoks)
                   "will be" (or state :ei-luoda-ollenkaan)
                   "because of" reason "in" field)
         (when state
-          (initiate! ctx (assoc palaute :state state :tapahtuma tapahtuma)))
+          (let [heratepvm       (get hoks (herate-date-basis kysely-type))
+                existing-herate (find-first palaute/unhandled?
+                                            existing-heratteet)
+                target-kasittelytila (not= state :odottaa-kasittelya)
+                amisherate-kasittelytila
+                (db-hoks/get-or-create-amisherate-kasittelytila-by-hoks-id!
+                  (:id hoks))]
+            (db-hoks/update-amisherate-kasittelytilat!
+              tx {:id (:id amisherate-kasittelytila)
+                  (kysely-kasittely-field-mapping kysely-type)
+                  target-kasittelytila})
+            (->> (build! ctx kysely-type state existing-herate)
+                 (palaute/upsert! tx)
+                 (palautetapahtuma/build ctx state field reason existing-herate)
+                 (palautetapahtuma/insert! tx))
+            (when (= :odottaa-kasittelya state)
+              (log/info "Making" type "heräte for HOKS" (:id hoks))
+              (sqs/send-amis-palaute-message
+                {:ehoks-id           (:id hoks)
+                 :kyselytyyppi       (translate-kyselytyyppi
+                                       (palaute/kyselytyyppi
+                                         kysely-type opiskeluoikeus))
+                 :opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
+                 :oppija-oid         (:oppija-oid hoks)
+                 :sahkoposti         (:sahkoposti hoks)
+                 :puhelinnumero      (:puhelinnumero hoks)
+                 :alkupvm            (str heratepvm)}))))
         state))))
 
 (defn initiate-every-needed!

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -3,7 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :refer [rename-keys]]
             [clojure.tools.logging :as log]
-            [medley.core :refer [find-first greatest]]
+            [medley.core :refer [greatest]]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -3,7 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :refer [rename-keys]]
             [clojure.tools.logging :as log]
-            [medley.core :refer [greatest]]
+            [medley.core :refer [find-first greatest]]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -9,7 +9,7 @@
   "Run these tasks sequentially."
   [opts]
   (amis/create-and-save-arvo-kyselylinkki-for-all-needed! opts)
-  (tep/create-and-save-arvo-vastaajatunnus-for-all-needed! opts))
+  (tep/handle-all-palautteet-waiting-for-vastaajatunnus! opts))
 
 (defn run-scheduler!
   "Simple (daily) scheduler for palaute scheduled tasks. Will be replaced with

--- a/src/oph/ehoks/palaute/tapahtuma.clj
+++ b/src/oph/ehoks/palaute/tapahtuma.clj
@@ -1,15 +1,16 @@
 (ns oph.ehoks.palaute.tapahtuma
   (:require [hugsql.core :as hugsql]
             [oph.ehoks.utils :as utils]
-            [plumbing.core :refer [map-vals]]))
+            [medley.core :refer [map-vals]]))
 
 (hugsql/def-db-fns "oph/ehoks/db/sql/palautetapahtuma.sql")
 
 (defn build
-  [{:keys [hoks jakso] :as ctx} state field reason existing-herate palaute]
+  [{:keys [hoks jakso existing-palaute] :as ctx} state field reason palaute]
   {:pre [(some? state)]}
   {:palaute-id      (:id palaute)
-   :vanha-tila      (utils/to-underscore-str (or (:tila existing-herate) state))
+   :vanha-tila      (utils/to-underscore-str
+                      (or (:tila existing-palaute) state))
    :uusi-tila       (utils/to-underscore-str state)
    :tapahtumatyyppi "hoks_tallennus"
    :syy             (utils/to-underscore-str (or reason :hoks-tallennettu))

--- a/src/oph/ehoks/palaute/tapahtuma.clj
+++ b/src/oph/ehoks/palaute/tapahtuma.clj
@@ -1,4 +1,16 @@
 (ns oph.ehoks.palaute.tapahtuma
-  (:require [hugsql.core :as hugsql]))
+  (:require [hugsql.core :as hugsql]
+            [oph.ehoks.utils :as utils]
+            [plumbing.core :refer [map-vals]]))
 
 (hugsql/def-db-fns "oph/ehoks/db/sql/palautetapahtuma.sql")
+
+(defn build
+  [{:keys [hoks jakso] :as ctx} state field reason existing-herate palaute]
+  {:pre [(some? state)]}
+  {:palaute-id      (:id palaute)
+   :vanha-tila      (utils/to-underscore-str (or (:tila existing-herate) state))
+   :uusi-tila       (utils/to-underscore-str state)
+   :tapahtumatyyppi "hoks_tallennus"
+   :syy             (utils/to-underscore-str (or reason :hoks-tallennettu))
+   :lisatiedot      (map-vals str (select-keys (merge jakso hoks) [field]))})

--- a/src/oph/ehoks/palaute/tapahtuma.clj
+++ b/src/oph/ehoks/palaute/tapahtuma.clj
@@ -1,17 +1,30 @@
 (ns oph.ehoks.palaute.tapahtuma
   (:require [hugsql.core :as hugsql]
-            [oph.ehoks.utils :as utils]
-            [medley.core :refer [map-vals]]))
+            [oph.ehoks.db :as db]
+            [oph.ehoks.utils :as utils]))
 
 (hugsql/def-db-fns "oph/ehoks/db/sql/palautetapahtuma.sql")
 
 (defn build
-  [{:keys [hoks jakso existing-palaute] :as ctx} state field reason palaute]
-  {:pre [(some? state)]}
-  {:palaute-id      (:id palaute)
-   :vanha-tila      (utils/to-underscore-str
-                      (or (:tila existing-palaute) state))
-   :uusi-tila       (utils/to-underscore-str state)
-   :tapahtumatyyppi "hoks_tallennus"
-   :syy             (utils/to-underscore-str (or reason :hoks-tallennettu))
-   :lisatiedot      (map-vals str (select-keys (merge jakso hoks) [field]))})
+  ([{:keys [existing-palaute] :as ctx} reason lisatiedot]
+    (build ctx (:tila existing-palaute) reason lisatiedot nil))
+  ([ctx state reason lisatiedot]
+    (build ctx state reason lisatiedot nil))
+  ([{:keys [tapahtumatyyppi existing-palaute] :as ctx}
+    state reason lisatiedot palaute]
+    {:pre [(some? tapahtumatyyppi) (some? state)]}
+    {:palaute-id      (or (:id palaute) (:id existing-palaute))
+     :vanha-tila      (utils/to-underscore-str
+                        (or (:tila existing-palaute) state))
+     :uusi-tila       (utils/to-underscore-str state)
+     :tapahtumatyyppi (utils/to-underscore-str tapahtumatyyppi)
+     :syy             (utils/to-underscore-str (or reason :hoks-tallennettu))
+     :lisatiedot      lisatiedot}))
+
+(defn build-and-insert!
+  ([{:keys [existing-palaute] :as ctx} reason lisatiedot]
+    (build-and-insert! ctx (:tila existing-palaute) reason lisatiedot nil))
+  ([ctx state reason lisatiedot]
+    (build-and-insert! ctx state reason lisatiedot nil))
+  ([{:keys [tx] :as ctx} state reason lisatiedot palaute]
+    (insert! (or tx db/spec) (build ctx state reason lisatiedot palaute))))

--- a/src/oph/ehoks/palaute/tapahtuma.clj
+++ b/src/oph/ehoks/palaute/tapahtuma.clj
@@ -8,8 +8,10 @@
 (defn build
   ([{:keys [existing-palaute] :as ctx} reason lisatiedot]
     (build ctx (:tila existing-palaute) reason lisatiedot nil))
+
   ([ctx state reason lisatiedot]
     (build ctx state reason lisatiedot nil))
+
   ([{:keys [tapahtumatyyppi existing-palaute] :as ctx}
     state reason lisatiedot palaute]
     {:pre [(some? tapahtumatyyppi) (some? state)]}

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -155,7 +155,7 @@
   (let [niputuspvm (str (next-niputus-date (date/now)))
         alkupvm (next-niputus-date
                   (LocalDate/parse (:jakso-loppupvm tep-palaute)))
-        koulutustoimija (opiskeluoikeus-koulutustoimija-oid opiskeluoikeus)
+        koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
         oo-suoritus (find-first suoritus/ammatillinen?
                                 (:suoritukset opiskeluoikeus))
         tutkinto (get-in oo-suoritus
@@ -209,8 +209,7 @@
       (log/warnf
         "Opiskeluoikeus not found for palaute %d, skipping processing"
         (:id tep-palaute))  ; FIXME: create tapahtuma and update state
-      (let [koulutustoimija (opiskeluoikeus-koulutustoimija-oid
-                              opiskeluoikeus)
+      (let [koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
             alkupvm         (next-niputus-date (:loppupvm tep-palaute))
             request-id      (str (UUID/randomUUID))
             suoritus        (find-first suoritus/ammatillinen?

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -8,8 +8,6 @@
             [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.external.koski :as koski]
-            [oph.ehoks.external.organisaatio :as org]
-            [oph.ehoks.hoks.common :as c]
             [oph.ehoks.hoks.osaamisen-hankkimistapa :as oht]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]

--- a/src/oph/ehoks/palaute/tyoelama/nippu.clj
+++ b/src/oph/ehoks/palaute/tyoelama/nippu.clj
@@ -1,0 +1,45 @@
+(ns oph.ehoks.palaute.tyoelama.nippu
+  (:require [clojure.tools.logging :as log]
+            [oph.ehoks.utils :as utils]))
+
+(defn tunniste
+  [ctx tep-palaute]
+  {:pre [(or (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
+             (:ohjaaja-nimi tep-palaute))
+         (or (:tyopaikan-y-tunnus tep-palaute)
+             (:tyopaikan-ytunnus tep-palaute))
+         (:koulutustoimija ctx)
+         (get-in (:suoritus ctx) [:koulutusmoduuli :tunniste :koodiarvo])]}
+  (format "%s/%s/%s/%s"
+          (or (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
+              (:ohjaaja-nimi tep-palaute))
+          (or (:tyopaikan-y-tunnus tep-palaute)
+              (:tyopaikan-ytunnus tep-palaute))
+          (:koulutustoimija ctx)
+          (get-in (:suoritus ctx) [:koulutusmoduuli :tunniste :koodiarvo])))
+
+(defn build-tpo-nippu-for-heratepalvelu
+  [{:keys [suoritus koulutustoimija niputuspvm] :as ctx}
+   tep-palaute keskeytymisajanjaksot]
+  {:pre [(:tyopaikan-nimi tep-palaute)]}
+  (let [tutkinto (get-in suoritus [:koulutusmoduuli :tunniste :koodiarvo])
+        tyopaikan-nimi     (:tyopaikan-nimi tep-palaute)
+        tyopaikan-y-tunnus (:tyopaikan-y-tunnus tep-palaute)
+        ohjaaja            (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
+        nippu-data {:ohjaaja-ytunnus-kj-tutkinto (tunniste ctx tep-palaute)
+                    :ohjaaja                     ohjaaja
+                    :tyopaikka                   tyopaikan-nimi
+                    :ytunnus                     tyopaikan-y-tunnus
+                    :koulutuksenjarjestaja       koulutustoimija
+                    :tutkinto                    tutkinto
+                    :kasittelytila               "ei_niputettu"
+                    :sms-kasittelytila           "ei_lahetetty"
+                    :niputuspvm                  niputuspvm}]
+    (utils/to-underscore-keys
+      (utils/remove-nils
+        (if (not-every? #(some? (:loppu %)) keskeytymisajanjaksot)
+          (do (log/info "Jakso on keskeytynyt, tätä ei niputeta.")
+              (assoc nippu-data
+                     :kasittelytila     "ei_niputeta"
+                     :sms-kasittelytila "ei_niputeta"))
+          nippu-data)))))

--- a/src/oph/ehoks/palaute/tyoelama/nippu.clj
+++ b/src/oph/ehoks/palaute/tyoelama/nippu.clj
@@ -1,6 +1,5 @@
 (ns oph.ehoks.palaute.tyoelama.nippu
-  (:require [clojure.tools.logging :as log]
-            [oph.ehoks.utils :as utils]))
+  (:require [oph.ehoks.utils :as utils]))
 
 (defn tunniste
   [ctx tep-palaute]
@@ -19,27 +18,21 @@
           (get-in (:suoritus ctx) [:koulutusmoduuli :tunniste :koodiarvo])))
 
 (defn build-tpo-nippu-for-heratepalvelu
-  [{:keys [suoritus koulutustoimija niputuspvm] :as ctx}
-   tep-palaute keskeytymisajanjaksot]
-  {:pre [(:tyopaikan-nimi tep-palaute)]}
+  [{:keys [existing-palaute suoritus koulutustoimija niputuspvm] :as ctx}]
+  {:pre [(:tyopaikan-nimi existing-palaute)]}
   (let [tutkinto (get-in suoritus [:koulutusmoduuli :tunniste :koodiarvo])
-        tyopaikan-nimi     (:tyopaikan-nimi tep-palaute)
-        tyopaikan-y-tunnus (:tyopaikan-y-tunnus tep-palaute)
-        ohjaaja            (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
-        nippu-data {:ohjaaja-ytunnus-kj-tutkinto (tunniste ctx tep-palaute)
-                    :ohjaaja                     ohjaaja
-                    :tyopaikka                   tyopaikan-nimi
-                    :ytunnus                     tyopaikan-y-tunnus
-                    :koulutuksenjarjestaja       koulutustoimija
-                    :tutkinto                    tutkinto
-                    :kasittelytila               "ei_niputettu"
-                    :sms-kasittelytila           "ei_lahetetty"
-                    :niputuspvm                  niputuspvm}]
-    (utils/to-underscore-keys
-      (utils/remove-nils
-        (if (not-every? #(some? (:loppu %)) keskeytymisajanjaksot)
-          (do (log/info "Jakso on keskeytynyt, tätä ei niputeta.")
-              (assoc nippu-data
-                     :kasittelytila     "ei_niputeta"
-                     :sms-kasittelytila "ei_niputeta"))
-          nippu-data)))))
+        tyopaikan-nimi     (:tyopaikan-nimi existing-palaute)
+        tyopaikan-y-tunnus (:tyopaikan-y-tunnus existing-palaute)
+        ohjaaja            (:vastuullinen-tyopaikka-ohjaaja-nimi
+                             existing-palaute)]
+    (-> {:ohjaaja-ytunnus-kj-tutkinto (tunniste ctx existing-palaute)
+         :ohjaaja                     ohjaaja
+         :tyopaikka                   tyopaikan-nimi
+         :ytunnus                     tyopaikan-y-tunnus
+         :koulutuksenjarjestaja       koulutustoimija
+         :tutkinto                    tutkinto
+         :kasittelytila               "ei_niputettu"
+         :sms-kasittelytila           "ei_lahetetty"
+         :niputuspvm                  niputuspvm}
+        (utils/remove-nils)
+        (utils/to-underscore-keys))))

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -1,21 +1,11 @@
 (ns oph.ehoks.utils
-  (:require [clojure.string :as string]
-            [medley.core :refer [dissoc-in map-keys]])
-  (:import (java.text Normalizer Normalizer$Form)))
+  (:require [medley.core :refer [dissoc-in map-keys]]))
 
 (defn apply-when
   "Apply function `f` to value `v` if predicate `(pred v)` returns `true`.
   Otherwise returns value `v` unchanged. Useful when used in a threading macro."
   [v pred f]
   (if (pred v) (f v) v))
-
-(defn assert-pred
-  "Takes a predicate `pred` and a value `v` that is given to the predicate.
-  Asserts that `(pred v)` returns `true` and then returns `v`. Useful when used
-  in a threading macro."
-  [pred v]
-  (assert (pred v))
-  v)
 
 (defn to-underscore-str
   [kw]

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -9,6 +9,14 @@
   [v pred f]
   (if (pred v) (f v) v))
 
+(defn assert-pred
+  "Takes a predicate `pred` and a value `v` that is given to the predicate.
+  Asserts that `(pred v)` returns `true` and then returns `v`. Useful when used
+  in a threading macro."
+  [pred v]
+  (assert (pred v))
+  v)
+
 (defn- deaccent-string
   "Poistaa diakriittiset merkit stringistä ja palauttaa muokatun stringin."
   [utf8-string]

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -1,11 +1,25 @@
 (ns oph.ehoks.utils
-  (:require [medley.core :refer [dissoc-in map-keys]]))
+  (:require [clojure.string :as string]
+            [medley.core :refer [dissoc-in map-keys]])
+  (:import (java.text Normalizer Normalizer$Form)))
 
 (defn apply-when
   "Apply function `f` to value `v` if predicate `(pred v)` returns `true`.
   Otherwise returns value `v` unchanged. Useful when used in a threading macro."
   [v pred f]
   (if (pred v) (f v) v))
+
+(defn- deaccent-string
+  "Poistaa diakriittiset merkit stringistä ja palauttaa muokatun stringin."
+  [utf8-string]
+  (string/replace (Normalizer/normalize utf8-string Normalizer$Form/NFD)
+                  #"\p{InCombiningDiacriticalMarks}+"
+                  ""))
+
+(defn normalize-string
+  "Muuttaa muut merkit kuin kirjaimet ja numerot alaviivaksi."
+  [string]
+  (string/lower-case (string/replace (deaccent-string string) #"\W+" "_")))
 
 (defn to-underscore-str
   [kw]

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -17,18 +17,6 @@
   (assert (pred v))
   v)
 
-(defn- deaccent-string
-  "Poistaa diakriittiset merkit stringistä ja palauttaa muokatun stringin."
-  [utf8-string]
-  (string/replace (Normalizer/normalize utf8-string Normalizer$Form/NFD)
-                  #"\p{InCombiningDiacriticalMarks}+"
-                  ""))
-
-(defn normalize-string
-  "Muuttaa muut merkit kuin kirjaimet ja numerot alaviivaksi."
-  [string]
-  (string/lower-case (string/replace (deaccent-string string) #"\W+" "_")))
-
 (defn to-underscore-str
   [kw]
   (.replace (name kw) \- \_))

--- a/src/oph/ehoks/utils/string.clj
+++ b/src/oph/ehoks/utils/string.clj
@@ -1,0 +1,21 @@
+(ns oph.ehoks.utils.string
+  (:require [clojure.string :as str])
+  (:import (java.text Normalizer Normalizer$Form)))
+
+(defn- deaccent
+  "Poistaa diakriittiset merkit merkkijonosta ja palauttaa muokatun
+  merkkijonon."
+  [utf8-string]
+  (str/replace (Normalizer/normalize utf8-string Normalizer$Form/NFD)
+               #"\p{InCombiningDiacriticalMarks}+"
+               ""))
+
+(defn normalize
+  "Convert non-alphanumeric characters to underscore characters  (`_`) and
+  make letters lower case. If the resulting string has an underscore character
+  as a prefix or postfix, those underscore characters are removed."
+  [string]
+  (-> (deaccent string)
+      (str/replace #"\W+" "_")
+      (str/replace #"(^_|_$)" "")
+      (str/lower-case)))

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -18,7 +18,7 @@
             [oph.ehoks.external.organisaatio :as organisaatio]
             [oph.ehoks.healthcheck.handler :as healthcheck-handler]
             [oph.ehoks.heratepalvelu.herate-handler :as herate-handler]
-            [oph.ehoks.heratepalvelu.heratepalvelu :as heratepalvelu]
+            [oph.ehoks.heratepalvelu :as heratepalvelu]
             [oph.ehoks.hoks :as hoks]
             [oph.ehoks.hoks.handler :as hoks-handler]
             [oph.ehoks.hoks.schema :as hoks-schema]

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -27,8 +27,12 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"item key missing"
                           (ddb/sync-item! :amis {}))))
   (testing "sync-amis-herate! fails when there is no information in db"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"palaute not found"
-                          (ddb/sync-amis-herate! 54343 "aloittaneet")))))
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"palaute not found"
+          (ddb/sync-amis-herate!
+            {:existing-palaute {:hoks-id 54343
+                                :kyselytyyppi "aloittaneet"}})))))
 
 (def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
                 :oppija-oid "1.2.246.562.24.12312312319"
@@ -54,7 +58,9 @@
                           :opiskeluoikeus opiskeluoikeus})
             hoks (hoks/get-by-id (:id saved-hoks))]
         (is (= (:sahkoposti hoks) "irma.isomerkki@esimerkki.com"))
-        (ddb/sync-amis-herate! (:id saved-hoks) "aloittaneet")
+        (ddb/sync-amis-herate!
+          {:existing-palaute {:hoks-id      (:id saved-hoks)
+                              :kyselytyyppi "aloittaneet"}})
         (let [ddb-key {:tyyppi_kausi
                        (str "aloittaneet/"
                             (palaute/rahoituskausi (LocalDate/now)))
@@ -75,7 +81,9 @@
                                     :sahkoposti "foo@bar.com")
              :opiskeluoikeus opiskeluoikeus}
             hoks/update!)
-          (ddb/sync-amis-herate! (:id saved-hoks) "aloittaneet")
+          (ddb/sync-amis-herate!
+            {:existing-palaute {:hoks-id      (:id saved-hoks)
+                                :kyselytyyppi "aloittaneet"}})
           ; fields that are owned by herätepalvelu are not overwritten
           (let [new-ddb-item
                 (far/get-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -36,11 +36,6 @@
                 :osaamisen-hankkimisen-tarve true
                 :sahkoposti "irma.isomerkki@esimerkki.com"})
 
-(deftest test-sync-tpo-nippu-herate!
-  (with-redefs [koski/get-opiskeluoikeus-info-raw
-                koski-test/mock-get-opiskeluoikeus-raw]
-    nil))
-
 (deftest sync-herate-to-dynamodb
   (with-redefs [koski/get-opiskeluoikeus-info-raw
                 koski-test/mock-get-opiskeluoikeus-raw]

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -36,6 +36,11 @@
                 :osaamisen-hankkimisen-tarve true
                 :sahkoposti "irma.isomerkki@esimerkki.com"})
 
+(deftest test-sync-tpo-nippu-herate!
+  (with-redefs [koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw]
+    nil))
+
 (deftest sync-herate-to-dynamodb
   (with-redefs [koski/get-opiskeluoikeus-info-raw
                 koski-test/mock-get-opiskeluoikeus-raw]

--- a/test/oph/ehoks/external/koski_test.clj
+++ b/test/oph/ehoks/external/koski_test.clj
@@ -63,8 +63,9 @@
             ExceptionInfo
             (re-pattern
               (str "Error while fetching opiskeluoikeus "
-                   "`1.246.562.15.12345678910` from Koski. "
-                   "Koski-virhekoodi is `badRequest.format.number`."))
+                   "`1.246.562.15.12345678910` from Koski. Got response with "
+                   "HTTP status 400 and Koski-virhekoodi "
+                   "`badRequest.format.number`."))
             (k/get-opiskeluoikeus! "1.246.562.15.12345678910"))))))
 
 (deftest test-get-existing-opiskeluoikeus!
@@ -80,8 +81,9 @@
             ExceptionInfo
             (re-pattern
               (str "Error while fetching opiskeluoikeus "
-                   "`1.246.562.15.12345678910` from Koski. "
-                   "Koski-virhekoodi is `badRequest.format.number`."))
+                   "`1.246.562.15.12345678910` from Koski. Got response with "
+                   "HTTP status 400 and Koski-virhekoodi "
+                   "`badRequest.format.number`."))
             (k/get-opiskeluoikeus! "1.246.562.15.12345678910"))))))
 
 (deftest test-get-oppija-opiskeluoikeudet

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -151,6 +151,9 @@
                   base-url
                   (dissoc hoks-test/hoks-1 :id))))
 
+(defn palautteet []
+  (db-helpers/query ["select * from palautteet"]))
+
 (defn kasittelemattomat-palauteet []
   (db-helpers/query
     [(str "select * from palautteet "

--- a/test/oph/ehoks/hoks_test.clj
+++ b/test/oph/ehoks/hoks_test.clj
@@ -47,12 +47,16 @@
        :osaamisen-hankkimistapa-koodi-versio 1
        :alku (LocalDate/of 2023 11 1)
        :loppu (LocalDate/of 2023 11 25)
+       :keskeytymisajanjaksot [{:alku (LocalDate/of 2023 11 5)
+                                :loppu (LocalDate/of 2023 11 8)}
+                               {:alku (LocalDate/of 2023 11 16)
+                                :loppu (LocalDate/of 2023 11 16)}]
        :osa-aikaisuustieto 80
        :tyopaikalla-jarjestettava-koulutus
        {:vastuullinen-tyopaikka-ohjaaja
-        {:nimi "Olli Ohjaaja"
-         :sahkoposti "olli.ohjaaja@esimerkki.com"
-         :puhelinnumero "0401111111"}
+        {:nimi "Matti Meikäläinen"
+         :sahkoposti "matti.meikalainen@esimerkki.com"
+         :puhelinnumero "0402222222"}
         :tyopaikan-nimi "Ohjaus Oy"
         :tyopaikan-y-tunnus "5523718-7"
         :keskeiset-tyotehtavat ["Hälytysten valvonta"
@@ -108,9 +112,9 @@
          :osa-aikaisuustieto 60
          :tyopaikalla-jarjestettava-koulutus
          {:vastuullinen-tyopaikka-ohjaaja
-          {:nimi "Olli Ohjaaja"
-           :sahkoposti "olli.ohjaaja@esimerkki.com"
-           :puhelinnumero "0401111111"}
+          {:nimi "Matti Meikäläinen"
+           :sahkoposti "matti.meikalainen@esimerkki.com"
+           :puhelinnumero "0402222222"}
           :tyopaikan-nimi "Ohjaus Oy"
           :tyopaikan-y-tunnus "5523718-7"
           :keskeiset-tyotehtavat ["Hälytysten valvonta"

--- a/test/oph/ehoks/palaute/handler_test.clj
+++ b/test/oph/ehoks/palaute/handler_test.clj
@@ -91,7 +91,8 @@
                       hoks-utils/mock-get-organisaatio!
                       koski/get-opiskeluoikeus!
                       hoks-utils/mock-get-opiskeluoikeus!
-                      arvo/create-jaksotunnus hoks-utils/mock-create-jaksotunnus
+                      arvo/create-jaksotunnus!
+                      hoks-utils/mock-create-jaksotunnus
                       date/now #(LocalDate/of 2024 6 30)]
           (is (= (count (hoks-utils/kasittelemattomat-palauteet)) 5))
 

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -177,8 +177,8 @@
      (str "Kysely is considered already initiated if it is for same "
           "oppija with same koulutustoimija and within same rahoituskausi.")
       (are [kysely-type] (= (:tila (first (op/existing-heratteet!
-                                            {:tx   db/spec
-                                             :hoks hoks-test/hoks-3
+                                            db/spec
+                                            {:hoks hoks-test/hoks-3
                                              :koulutustoimija
                                              "1.2.246.562.10.346830761110"}
                                             kysely-type)))
@@ -188,8 +188,8 @@
     (testing "Kysely is not considered already initiated when"
       (testing "koulutustoimija differs."
         (are [kysely-type] (empty? (op/existing-heratteet!
-                                     {:tx db/spec
-                                      :hoks hoks-test/hoks-3
+                                     db/spec
+                                     {:hoks hoks-test/hoks-3
                                       :koulutustoimija
                                       "1.2.246.562.10.45678901237"}
                                      kysely-type))
@@ -197,8 +197,8 @@
 
       (testing "heratepvm is within different rahoituskausi."
         (are [kysely-type] (empty? (op/existing-heratteet!
-                                     {:tx db/spec
-                                      :hoks hoks-test/hoks-4
+                                     db/spec
+                                     {:hoks hoks-test/hoks-4
                                       :koulutustoimija
                                       "1.2.246.562.10.346830761110"}
                                      kysely-type))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -20,7 +20,7 @@
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.oppijaindex-test :as oppijaindex-test]
             [oph.ehoks.palaute :as palaute]
-            [oph.ehoks.palaute.tapahtuma :as palautetapahtuma]
+            [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.opiskelija :as op]
             [oph.ehoks.test-utils :as test-utils]
             [oph.ehoks.utils.date :as date])
@@ -243,7 +243,7 @@
             :paattokysely)
           (is (= (set (map
                         (juxt :kyselytyyppi :uusi-tila :syy)
-                        (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                        (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                           db/spec {:hoks-id      (:id hoks-test/hoks-1)
                                    :kyselytyypit op/kyselytyypit})))
                  #{["aloittaneet" "odottaa_kasittelya" "hoks_tallennettu"]
@@ -411,7 +411,7 @@
                    :kysely_linkki "https://arvovastaus.csc.fi/v/foo1"
                    :voimassa_loppupvm "2024-10-10"}}]]
                (->> {:hoks-id (:id hoks) :kyselytyypit ["valmistuneet"]}
-                    (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                    (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                       db/spec)
                     (map (juxt :vanha-tila :uusi-tila :lisatiedot)))))
         (client/reset-functions!))
@@ -451,7 +451,7 @@
                  {:errormsg "HTTP request error: not found"
                   :body {:msg "Huonosti menee", :error "ei_kyselykertaa"}}]]
                (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
-                    (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                    (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                       db/spec)
                     (map (juxt :vanha-tila :uusi-tila :lisatiedot)))))
         (client/reset-functions!)))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -40,7 +40,7 @@
                           [:aloituskysely :paattokysely])]
       (let [state-and-reason
             (op/initial-palaute-state-and-reason
-              {:hoks hoks :opiskeluoikeus opiskeluoikeus} {:type kysely-type})]
+              {:hoks hoks :opiskeluoikeus opiskeluoikeus} kysely-type nil)]
         (is (contains? #{:ei-laheteta nil} (first state-and-reason)))
         (is (= (last state-and-reason) reason))))))
 
@@ -127,14 +127,14 @@
         (testing
          "initiate aloituskysely if `osaamisen-hankkimisen-tarve` is `true`."
           (is (= (op/initial-palaute-state-and-reason
-                   ctx {:type :aloituskysely})
+                   ctx :aloituskysely nil)
                  [:odottaa-kasittelya :ensikertainen-hyvaksyminen
                   :hoks-tallennettu])))
 
         (testing
          (str "initiate paattokysely if `osaamisen-hankkimisen-tarve` is "
               "`true` and `osaamisen-saavuttamisen-pvm` is not missing.")
-          (is (= (op/initial-palaute-state-and-reason ctx {:type :paattokysely})
+          (is (= (op/initial-palaute-state-and-reason ctx :paattokysely nil)
                  [:odottaa-kasittelya :osaamisen-saavuttamisen-pvm
                   :hoks-tallennettu])))))))
 

--- a/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
@@ -16,32 +16,14 @@
    :niputuspvm                  (LocalDate/of 2024 12 16)})
 
 (deftest test-build-tpo-nippu-for-heratepalvelu
-  (let [ctx {:koulutustoimija "1.2.246.562.10.346830761110"
-             :suoritus        {:koulutusmoduuli
-                               {:tunniste {:koodiarvo "12345"}}}
-             :niputuspvm      (LocalDate/of 2024 12 16)}
-        tep-palaute
+  (let [tep-palaute
         {:vastuullinen-tyopaikka-ohjaaja-nimi "Matti Meikäläinen"
          :tyopaikan-y-tunnus                  "1234567-1"
-         :tyopaikan-nimi                      "Meikäläisen Murkinat Oy"}]
-    (testing "Kasittelytila for nippu will be"
-      (testing "\"ei_niputettu\" when"
-        (testing "there are no keskeytymisajanjaksos"
-          (is (= (nippu/build-tpo-nippu-for-heratepalvelu ctx tep-palaute {})
-                 expected-tpo-nippu-data)))
-        (testing "there are keskeytymisajanjaksos but they're all closed"
-          (is (= (nippu/build-tpo-nippu-for-heratepalvelu
-                   ctx tep-palaute [{:alku  (LocalDate/of 2023 11 1)
-                                     :loppu (LocalDate/of 2023 11 16)}
-                                    {:alku  (LocalDate/of 2024 02 5)
-                                     :loppu (LocalDate/of 2024 02 8)}])
-                 expected-tpo-nippu-data))))
-      (testing
-       "\"ei_niputeta\" when there are one or more open keskeytymisajanjakso"
-        (is (= (nippu/build-tpo-nippu-for-heratepalvelu
-                 ctx tep-palaute [{:alku  (LocalDate/of 2023 11 1)
-                                   :loppu (LocalDate/of 2023 11 16)}
-                                  {:alku  (LocalDate/of 2024 02 5)}])
-               (assoc expected-tpo-nippu-data
-                      :kasittelytila     "ei_niputeta"
-                      :sms_kasittelytila "ei_niputeta")))))))
+         :tyopaikan-nimi                      "Meikäläisen Murkinat Oy"}
+        ctx {:existing-palaute tep-palaute
+             :koulutustoimija "1.2.246.562.10.346830761110"
+             :suoritus        {:koulutusmoduuli
+                               {:tunniste {:koodiarvo "12345"}}}
+             :niputuspvm      (LocalDate/of 2024 12 16)}]
+    (is (= (nippu/build-tpo-nippu-for-heratepalvelu ctx)
+           expected-tpo-nippu-data))))

--- a/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
@@ -1,0 +1,47 @@
+(ns oph.ehoks.palaute.tyoelama.nippu-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [oph.ehoks.palaute.tyoelama.nippu :as nippu])
+  (:import [java.time LocalDate]))
+;
+(def expected-tpo-nippu-data
+  {:ohjaaja_ytunnus_kj_tutkinto (str "Matti Meikäläinen/1234567-1/"
+                                     "1.2.246.562.10.346830761110/12345")
+   :ohjaaja                     "Matti Meikäläinen"
+   :tyopaikka                   "Meikäläisen Murkinat Oy"
+   :ytunnus                     "1234567-1"
+   :koulutuksenjarjestaja       "1.2.246.562.10.346830761110"
+   :tutkinto                    "12345"
+   :kasittelytila               "ei_niputettu"
+   :sms_kasittelytila           "ei_lahetetty"
+   :niputuspvm                  (LocalDate/of 2024 12 16)})
+
+(deftest test-build-tpo-nippu-for-heratepalvelu
+  (let [ctx {:koulutustoimija "1.2.246.562.10.346830761110"
+             :suoritus        {:koulutusmoduuli
+                               {:tunniste {:koodiarvo "12345"}}}
+             :niputuspvm      (LocalDate/of 2024 12 16)}
+        tep-palaute
+        {:vastuullinen-tyopaikka-ohjaaja-nimi "Matti Meikäläinen"
+         :tyopaikan-y-tunnus                  "1234567-1"
+         :tyopaikan-nimi                      "Meikäläisen Murkinat Oy"}]
+    (testing "Kasittelytila for nippu will be"
+      (testing "\"ei_niputettu\" when"
+        (testing "there are no keskeytymisajanjaksos"
+          (is (= (nippu/build-tpo-nippu-for-heratepalvelu ctx tep-palaute {})
+                 expected-tpo-nippu-data)))
+        (testing "there are keskeytymisajanjaksos but they're all closed"
+          (is (= (nippu/build-tpo-nippu-for-heratepalvelu
+                   ctx tep-palaute [{:alku  (LocalDate/of 2023 11 1)
+                                     :loppu (LocalDate/of 2023 11 16)}
+                                    {:alku  (LocalDate/of 2024 02 5)
+                                     :loppu (LocalDate/of 2024 02 8)}])
+                 expected-tpo-nippu-data))))
+      (testing
+       "\"ei_niputeta\" when there are one or more open keskeytymisajanjakso"
+        (is (= (nippu/build-tpo-nippu-for-heratepalvelu
+                 ctx tep-palaute [{:alku  (LocalDate/of 2023 11 1)
+                                   :loppu (LocalDate/of 2023 11 16)}
+                                  {:alku  (LocalDate/of 2024 02 5)}])
+               (assoc expected-tpo-nippu-data
+                      :kasittelytila     "ei_niputeta"
+                      :sms_kasittelytila "ei_niputeta")))))))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -115,26 +115,25 @@
   (testing "On HOKS creation or update"
     (with-redefs [date/now #(LocalDate/of 2023 7 1)]
       (testing "don't initiate kysely if"
-        (testing "there is already herate for tyopaikkajakso."
+        (testing "there is already a handled herate for tyopaikkajakso."
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-1
-                    :jakso          test-jakso}
-                   {:yksiloiva-tunniste "asd"})
+                    :jakso          test-jakso
+                    :existing-palaute {:yksiloiva-tunniste "asd"
+                                       :tila "vastaajatunnus_muodostettu"}})
                  [nil :yksiloiva-tunniste :jo-lahetetty])))
         (testing "opiskeluoikeus is in terminal state."
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-5
-                    :jakso test-jakso}
-                   nil)
+                    :jakso test-jakso})
                  [:ei-laheteta :opiskeluoikeus-oid :opiskelu-paattynyt])))
         (testing "osa-aikaisuus is missing from työpaikkajakso"
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-1
-                    :jakso (dissoc test-jakso :osa-aikaisuustieto)}
-                   nil)
+                    :jakso (dissoc test-jakso :osa-aikaisuustieto)})
                  [:ei-laheteta :osa-aikaisuustieto :ei-ole])))
         (testing "workplace information is missing from työpaikkajakso"
           (is (= (tep/initial-palaute-state-and-reason
@@ -143,8 +142,7 @@
                     :jakso (update test-jakso
                                    :tyopaikalla-jarjestettava-koulutus
                                    dissoc
-                                   :tyopaikan-y-tunnus)}
-                   nil)
+                                   :tyopaikan-y-tunnus)})
                  [:ei-laheteta :tyopaikalla-jarjestettava-koulutus
                   :puuttuva-yhteystieto])))
         (testing "työpaikkajakso is interrupted on it's end date"
@@ -154,22 +152,19 @@
                     :jakso (assoc-in test-jakso
                                      [:keskeytymisajanjaksot 1]
                                      {:alku  (LocalDate/of 2023 12 1)
-                                      :loppu (LocalDate/of 2023 12 15)})}
-                   nil)
+                                      :loppu (LocalDate/of 2023 12 15)})})
                  [:ei-laheteta :keskeytymisajanjaksot :jakso-keskeytynyt])))
         (testing "opiskeluoikeus doesn't have any ammatillinen suoritus"
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-2
-                    :jakso test-jakso}
-                   nil)
+                    :jakso test-jakso})
                  [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen])))
         (testing "there is a feedback preventing code in opiskeluoikeusjakso."
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-4
-                    :jakso test-jakso}
-                   nil)
+                    :jakso test-jakso})
                  [:ei-laheteta :opiskeluoikeus-oid :ulkoisesti-rahoitettu])))
         (testing "HOKS is a TUVA-HOKS or a HOKS related to TUVA-HOKS."
           (doseq [test-hoks [(assoc hoks-test/hoks-1
@@ -181,8 +176,7 @@
             (is (= (tep/initial-palaute-state-and-reason
                      {:hoks           test-hoks
                       :opiskeluoikeus oo-test/opiskeluoikeus-1
-                      :jakso test-jakso}
-                     nil)
+                      :jakso test-jakso})
                    [:ei-laheteta
                     :tuva-opiskeluoikeus-oid
                     :tuva-opiskeluoikeus]))))
@@ -191,22 +185,19 @@
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus (assoc-in oo-test/opiskeluoikeus-1
                                               [:tyyppi :koodiarvo] "tuva")
-                    :jakso test-jakso}
-                   nil)
+                    :jakso test-jakso})
                  [:ei-laheteta :opiskeluoikeus-oid :tuva-opiskeluoikeus])))
         (testing "opiskeluoikeus is linked to another opiskeluoikeus"
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-3
-                    :jakso test-jakso}
-                   nil)
+                    :jakso test-jakso})
                  [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus]))))
       (testing "initiate kysely if when all of the checks are OK."
         (is (= (tep/initial-palaute-state-and-reason
                  {:hoks           hoks-test/hoks-1
                   :opiskeluoikeus oo-test/opiskeluoikeus-1
-                  :jakso test-jakso}
-                 nil)
+                  :jakso test-jakso})
                [:odottaa-kasittelya :loppu :hoks-tallennettu]))))))
 
 (defn- build-expected-herate

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -16,7 +16,7 @@
             [oph.ehoks.hoks.hoks-test-utils :as hoks-utils]
             [oph.ehoks.opiskeluoikeus-test :as oo-test]
             [oph.ehoks.palaute :as palaute]
-            [oph.ehoks.palaute.tapahtuma :as palautetapahtuma]
+            [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.tyoelama :as tep]
             [oph.ehoks.test-utils :as test-utils]
             [oph.ehoks.utils.date :as date])
@@ -242,7 +242,7 @@
               expected (build-expected-herate test-jakso hoks-test/hoks-1)]
           (is (= real expected)
               ["diff: " (clojure.data/diff real expected)]))
-        (let [tapahtumat (palautetapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+        (let [tapahtumat (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
                            db/spec
                            {:hoks-id      (:id hoks-test/hoks-1)
                             :kyselytyypit ["tyopaikkajakson_suorittaneet"]})]

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -55,6 +55,175 @@
    :hankkimistapa-id 2
    :hankkimistapa-tyyppi "koulutussopimus_01"})
 
+(def expected-ddb-jaksot
+  [{:osa_aikaisuus 100
+    :ohjaaja_nimi "Olli Ohjaaja"
+    :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
+    :hankkimistapa_tyyppi "oppisopimus"
+    :hoks_id 1
+    :oppisopimuksen_perusta "01"
+    :tyopaikan_nimi "Ohjaus Oy"
+    :tyopaikan_ytunnus "5523718-7"
+    :jakso_loppupvm "2023-12-05"
+    :ohjaaja_puhelinnumero "0401111111"
+    :osaamisala "(\"test-osaamisala\")"
+    :tutkinnonosa_tyyppi "hato"
+    :yksiloiva_tunniste "1"
+    :tutkinnonosa_koodi "tutkinnonosat_300268"
+    :tpk-niputuspvm "ei_maaritelty"
+    :tallennuspvm "2024-06-30"
+    :oppilaitos "1.2.246.562.10.12944436166"
+    :ohjaaja_ytunnus_kj_tutkinto
+    "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
+    :tutkinnonosa_id 1
+    :niputuspvm "2024-07-01"
+    :tyopaikan_normalisoitu_nimi "ohjaus_oy"
+    :toimipiste_oid "1.2.246.562.10.12345678903"
+    :tutkinto "123456"
+    :alkupvm "2023-12-16"
+    :koulutustoimija "1.2.246.562.10.346830761110"
+    :jakso_alkupvm "2023-12-01"
+    :ohjaaja_email "olli.ohjaaja@esimerkki.com"
+    :hankkimistapa_id 12
+    :oppija_oid "1.2.246.562.24.12312312319"
+    :rahoituskausi "2023-2024"
+    :tutkintonimike "(\"12345\" \"23456\")"
+    :viimeinen_vastauspvm "2024-02-14"
+    :kasittelytila "ei_niputettu"}
+   {:osa_aikaisuus 100
+    :ohjaaja_nimi "Olli Ohjaaja"
+    :tutkinnonosa_nimi "Testiosa"
+    :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
+    :hankkimistapa_tyyppi "koulutussopimus"
+    :hoks_id 1
+    :tyopaikan_nimi "Ohjaus Oy"
+    :tyopaikan_ytunnus "5523718-7"
+    :jakso_loppupvm "2024-01-06"
+    :ohjaaja_puhelinnumero "0401111111"
+    :osaamisala "(\"test-osaamisala\")"
+    :tutkinnonosa_tyyppi "hpto"
+    :yksiloiva_tunniste "4"
+    :tpk-niputuspvm "ei_maaritelty"
+    :tallennuspvm "2024-06-30"
+    :oppilaitos "1.2.246.562.10.12944436166"
+    :ohjaaja_ytunnus_kj_tutkinto
+    "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
+    :tutkinnonosa_id 1
+    :niputuspvm "2024-07-01"
+    :tyopaikan_normalisoitu_nimi "ohjaus_oy"
+    :toimipiste_oid "1.2.246.562.10.12345678903"
+    :tutkinto "123456"
+    :alkupvm "2024-01-16"
+    :koulutustoimija "1.2.246.562.10.346830761110"
+    :jakso_alkupvm "2024-01-01"
+    :ohjaaja_email "olli.ohjaaja@esimerkki.com"
+    :hankkimistapa_id 10
+    :oppija_oid "1.2.246.562.24.12312312319"
+    :rahoituskausi "2023-2024"
+    :tutkintonimike "(\"12345\" \"23456\")"
+    :viimeinen_vastauspvm "2024-03-16"
+    :kasittelytila "ei_niputettu"}
+   {:osa_aikaisuus 80
+    :ohjaaja_nimi "Matti Meikäläinen"
+    :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
+    :hankkimistapa_tyyppi "koulutussopimus"
+    :hoks_id 1
+    :tyopaikan_nimi "Ohjaus Oy"
+    :tyopaikan_ytunnus "5523718-7"
+    :jakso_loppupvm "2023-11-25"
+    :ohjaaja_puhelinnumero "0402222222"
+    :osaamisala "(\"test-osaamisala\")"
+    :tutkinnonosa_tyyppi "hato"
+    :yksiloiva_tunniste "3"
+    :tutkinnonosa_koodi "tutkinnonosat_300269"
+    :tpk-niputuspvm "ei_maaritelty"
+    :tallennuspvm "2024-06-30"
+    :oppilaitos "1.2.246.562.10.12944436166"
+    :ohjaaja_ytunnus_kj_tutkinto
+    "Matti Meikäläinen/5523718-7/1.2.246.562.10.346830761110/123456"
+    :tutkinnonosa_id 2
+    :niputuspvm "2024-07-01"
+    :tyopaikan_normalisoitu_nimi "ohjaus_oy"
+    :toimipiste_oid "1.2.246.562.10.12345678903"
+    :tutkinto "123456"
+    :alkupvm "2023-12-01"
+    :koulutustoimija "1.2.246.562.10.346830761110"
+    :jakso_alkupvm "2023-11-01"
+    :ohjaaja_email "matti.meikalainen@esimerkki.com"
+    :hankkimistapa_id 14
+    :oppija_oid "1.2.246.562.24.12312312319"
+    :rahoituskausi "2023-2024"
+    :tutkintonimike "(\"12345\" \"23456\")"
+    :viimeinen_vastauspvm "2024-01-30"
+    :kasittelytila "ei_niputettu"}
+   {:osa_aikaisuus 60
+    :ohjaaja_nimi "Matti Meikäläinen"
+    :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
+    :hankkimistapa_tyyppi "koulutussopimus"
+    :hoks_id 1
+    :tyopaikan_nimi "Ohjaus Oy"
+    :tyopaikan_ytunnus "5523718-7"
+    :jakso_loppupvm "2024-01-25"
+    :ohjaaja_puhelinnumero "0402222222"
+    :osaamisala "(\"test-osaamisala\")"
+    :tutkinnonosa_tyyppi "hyto"
+    :yksiloiva_tunniste "7"
+    :tutkinnonosa_koodi "tutkinnonosat_300270"
+    :tpk-niputuspvm "ei_maaritelty"
+    :tallennuspvm "2024-06-30"
+    :oppilaitos "1.2.246.562.10.12944436166"
+    :ohjaaja_ytunnus_kj_tutkinto
+    "Matti Meikäläinen/5523718-7/1.2.246.562.10.346830761110/123456"
+    :tutkinnonosa_id 4
+    :niputuspvm "2024-07-01"
+    :tyopaikan_normalisoitu_nimi "ohjaus_oy"
+    :toimipiste_oid "1.2.246.562.10.12345678903"
+    :tutkinto "123456"
+    :alkupvm "2024-02-01"
+    :koulutustoimija "1.2.246.562.10.346830761110"
+    :jakso_alkupvm "2024-01-01"
+    :ohjaaja_email "matti.meikalainen@esimerkki.com"
+    :hankkimistapa_id 16
+    :oppija_oid "1.2.246.562.24.12312312319"
+    :rahoituskausi "2023-2024"
+    :tutkintonimike "(\"12345\" \"23456\")"
+    :viimeinen_vastauspvm "2024-04-01"
+    :kasittelytila "ei_niputettu"}
+   {:osa_aikaisuus 80
+    :ohjaaja_nimi "Olli Ohjaaja"
+    :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
+    :hankkimistapa_tyyppi "oppisopimus"
+    :hoks_id 1
+    :oppisopimuksen_perusta "01"
+    :tyopaikan_nimi "Ohjaus Oy"
+    :tyopaikan_ytunnus "5523718-7"
+    :jakso_loppupvm "2024-04-05"
+    :ohjaaja_puhelinnumero "0401111111"
+    :osaamisala "(\"test-osaamisala\")"
+    :tutkinnonosa_tyyppi "hyto"
+    :yksiloiva_tunniste "9"
+    :tutkinnonosa_koodi "tutkinnonosat_300271"
+    :tpk-niputuspvm "ei_maaritelty"
+    :tallennuspvm "2024-06-30"
+    :oppilaitos "1.2.246.562.10.12944436166"
+    :ohjaaja_ytunnus_kj_tutkinto
+    "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
+    :tutkinnonosa_id 6
+    :niputuspvm "2024-07-01"
+    :tyopaikan_normalisoitu_nimi "ohjaus_oy"
+    :toimipiste_oid "1.2.246.562.10.12345678903"
+    :tutkinto "123456"
+    :alkupvm "2024-04-16"
+    :koulutustoimija "1.2.246.562.10.346830761110"
+    :jakso_alkupvm "2024-04-01"
+    :ohjaaja_email "olli.ohjaaja@esimerkki.com"
+    :hankkimistapa_id 18
+    :oppija_oid "1.2.246.562.24.12312312319"
+    :rahoituskausi "2023-2024"
+    :tutkintonimike "(\"12345\" \"23456\")"
+    :viimeinen_vastauspvm "2024-06-15"
+    :kasittelytila "ei_niputettu"}])
+
 (def expected-ddb-niput
   [{:tyopaikka                   "Ohjaus Oy"
     :ytunnus                     "5523718-7"
@@ -314,7 +483,9 @@
 (def required-jakso-keys
   #{:ohjaaja_nimi
     :opiskeluoikeus_oid
+    :oppija_oid
     :hoks_id
+    :yksiloiva_tunniste
     :hankkimistapa_tyyppi
     :tyopaikan_nimi
     :tyopaikan_ytunnus
@@ -373,6 +544,8 @@
                                "'vastaajatunnus_muodostettu'")])]
         (is (= (count palautteet) 5))
         (is (= (count ddb-jaksot) 5))
+        (is (= (map #(dissoc % :tunnus :request_id) ddb-jaksot)
+               expected-ddb-jaksot))
         (is (= ddb-niput expected-ddb-niput))
         (is (= (count tapahtumat) 5))
         (is (= (set (map :arvo_tunniste palautteet))

--- a/test/oph/ehoks/utils/string_test.clj
+++ b/test/oph/ehoks/utils/string_test.clj
@@ -1,0 +1,22 @@
+(ns oph.ehoks.utils.string-test
+  (:require [clojure.test :refer [are deftest is testing]]
+            [oph.ehoks.utils.string :refer [normalize]]))
+
+(deftest test-normalize
+  (testing "Characters with diacritics are converted to ASCII characters."
+    (is (= (normalize "äåéëúíóöáïñ") "aaeeuiooain")))
+  (testing "Whitespace characters are replaced with underscore (`_`)."
+    (are [string expected] (= (normalize string) expected)
+      "a b" "a_b"   "a\nb" "a_b"   "a\tb" "a_b"   "a\r\nb" "a_b"))
+  (testing "Uppercase characters will be converted to lower case."
+    (is (= (normalize "ABCDEF") "abcdef")))
+  (testing "There won't be consecutive underscore characters."
+    (are [string expected] (= (normalize string) expected)
+      "a!#$b" "a_b"   "!#$ab^&*" "ab"))
+  (testing "Non-alphanumeric characters are converted to underscores (`_`)."
+    (is (= (normalize "a!b@c#d$e%f^g&h*i(j)k_l+m-n=o\"p'q]r[s{t}u\\v|w/x.y,z")
+           "a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x_y_z")))
+  (testing (str "The function strips underscore characters (`_`) from the "
+                "beginning and the end of the string.")
+    (are [string expected] (= (normalize string) expected)
+      "Severi (testaaja)" "severi_testaaja"   "#testi" "testi")))


### PR DESCRIPTION
## Kuvaus muutoksista

* Alustavien TPO-nippujen lähetys Herätepalveluun
* Pieni refaktorointi, käytetään `build`-funktiota (opiskelijapalautteelle ja työelämäpalautteelle omat) rakentamaan tietokantaan tallennettavat palautteet (`insert!`,`update!` & `upsert!` tekevät ainoastaan tietokantaan tallennusen): https://github.com/Opetushallitus/ehoks/pull/654/commits/cacb927c1b2e79858f5d7c150a9448a693465242

https://jira.eduuni.fi/browse/EH-1712

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [x] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
