### PR TITLE
Validate opiskeluoikeus type

### DIFF
--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -222,6 +222,13 @@
     (s/optional-key :loppu) LocalDate
     "Keskeytymisajanjakson päättymispäivämäärä."))
 
+(defn- valid-opiskeluoikeus-type?
+  "Palauttaa `true` jos opiskeluoikeuden tyyppi on joko `ammatillinenkoulutus`
+  tai `tuva`."
+  [_]
+  (contains? #{"ammatillinenkoulutus" "tuva"}
+             (get-in (get-current-opiskeluoikeus) [:tyyppi :koodiarvo])))
+
 (defn- not-overlapping?
   "Varmistaa, että keskeytymisajanjaksot eivät mene päällekkäin."
   [jaksot]
@@ -988,7 +995,13 @@
    :opiskeluoikeus-oid
    {:methods {:any :optional
               :post :required} ; FIXME: should be required for :put
-    :types {:any OpiskeluoikeusOID}
+    :types {:any (s/constrained
+                   OpiskeluoikeusOID
+                   (protect-against-not-running-in-wrap-opiskeluoikeus
+                     valid-opiskeluoikeus-type?)
+                   (str "Opiskeluoikeuden tyypin on oltava joko "
+                        "\"Ammatillinen koulutus\" tai \"Tutkintokoulutukseen "
+                        "valmentava koulutus (TUVA)\"."))}
     :description (str "Opiskeluoikeuden oid-tunniste Koski-järjestelmässä "
                       "muotoa '1.2.246.562.15.00000000001'.")}
    :tuva-opiskeluoikeus-oid

--- a/test/oph/ehoks/external/koski_test.clj
+++ b/test/oph/ehoks/external/koski_test.clj
@@ -31,6 +31,7 @@
     "1.2.246.562.15.10000000009"
     {:oid "1.2.246.562.15.10000000009"
      :oppilaitos {:oid "1.2.246.562.10.12944436166"}
+     :tyyppi {:koodiarvo "ammatillinenkoulutus"}
      :suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
      :koulutustoimija {:oid "1.2.246.562.10.10000000009"}}
     "1.246.562.15.12345678911" {}
@@ -41,10 +42,12 @@
               :body   (str "[{\"key\": \"badRequest.format.number\"}]")}))
     "1.2.246.562.15.12345678903" {}
     "1.2.246.562.15.23456789017"
-    {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
+    {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+     :suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
      :koulutustoimija {:oid "1.2.246.562.10.23456789017"}}
     "1.2.246.562.15.34567890123"
-    {:suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
+    {:tyyppi {:koodiarvo "ammatillinenkoulutus"}
+     :suoritukset [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
      :koulutustoimija {:oid "1.2.246.562.10.34567890123"}}
     (->> {:status 404
           :body (str "[{\"key\": \"notFound.opiskeluoikeutta"

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -75,6 +75,21 @@
                  :eid (:eid hoks)
                  :manuaalisyotto false))))))
 
+(deftest opiskeluoikeus-type-is-validated
+  (testing "Opiskeluoikeus type is validated"
+    (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.60000000012"
+                     :oppija-oid "1.2.246.562.24.12312312319"
+                     :osaamisen-hankkimisen-tarve true
+                     :ensikertainen-hyvaksyminen "2025-01-01"}
+          response
+          (hoks-utils/mock-st-post
+            (hoks-utils/create-app nil) base-url hoks-data)
+          body (test-utils/parse-body (:body response))]
+      (is (= (:status response) 400))
+      (is (not (nil? (-> body
+                         :errors
+                         :opiskeluoikeus-oid)))))))
+
 (deftest tuva-oo-oid-is-validated
   (testing "TUVA opiskeluoikeus oid form is validated as oid"
     (let [hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"

--- a/test/oph/ehoks/test_utils.clj
+++ b/test/oph/ehoks/test_utils.clj
@@ -261,6 +261,22 @@
                       :suoritukset
                       [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]
                       :tyyppi {:koodiarvo "ammatillinenkoulutus"}}}
+              (.endsWith
+                url "/koski/api/opiskeluoikeus/1.2.246.562.15.60000000012")
+              {:status 200
+               :body {:oid "1.2.246.562.15.60000000012"
+                      :tila {:opiskeluoikeusjaksot
+                             [{:alku "2025-01-01"
+                               :tila {:koodiarvo "lasna"
+                                      :nimi {:fi "Läsnä"}
+                                      :koodistoUri "koskiopiskeluoikeudentila"
+                                      :koodistoVersio 1}}]}
+                      :oppilaitos {:oid (or oppilaitos-oid
+                                            "1.2.246.562.10.12944436166")}
+                      :alkamispäivä "2025-01-01"
+                      :arvioituPäättymispäivä "2025-12-01"
+                      :suoritukset []
+                      :tyyppi {:koodiarvo "lukiokoulutus"}}}
               (.endsWith url "/kayttooikeus-service/kayttooikeus/kayttaja")
               {:status 200
                :body [{:oidHenkilo "1.2.246.562.24.11474338834"


### PR DESCRIPTION
## Kuvaus muutoksista

Varmistetaan osana skeematarkituksia, että opiskeluoikeuden tyyppi on joko `ammatillinenkoulutus` tai `tuva`.

https://jira.eduuni.fi/browse/EH-1748

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
