### PR TITLE
EH-1771: create missing indices on reference columns

### DIFF
--- a/src/db/migration/V1_1738230258420__add_missing_palautteet_indices.sql
+++ b/src/db/migration/V1_1738230258420__add_missing_palautteet_indices.sql
@@ -1,0 +1,11 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS palautteet_nippu_id_key
+ON palautteet(nippu_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS palautteet_hoks_id_key
+ON palautteet(hoks_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS palaute_tapahtumat_palaute_id_key
+ON palaute_tapahtumat(palaute_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS palaute_viestit_palaute_id_key
+ON palaute_viestit(palaute_id);


### PR DESCRIPTION
## Kuvaus muutoksista

EH-1757:n asennuksen yhteydessä (#665) tuli ilmi, että kyselyt ovat todella hitaita.  Testatessa ilmeni, että se johtuu hitaasta FOREIGN KEY -triggerien suorituksesta, koska tietokannasta puuttuvat indeksit, joita ne tarvitsisivat.

Tämä PR perustaa kyseiset indeksit.  `master`-haaraan on tosin jo mergetty migraatio, joka tarvitsisi näitä indeksejä.  Ratkaisu on se, että ajetaan molempien SQL-komennot etukäteen käsin (ne ovat idempotentteja).  Migraatiot jäävät dokumentaatioksi, että nämä operaatiot on tehty.

https://jira.eduuni.fi/browse/EH-1771

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
