### PR TITLE
Don't run scheduled operations if not configured to create arvo tunnus

### DIFF
--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -1,22 +1,23 @@
 (ns oph.ehoks.palaute.opiskelija
   "A namespace for everything related to opiskelijapalaute"
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.set :refer [rename-keys]]
             [clojure.tools.logging :as log]
             [medley.core :refer [greatest]]
-            [clojure.set :refer [rename-keys]]
+            [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
             [oph.ehoks.db.dynamodb :as dynamodb]
-            [oph.ehoks.external.aws-sqs :as sqs]
             [oph.ehoks.external.arvo :as arvo]
+            [oph.ehoks.external.aws-sqs :as sqs]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.hoks.common :as c]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as palautetapahtuma]
             [oph.ehoks.utils :as utils]
             [oph.ehoks.utils.date :as date])
-  (:import (java.util UUID)
-           (clojure.lang ExceptionInfo)))
+  (:import (clojure.lang ExceptionInfo)
+           (java.util UUID)))
 
 (def kyselytyypit #{"aloittaneet" "valmistuneet" "osia_suorittaneet"})
 (def paattokyselyt #{"valmistuneet" "osia_suorittaneet"})
@@ -233,11 +234,13 @@
   "Create kyselylinkki for palautteet whose herätepvm has come but
   which don't have a kyselylinkki yet."
   [_]
-  (log/info "Creating kyselylinkki for unprocessed amispalaute.")
-  (doseq [palaute (palaute/get-amis-palautteet-waiting-for-kyselylinkki!
-                    db/spec {:heratepvm (date/now)})]
-    (try
-      (log/infof "Creating kyselylinkki for %d" (:id palaute))
-      (create-and-save-arvo-kyselylinkki! palaute)
-      (catch ExceptionInfo e
-        (log/errorf e "Error processing amispalaute %s" palaute)))))
+  (if-not (contains? (set (:arvo-responsibilities config)) :create-kyselytunnus)
+    (log/warn "`create-and-save-arvo-kyselylinkki-for-all-needed!` configured"
+              "not to do anything")
+    (do (log/info "Creating kyselylinkki for unprocessed amispalaute.")
+        (doseq [palaute (palaute/get-amis-palautteet-waiting-for-kyselylinkki!
+                          db/spec {:heratepvm (date/now)})]
+          (try (log/infof "Creating kyselylinkki for %d" (:id palaute))
+               (create-and-save-arvo-kyselylinkki! palaute)
+               (catch ExceptionInfo e
+                 (log/errorf e "Error processing amispalaute %s" palaute)))))))


### PR DESCRIPTION
## Kuvaus muutoksista

Tuotannossa palaute-backend on konfiguroitu siten, että amis- ja tep-palautteen arvo-tunnuksia ei muodosteta, eli `create-arvo-kyselylinkki!` ja `create-jaksotunnus!` palauttaa `nil`. Näitä `nil` tunnisteita sitten yritetään tallentaa tietokantaan, mistä nousee poikkeus, ja poikkeuksenkäsittelyssä jo muodostettua `nil` tunnusta yritetään poistaa Arvosta.

TODO: Tee Jira-tiketti

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
