### PR TITLE
EH-1757: Fix resend functionality

### DIFF
--- a/resources/db/hoksit/select_non_tuva_hoksit_created_between.sql
+++ b/resources/db/hoksit/select_non_tuva_hoksit_created_between.sql
@@ -1,5 +1,5 @@
 SELECT * FROM hoksit h
-    WHERE h.created_at >= ?
+    WHERE h.created_at >= ?  -- FIXME: is this correct, what about updated_at?
     AND h.created_at <= ?
     AND h.deleted_at IS NULL
     AND h.tuva_opiskeluoikeus_oid IS NULL

--- a/resources/db/hoksit/select_non_tuva_hoksit_started_between.sql
+++ b/resources/db/hoksit/select_non_tuva_hoksit_started_between.sql
@@ -1,6 +1,6 @@
 SELECT * FROM hoksit h
-    WHERE h.created_at >= ?  -- FIXME: is this correct, what about updated_at?
-    AND h.created_at <= ?
+    WHERE h.ensikertainen_hyvaksyminen >= ?
+    AND h.ensikertainen_hyvaksyminen <= ?
     AND h.deleted_at IS NULL
     AND h.tuva_opiskeluoikeus_oid IS NULL
     AND NOT EXISTS (SELECT 1 FROM hankittavat_koulutuksen_osat hko

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -426,17 +426,17 @@
     [queries/select-hoksit-finished-between from to]
     {:row-fn hoks-from-sql}))
 
-(defn select-non-tuva-hoksit-created-between
-  "Hakee tietokannasta ne HOKSit, jotka on luotu annettujen ajankohtien
-  välillä ja jotka eivät ole TUVA-HOKSeja tai TUVA-HOKSien kanssa
-  rinnakkaisia ammatillisia HOKSeja."
+(defn select-non-tuva-hoksit-started-between
+  "Hakee tietokannasta ne HOKSit, jotka on merkitty alkaneiksi annettujen
+  ajankohtien välillä ja jotka eivät ole TUVA-HOKSeja tai TUVA-HOKSien
+  kanssa rinnakkaisia ammatillisia HOKSeja."
   [from to]
   (db-ops/query
-    [queries/select-non-tuva-hoksit-created-between from to]
+    [queries/select-non-tuva-hoksit-started-between from to]
     {:row-fn hoks-from-sql}))
 
 (defn select-non-tuva-hoksit-finished-between
-  "Hakee tietokannasta ne HOKSit, jotka on merkattu valmiiksi annettujen
+  "Hakee tietokannasta ne HOKSit, jotka on merkitty valmiiksi annettujen
   ajankohtien välillä ja jotka eivät ole TUVA-HOKSeja tai TUVA-HOKSien kanssa
   rinnakkaisia ammatillisia HOKSeja."
   [from to]

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -60,8 +60,8 @@
 (defq select-hoksit-created-between "hoksit/select_hoksit_created_between.sql")
 (defq select-hoksit-finished-between
       "hoksit/select_hoksit_finished_between.sql")
-(defq select-non-tuva-hoksit-created-between
-      "hoksit/select_non_tuva_hoksit_created_between.sql")
+(defq select-non-tuva-hoksit-started-between
+      "hoksit/select_non_tuva_hoksit_started_between.sql")
 (defq select-non-tuva-hoksit-finished-between
       "hoksit/select_non_tuva_hoksit_finished_between.sql")
 (defq select-hoks-oppijat-without-index

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -63,8 +63,8 @@
     (log/infof
       "Sending %d (limit %d) hoksit between %s and %s"
       (+ (count aloittaneet) (count paattyneet)) (* 2 limit) start end)
-    (op/initiate-every-needed! :aloituskysely aloittaneet {:resend? true})
-    (op/initiate-every-needed! :paattokysely  paattyneet {:resend? true})
+    (op/initiate-every-needed! :aloituskysely aloittaneet)
+    (op/initiate-every-needed! :paattokysely  paattyneet)
     (concat aloittaneet paattyneet)))
 
 (defn set-aloitusherate-kasitelty

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -38,7 +38,10 @@
           (restful/ok (count periods))))
 
       (c-api/GET "/kasittelemattomat-heratteet" []
-        :summary "HOKSit, joilla on käsittelemättömiä herätteitä"
+        :summary
+        "lähettää uudestaan herätepalveluun herätteet HOKSeista,
+        joilla on käsittelemättömiä herätteitä.  Herätepalvelu
+        kutsuu tätä säännöllisesti."
         :query-params [start :- LocalDate
                        end :- LocalDate
                        limit :- (s/maybe s/Int)]
@@ -63,24 +66,30 @@
         (response/no-content))
 
       (c-api/POST "/hoksit/resend-aloitusherate" request
-        :summary "Lähettää uudet aloituskyselyherätteet herätepalveluun"
+        :summary
+        "Lähettää uudet aloituskyselyherätteet herätepalveluun.
+        Herätepalvelu kutsuu tätä viikon välein saadakseen
+        varmistettua kahden viime viikon herätteet (jotka lähetetään
+        uudestaan)."
         :header-params [caller-id :- s/Str]
         :query-params [from :- LocalDate
                        to :- LocalDate]
         :return (restful/response {:count s/Int})
-        (let [hoksit (db-hoks/select-non-tuva-hoksit-created-between from to)
-              count  (op/initiate-every-needed! :aloituskysely hoksit)]
-          (restful/ok {:count count})))
+        (let [result (op/reinitiate-hoksit-between! :aloituskysely from to)]
+          (restful/ok {:count result})))
 
       (c-api/POST "/hoksit/resend-paattoherate" request
-        :summary "Lähettää uudet päättökyselyherätteet herätepalveluun"
+        :summary
+        "Lähettää uudet päättökyselyherätteet herätepalveluun.
+        Herätepalvelu kutsuu tätä viikon välein saadakseen
+        varmistettua kahden viime viikon herätteet (jotka lähetetään
+        uudestaan)."
         :header-params [caller-id :- s/Str]
         :query-params [from :- LocalDate
                        to :- LocalDate]
         :return (restful/response {:count s/Int})
-        (let [hoksit (db-hoks/select-non-tuva-hoksit-finished-between from to)
-              count  (op/initiate-every-needed! :paattokysely hoksit)]
-          (restful/ok {:count count})))
+        (let [result (op/reinitiate-hoksit-between! :paattokysely from to)]
+          (restful/ok {:count result})))
 
       (c-api/POST "/opiskeluoikeus-update" request
         :summary "Päivittää aktiivisten hoksien opiskeluoikeudet Koskesta"

--- a/src/oph/ehoks/heratepalvelu/herate_handler.clj
+++ b/src/oph/ehoks/heratepalvelu/herate_handler.clj
@@ -69,8 +69,7 @@
                        to :- LocalDate]
         :return (restful/response {:count s/Int})
         (let [hoksit (db-hoks/select-non-tuva-hoksit-created-between from to)
-              count  (op/initiate-every-needed!
-                       :aloituskysely hoksit {:resend? true})]
+              count  (op/initiate-every-needed! :aloituskysely hoksit)]
           (restful/ok {:count count})))
 
       (c-api/POST "/hoksit/resend-paattoherate" request
@@ -80,8 +79,7 @@
                        to :- LocalDate]
         :return (restful/response {:count s/Int})
         (let [hoksit (db-hoks/select-non-tuva-hoksit-finished-between from to)
-              count  (op/initiate-every-needed!
-                       :paattokysely hoksit {:resend? true})]
+              count  (op/initiate-every-needed! :paattokysely hoksit)]
           (restful/ok {:count count})))
 
       (c-api/POST "/opiskeluoikeus-update" request

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -163,6 +163,14 @@
                        kysely-type))
                  hoksit)))
 
+(defn reinitiate-hoksit-between!
+  "Hakee ei-TUVA-HOKSit tietyllä aikavälillä ja päivittää niiden
+  palautteet ja lähettää SQS-viestit samaan tapaan kuin HOKSit olisi
+  juuri tallennettu."
+  [kyselytyyppi from to]
+  (->> (db-hoks/select-non-tuva-hoksit-created-between from to)
+       (initiate-every-needed! kyselytyyppi)))
+
 (defn create-arvo-kyselylinkki!
   "For the given palaute, make Arvo call for creating its kyselylinkki
   and return the Arvo reply."

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -169,8 +169,11 @@
   juuri tallennettu."
   [kyselytyyppi from to]
   (log/info "Reinitiating" kyselytyyppi "for HOKSit between" from "and" to)
-  (->> (db-hoks/select-non-tuva-hoksit-created-between from to)
-       (initiate-every-needed! kyselytyyppi)))
+  (let [fetcher
+        (case kyselytyyppi
+          :aloituskysely db-hoks/select-non-tuva-hoksit-started-between
+          :paattokysely db-hoks/select-non-tuva-hoksit-finished-between)]
+    (initiate-every-needed! kyselytyyppi (fetcher from to))))
 
 (defn create-arvo-kyselylinkki!
   "For the given palaute, make Arvo call for creating its kyselylinkki

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -168,6 +168,7 @@
   palautteet ja lähettää SQS-viestit samaan tapaan kuin HOKSit olisi
   juuri tallennettu."
   [kyselytyyppi from to]
+  (log/info "Reinitiating" kyselytyyppi "for HOKSit between" from "and" to)
   (->> (db-hoks/select-non-tuva-hoksit-created-between from to)
        (initiate-every-needed! kyselytyyppi)))
 

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -97,14 +97,7 @@
   "Initiates opiskelijapalautekysely (`:aloituskysely` or `:paattokysely`).
   Currently, stores kysely data to eHOKS DB `palautteet` table and also sends
   the herate to AWS SQS for Herätepalvelu to process. Returns `true` if kysely
-  was successfully initiated, `nil` or `false` otherwise.
-  Supported options in `opts`:
-  `:resend?`  If set to true, don't check if kysely is already
-              intiated, i.e., resend herate straight to Herätepalvelu. Also skip
-              the insertion to eHOKS `palautteet` table. Without this flag, the
-              functionality to resend heratteet to Herätepalvelu wouldn't work.
-              This should be removed once Herätepalvelu functionality has been
-              fully migrated to eHOKS."
+  was successfully initiated, `nil` or `false` otherwise."
   [{:keys [tx hoks opiskeluoikeus state reason lisatiedot] :as ctx} kysely-type]
   (let [heratepvm            (get hoks (herate-date-basis kysely-type))
         target-kasittelytila (not= state :odottaa-kasittelya)
@@ -132,62 +125,43 @@
          :alkupvm            (str heratepvm)}))))
 
 (defn initiate-if-needed!
-  "Sends heräte data required for opiskelijapalautekysely (`:aloituskysely` or
-  `:paattokysely`) to appropriate DynamoDB table of Herätepalvelu if no check is
-  preventing the sending. Returns `true` if kysely was successfully sent.
-
-  Supported options in `opts`:
-  `:resend?`  If set to true, don't check if kysely is already
-              intiated, i.e., resend herate straight to Herätepalvelu. Also skip
-              the insertion to eHOKS `palautteet` table. Without this flag, the
-              functionality to resend heratteet to Herätepalvelu wouldn't work.
-              This should be removed once Herätepalvelu functionality has been
-              fully migrated to eHOKS."
-  ([ctx kysely-type] (initiate-if-needed! ctx kysely-type nil))
-  ([{:keys [hoks opiskeluoikeus] :as ctx} kysely-type opts]
-    (jdbc/with-db-transaction
-      [tx db/spec]
-      (let [ctx (assoc
-                  ctx
-                  :tapahtumatyyppi :hoks-tallennus
-                  :tx              tx
-                  :koulutustoimija (palaute/koulutustoimija-oid!
-                                     opiskeluoikeus)
-                  :existing-palaute (when-not (:resend? opts)
-                                      (existing-palaute! tx ctx kysely-type)))
-            [state field reason] (initial-palaute-state-and-reason
-                                   ctx kysely-type)
-            lisatiedot (map-vals str (select-keys hoks [field]))]
-        (log/info "Initial state for" kysely-type "for HOKS" (:id hoks)
-                  "will be" (or state :ei-luoda-ollenkaan)
-                  "because of" reason "in" field)
-        (when state
-          (initiate!
-            (assoc ctx :state state :reason reason :lisatiedot lisatiedot)
-            kysely-type))
-        state))))
+  "Saves heräte data required for opiskelijapalautekysely
+  (`:aloituskysely` or `:paattokysely`) to database and sends it to
+  appropriate DynamoDB table of Herätepalvelu if no check is preventing
+  the sending. Returns the initial state of kysely if it was created,
+  `nil` otherwise."
+  [{:keys [hoks opiskeluoikeus] :as ctx} kysely-type]
+  (jdbc/with-db-transaction
+    [tx db/spec]
+    (let [ctx (assoc
+                ctx
+                :tapahtumatyyppi :hoks-tallennus
+                :tx              tx
+                :koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
+                :existing-palaute (existing-palaute! tx ctx kysely-type))
+          [state field reason]
+          (initial-palaute-state-and-reason ctx kysely-type)
+          lisatiedot (map-vals str (select-keys hoks [field]))]
+      (log/info "Initial state for" kysely-type "for HOKS" (:id hoks)
+                "will be" (or state :ei-luoda-ollenkaan)
+                "because of" reason "in" field)
+      (when state
+        (initiate!
+          (assoc ctx :state state :reason reason :lisatiedot lisatiedot)
+          kysely-type))
+      state)))
 
 (defn initiate-every-needed!
   "Effectively the same as running `initiate-if-needed!` for multiple HOKSes,
-  but also returns a count of the number of kyselys initiated.
-
-  Supported options in `opts`:
-  `:resend?`  If set to true, don't check if kysely is already
-              intiated, i.e., resend herate straight to Herätepalvelu. Also skip
-              the insertion to eHOKS `palautteet` table. Without this flag, the
-              functionality to resend heratteet to Herätepalvelu wouldn't work.
-              This should be removed once Herätepalvelu functionality has been
-              fully migrated to eHOKS."
-  ([kysely-type hoksit] (initiate-every-needed! kysely-type hoksit nil))
-  ([kysely-type hoksit opts]
-    (count (filter #(= :odottaa-kasittelya
-                       (initiate-if-needed!
-                         {:hoks           %
-                          :opiskeluoikeus (koski/get-opiskeluoikeus!
-                                            (:opiskeluoikeus-oid %))}
-                         kysely-type
-                         opts))
-                   hoksit))))
+  but also returns a count of the number of kyselys initiated."
+  [kysely-type hoksit]
+  (count (filter #(= :odottaa-kasittelya
+                     (initiate-if-needed!
+                       {:hoks           %
+                        :opiskeluoikeus (koski/get-opiskeluoikeus!
+                                          (:opiskeluoikeus-oid %))}
+                       kysely-type))
+                 hoksit)))
 
 (defn create-arvo-kyselylinkki!
   "For the given palaute, make Arvo call for creating its kyselylinkki

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -121,12 +121,10 @@
                      (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
                        tx {:hoks-id            (:id hoks)
                            :yksiloiva-tunniste (:yksiloiva-tunniste jakso)}))
-          [state field reason]
-          (initial-palaute-state-and-reason ctx)
+          [state field reason] (initial-palaute-state-and-reason ctx)
           lisatiedot (map-vals str (select-keys (merge jakso hoks) [field]))]
       (log/info "Initial state for jakso" (:yksiloiva-tunniste jakso)
-                "of HOKS" (:id hoks) "will be"
-                (or state :ei-luoda-ollenkaan)
+                "of HOKS" (:id hoks) "will be" (or state :ei-luoda-ollenkaan)
                 "because of" reason "in" field)
       (when state
         (->> (build! ctx state)

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -288,27 +288,27 @@
         ::audit/target    {:hoks-id hoks-id}))
 
     (c-api/POST "/hoks/resend-aloitusherate" request
-      :summary "Lähettää uudet aloituskyselyherätteet herätepalveluun"
+      :summary "Lähettää uudet aloituskyselyherätteet herätepalveluun.
+               Tätä kutsutaan käsin käyttöliittymän ylläpitonäkymästä."
       :header-params [caller-id :- s/Str]
       :query-params [from :- LocalDate
                      to :- LocalDate]
       :return {:count s/Int}
-      (let [hoksit (db-hoks/select-non-tuva-hoksit-created-between from to)
-            count  (op/initiate-every-needed! :aloituskysely hoksit)]
-        (assoc (restful/ok {:count count})
+      (let [result (op/reinitiate-hoksit-between! :aloituskysely from to)]
+        (assoc (restful/ok {:count result})
                ::audit/operation :system/resend-aloitusheratteet
                ::audit/target {:hoksit-from from
                                :hoksit-to   to})))
 
     (c-api/POST "/hoks/resend-paattoherate" request
-      :summary "Lähettää uudet päättökyselyherätteet herätepalveluun"
+      :summary "Lähettää uudet päättökyselyherätteet herätepalveluun.
+               Tätä kutsutaan käsin käyttöliittymän ylläpitonäkymästä."
       :header-params [caller-id :- s/Str]
       :query-params [from :- LocalDate
                      to :- LocalDate]
       :return {:count s/Int}
-      (let [hoksit (db-hoks/select-non-tuva-hoksit-finished-between from to)
-            count  (op/initiate-every-needed! :paattokysely hoksit)]
-        (assoc (restful/ok {:count count})
+      (let [result (op/reinitiate-hoksit-between! :paattokysely from to)]
+        (assoc (restful/ok {:count result})
                ::audit/operation :system/resend-paattoheratteet
                ::audit/target    {:hoksit-from from
                                   :hoksit-to   to})))))

--- a/src/oph/ehoks/virkailija/system_handler.clj
+++ b/src/oph/ehoks/virkailija/system_handler.clj
@@ -255,8 +255,7 @@
                    {:hoks           hoks
                     :opiskeluoikeus (koski/get-existing-opiskeluoikeus!
                                       (:opiskeluoikeus-oid hoks))}
-                   :aloituskysely
-                   {:resend? true}))
+                   :aloituskysely))
             (response/no-content)
             (response/bad-request
               {:error (str "Either `osaamisen-hankkimisen-tarve` is `false` or "
@@ -277,8 +276,7 @@
                    {:hoks hoks
                     :opiskeluoikeus (koski/get-existing-opiskeluoikeus!
                                       (:opiskeluoikeus-oid hoks))}
-                   :paattokysely
-                   {:resend? true}))
+                   :paattokysely))
             (response/no-content)
             (response/bad-request
               {:error (str "Either `osaamisen-hankkimisen-tarve` is `false`, "
@@ -296,8 +294,7 @@
                      to :- LocalDate]
       :return {:count s/Int}
       (let [hoksit (db-hoks/select-non-tuva-hoksit-created-between from to)
-            count  (op/initiate-every-needed!
-                     :aloituskysely hoksit {:resend? true})]
+            count  (op/initiate-every-needed! :aloituskysely hoksit)]
         (assoc (restful/ok {:count count})
                ::audit/operation :system/resend-aloitusheratteet
                ::audit/target {:hoksit-from from
@@ -310,8 +307,7 @@
                      to :- LocalDate]
       :return {:count s/Int}
       (let [hoksit (db-hoks/select-non-tuva-hoksit-finished-between from to)
-            count  (op/initiate-every-needed!
-                     :paattokysely hoksit {:resend? true})]
+            count  (op/initiate-every-needed! :paattokysely hoksit)]
         (assoc (restful/ok {:count count})
                ::audit/operation :system/resend-paattoheratteet
                ::audit/target    {:hoksit-from from

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -734,10 +734,14 @@
                 ["lahetetty" "aloittaneet" (LocalDate/of 2019 3 18)]})
           (is (= @sqs-call-counter 3))
           (is (= 1 (opalaute/reinitiate-hoksit-between!
-                     :aloituskysely (LocalDate/now) (.plusDays (LocalDate/now) 1))))
+                     :aloituskysely
+                     (LocalDate/of 2021 1 1)
+                     (LocalDate/of 2021 6 1))))
           (is (= @sqs-call-counter 4))
           (is (= 1 (opalaute/reinitiate-hoksit-between!
-                     :paattokysely (LocalDate/now) (.plusDays (LocalDate/now) 1))))
+                     :paattokysely
+                     (LocalDate/of 2022 12 1)
+                     (LocalDate/of 2022 12 30))))
           (is (= @sqs-call-counter 5))
           (eq (set (map (juxt :tila :kyselytyyppi :heratepvm)
                         (palaute/get-by-hoks-id-and-kyselytyypit!

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -286,12 +286,6 @@
           (db-ops/query ["UPDATE palautteet SET tila='lahetetty'
                          WHERE hoks_id=12345 RETURNING *"])
           (are [kysely-type] (nil? (op/initiate-if-needed! ctx kysely-type))
-            :aloituskysely :paattokysely))
-
-        (testing "sends kysely info to AWS SQS when `:resend?` option is given."
-          (are [kysely-type] (= :odottaa-kasittelya
-                                (op/initiate-if-needed!
-                                  ctx kysely-type {:resend? true}))
             :aloituskysely :paattokysely))))))
 
 (deftest test-create-arvo-kyselylinkki!


### PR DESCRIPTION
## Kuvaus muutoksista

After these changes, the `resend-aloitusherate` and `resend-paattoherate` APIs (there are two of each) do the following things for the HOKSen created between the given dates:
- update palaute status and info in DB, for instance if opiskeluoikeus info has changed in between
- resend the SQS message to heratepalvelu.

As a sidenote, using the creation date is probably not correct; it will skip HOKSen that were just updated in the last two weeks (or whatever the given dates are).

https://jira.eduuni.fi/browse/EH-1757

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
