### PR TITLE
EH-1711: add missing fields needed by heratepalvelu

### DIFF
--- a/src/db/migration/V1_1733403708934__extend_tapahtumatyypit.sql
+++ b/src/db/migration/V1_1733403708934__extend_tapahtumatyypit.sql
@@ -1,0 +1,1 @@
+ALTER TYPE tapahtumatyypit ADD VALUE IF NOT EXISTS 'heratepalvelu_sync';

--- a/src/db/migration/V1_1733765792887__add_lahetystila_to_tep_heratepalvelu_view.sql
+++ b/src/db/migration/V1_1733765792887__add_lahetystila_to_tep_heratepalvelu_view.sql
@@ -1,4 +1,5 @@
 DROP VIEW palaute_for_tep_heratepalvelu;
+
 CREATE VIEW palaute_for_tep_heratepalvelu AS
 SELECT
   jakson_yksiloiva_tunniste,
@@ -14,6 +15,10 @@ SELECT
   opiskeluoikeus_oid,
   oppisopimuksen_perusta_koodi_uri AS oppisopimuksen_perusta,
   osa_aikaisuustieto AS osa_aikaisuus,
+  CASE tila
+    WHEN 'odottaa_kasittelya' THEN 'ei_niputettu'
+    WHEN 'vastaajatunnus_muodostettu' THEN 'ei_niputettu'
+    ELSE tila::text END AS kasittelytila,
   CASE WHEN EXTRACT(MONTH FROM heratepvm) <= 6
     THEN CONCAT(EXTRACT(YEAR FROM heratepvm) - 1, '-',
                 EXTRACT(YEAR FROM heratepvm))

--- a/src/db/migration/V1_1733765792887__add_lahetystila_to_tep_heratepalvelu_view.sql
+++ b/src/db/migration/V1_1733765792887__add_lahetystila_to_tep_heratepalvelu_view.sql
@@ -1,0 +1,28 @@
+DROP VIEW palaute_for_tep_heratepalvelu;
+CREATE VIEW palaute_for_tep_heratepalvelu AS
+SELECT
+  jakson_yksiloiva_tunniste,
+  kyselytyyppi AS internal_kyselytyyppi,
+  hankkimistapa_id,
+  osaamisen_hankkimistapa_koodi_uri AS hankkimistapa_tyyppi,
+  hoks_id,
+  alkupvm::text AS jakso_alkupvm,
+  loppupvm::text AS jakso_loppupvm,
+  vastuullinen_tyopaikka_ohjaaja_sahkoposti AS ohjaaja_email,
+  vastuullinen_tyopaikka_ohjaaja_nimi AS ohjaaja_nimi,
+  vastuullinen_tyopaikka_ohjaaja_puhelinnumero AS ohjaaja_puhelinnumero,
+  opiskeluoikeus_oid,
+  oppisopimuksen_perusta_koodi_uri AS oppisopimuksen_perusta,
+  osa_aikaisuustieto AS osa_aikaisuus,
+  CASE WHEN EXTRACT(MONTH FROM heratepvm) <= 6
+    THEN CONCAT(EXTRACT(YEAR FROM heratepvm) - 1, '-',
+                EXTRACT(YEAR FROM heratepvm))
+    ELSE CONCAT(EXTRACT(YEAR FROM heratepvm), '-',
+                EXTRACT(YEAR FROM heratepvm) + 1) END AS rahoituskausi,
+  tutkinnonosa_id,
+  tutkinnon_osa_koodi_uri AS tutkinnonosa_koodi,
+  tutkinnonosa_nimi,
+  tyyppi AS tutkinnonosa_tyyppi,
+  tyopaikan_nimi,
+  tyopaikan_y_tunnus AS tyopaikan_ytunnus
+FROM tep_palaute;

--- a/src/db/migration/V1_1733775117387__add_lahetystila_to_amis_heratepalvelu_view.sql
+++ b/src/db/migration/V1_1733775117387__add_lahetystila_to_amis_heratepalvelu_view.sql
@@ -1,0 +1,52 @@
+DROP VIEW palaute_for_amis_heratepalvelu;
+
+CREATE VIEW palaute_for_amis_heratepalvelu AS
+SELECT
+	h.sahkoposti,
+	p.heratepvm,
+	p.voimassa_loppupvm,
+	p.toimipiste_oid,
+	h.puhelinnumero,
+	p.hankintakoulutuksen_toteuttaja,
+	p.voimassa_alkupvm AS alkupvm,
+	p.hoks_id AS ehoks_id,
+	CASE p.tila
+		WHEN 'odottaa_kasittelya' THEN 'ei_lahetetty'
+		WHEN 'kysely_muodostettu' THEN 'ei_lahetetty'
+		ELSE p.tila::text END AS lahetystila,
+	CASE p.herate_source
+		WHEN 'ehoks_update' THEN 'sqs_viesti_ehoksista'
+		WHEN 'koski_update' THEN 'tiedot_muuttuneet_koskessa'
+		ELSE p.herate_source::TEXT END AS herate_source,
+	p.koulutustoimija,
+	p.kyselylinkki,
+	p.tyyppi AS kyselytyyppi,
+	p.kyselytyyppi as internal_kyselytyyppi,
+	h.opiskeluoikeus_oid,
+	h.oppija_oid,
+	oo.oppilaitos_oid AS oppilaitos,
+	NULL AS osaamisala,  -- TODO: populate this in opiskeluoikeudet
+	p.rahoituskausi,
+	p.suorituskieli,
+	date(p.created_at) AS tallennuspvm,
+	p.tutkintotunnus,
+	concat(p.koulutustoimija, '/', oo.oppija_oid) AS toimija_oppija,
+	concat(p.tyyppi, '/', p.rahoituskausi) AS tyyppi_kausi
+FROM (SELECT *,
+	CASE WHEN EXTRACT(MONTH FROM heratepvm) <= 6
+		THEN CONCAT(EXTRACT(YEAR FROM heratepvm) - 1, '-',
+			EXTRACT(YEAR FROM heratepvm))
+		ELSE CONCAT(EXTRACT(YEAR FROM heratepvm), '-',
+			EXTRACT(YEAR FROM heratepvm) + 1) END
+		AS rahoituskausi,
+	CASE kyselytyyppi
+		WHEN 'valmistuneet' THEN 'tutkinnon_suorittaneet'
+		WHEN 'osia_suorittaneet' THEN 'tutkinnon_osia_suorittaneet'
+		ELSE kyselytyyppi::TEXT END
+		AS tyyppi
+	FROM palautteet
+	WHERE kyselytyyppi IN
+		('aloittaneet','valmistuneet','osia_suorittaneet'))
+	AS p
+JOIN hoksit h ON (p.hoks_id = h.id)
+JOIN opiskeluoikeudet oo ON (h.opiskeluoikeus_oid = oo.oid);

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -55,7 +55,7 @@ update	palautteet
 set	arvo_tunniste = :tunnus,
 	kyselylinkki = :url,
 	updated_at = now(),
-	tila = 'vastaajatunnus_muodostettu'
+	tila = :tila
 where	id = :id
   and	arvo_tunniste is null
   and	tila = 'odottaa_kasittelya'

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -150,6 +150,8 @@
 
 (defn add-keys
   [tep-palaute opiskeluoikeus request-id tunnus]
+  ;; TODO: check this niputuspvm rule when palaute-backend is
+  ;; responsible for niputus
   (let [niputuspvm (str (next-niputus-date (date/now)))
         alkupvm (next-niputus-date
                   (LocalDate/parse (:jakso-loppupvm tep-palaute)))

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -65,8 +65,10 @@
           (is (= (:sahkoposti ddb-item) "irma.isomerkki@esimerkki.com"))
           (is (= (:herate-source ddb-item) "sqs_viesti_ehoksista"))
           (far/update-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key
-                           {:update-expr "SET lahetystila = :1"
-                            :expr-attr-vals {":1" "lahetetty"}})
+                           {:update-expr "SET lahetystila = :1, #2 = :2"
+                            :expr-attr-names {"#2" "viestintapalvelu-id"}
+                            :expr-attr-vals {":1" "lahetetty"
+                                             ":2" "2027-05-06"}})
           (hoks-handler/change-hoks-and-initiate-all-palautteet!
             {:hoks           (assoc hoks-data
                                     :id (:id saved-hoks)
@@ -78,4 +80,5 @@
           (let [new-ddb-item
                 (far/get-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]
             (is (= (:sahkoposti new-ddb-item) "foo@bar.com"))
-            (is (= (:lahetystila new-ddb-item) "lahetetty"))))))))
+            (is (= (:viestintapalvelu-id new-ddb-item) "2027-05-06"))
+            (is (= (:lahetystila new-ddb-item) "ei_lahetetty"))))))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -388,14 +388,14 @@
                  (op/create-and-save-arvo-kyselylinkki!)
                  (nil?)))
         (is (= [["odottaa_kasittelya" "aloittaneet"]
-                ["vastaajatunnus_muodostettu" "valmistuneet"]]
+                ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
                      :kyselytyypit ["aloittaneet" "valmistuneet"]}
                     (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                     (map (juxt :tila :kyselytyyppi)))))
         (is (= [["odottaa_kasittelya" "odottaa_kasittelya"
                  {:osaamisen-saavuttamisen-pvm "2024-02-05"}]
-                ["odottaa_kasittelya" "vastaajatunnus_muodostettu"
+                ["odottaa_kasittelya" "kysely_muodostettu"
                  {:arvo_response
                   {:tunnus "foo1"
                    :kysely_linkki "https://arvovastaus.csc.fi/v/foo1"
@@ -430,7 +430,7 @@
                    (op/create-and-save-arvo-kyselylinkki!)
                    (keys))))
         (is (= [["odottaa_kasittelya" "aloittaneet"]
-                ["vastaajatunnus_muodostettu" "valmistuneet"]]
+                ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
                      :kyselytyypit ["aloittaneet" "valmistuneet"]}
                     (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
@@ -476,8 +476,8 @@
                                           @vastauslinkki-counter)
                       :voimassa_loppupvm "2024-10-10"}})))
         (op/create-and-save-arvo-kyselylinkki-for-all-needed! {})
-        (is (= [["vastaajatunnus_muodostettu" "aloittaneet"]
-                ["vastaajatunnus_muodostettu" "valmistuneet"]]
+        (is (= [["kysely_muodostettu" "aloittaneet"]
+                ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
                      :kyselytyypit ["aloittaneet" "valmistuneet"]}
                     (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -306,6 +306,7 @@
     :oppilaitos
     :tunnus
     :ohjaaja_ytunnus_kj_tutkinto
+    :kasittelytila
     :tutkinnonosa_id
     :niputuspvm
     :tyopaikan_normalisoitu_nimi


### PR DESCRIPTION
## Kuvaus muutoksista

When syncing palaute to heratepalvelu, create lahetystila/kasittelytila fields that heratepalvelu uses to find heratteet to process forth.

https://jira.eduuni.fi/browse/EH-1711

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
