### PR TITLE
EH-1732: checking kohderyhmä at herätepvm

### DIFF
--- a/src/db/migration/V1_1740751280614__Remove_unused_palaute_views.sql
+++ b/src/db/migration/V1_1740751280614__Remove_unused_palaute_views.sql
@@ -1,0 +1,5 @@
+
+DROP VIEW IF EXISTS palaute_for_amis_heratepalvelu;
+DROP VIEW IF EXISTS palaute_for_tep_heratepalvelu;
+DROP VIEW IF EXISTS tep_palaute;
+

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -100,21 +100,4 @@
                      {:update-expr update-expr :expr-attr-names attr-names
                       :expr-attr-vals attr-values})))
 
-(defn sync-amis-herate!
-  "Update the herätepalvelu AMISheratetable to have the same content
-  for given heräte as palaute-backend has in its own database.
-  sync-amis-herate! only updates fields it 'owns': currently that
-  means that the messaging tracking fields are left intact (because
-  herätepalvelu will update those)."
-  [{:keys [existing-palaute] :as ctx} amis-herate]
-  (if-not (contains? (set (:heratepalvelu-responsibities config))
-                     :sync-amis-heratteet)
-    (log/warn "sync-amis-herate!: configured to not do anything")
-    (try (sync-item! :amis amis-herate)
-         (catch Exception e
-           (log/error e "while processing palaute" existing-palaute)
-           (tapahtuma/build-and-insert!
-             (assoc ctx :tapahtumatyyppi :heratepalvelu-sync)
-             :synkronointi-epaonnistui
-             {:errormsg (.getMessage e) :body (:body (ex-data e))})
-           (throw e)))))
+(def sync-amis-herate! (partial sync-item! :amis))

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -5,8 +5,6 @@
             [environ.core :refer [env]]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.db :as db]
-            [oph.ehoks.palaute :refer
-             [get-for-heratepalvelu-by-hoks-id-and-kyselytyypit!]]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.utils :as utils]
             [taoensso.faraday :as far])
@@ -102,38 +100,21 @@
                      {:update-expr update-expr :expr-attr-names attr-names
                       :expr-attr-vals attr-values})))
 
-(def map-keys-to-ddb
-  (some-fn {:toimija-oppija :toimija_oppija, :tyyppi-kausi :tyyppi_kausi}
-           identity))
-
 (defn sync-amis-herate!
   "Update the herätepalvelu AMISheratetable to have the same content
   for given heräte as palaute-backend has in its own database.
   sync-amis-herate! only updates fields it 'owns': currently that
   means that the messaging tracking fields are left intact (because
   herätepalvelu will update those)."
-  [{:keys [existing-palaute] :as ctx}]
+  [{:keys [existing-palaute] :as ctx} amis-herate]
   (if-not (contains? (set (:heratepalvelu-responsibities config))
                      :sync-amis-heratteet)
     (log/warn "sync-amis-herate!: configured to not do anything")
-    (let [hoks-id      (:hoks-id existing-palaute)
-          kyselytyyppi (:kyselytyyppi existing-palaute)
-          palautteet (get-for-heratepalvelu-by-hoks-id-and-kyselytyypit!
-                       db/spec {:hoks-id hoks-id :kyselytyypit [kyselytyyppi]})
-          palaute (-> (not-empty palautteet)
-                      (or (throw (ex-info "palaute not found"
-                                          {:hoks-id      hoks-id
-                                           :kyselytyyppi kyselytyyppi})))
-                      (first))]
-      (try (-> palaute
-               (utils/remove-nils)
-               (update-keys map-keys-to-ddb)
-               (dissoc :internal-kyselytyyppi)
-               (->> (sync-item! :amis)))
-           (catch Exception e
-             (log/error e "while processing palaute" palaute)
-             (tapahtuma/build-and-insert!
-               (assoc ctx :tapahtumatyyppi :heratepalvelu-sync)
-               :synkronointi-epaonnistui
-               {:errormsg (.getMessage e) :body (:body (ex-data e))})
-             (throw e))))))
+    (try (sync-item! :amis amis-herate)
+         (catch Exception e
+           (log/error e "while processing palaute" existing-palaute)
+           (tapahtuma/build-and-insert!
+             (assoc ctx :tapahtumatyyppi :heratepalvelu-sync)
+             :synkronointi-epaonnistui
+             {:errormsg (.getMessage e) :body (:body (ex-data e))})
+           (throw e)))))

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -71,6 +71,7 @@ select	p.id,
 	p.hoks_id,
 	p.heratepvm,
 	p.tila,
+	p.herate_source,
 	p.kyselytyyppi,
 	p.jakson_yksiloiva_tunniste,
 	ohm.hankkimistapa_id

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -81,6 +81,8 @@ on	(p.hoks_id = ohm.hoks_id
 		and p.jakson_yksiloiva_tunniste = ohm.yksiloiva_tunniste)
 where	p.tila = 'odottaa_kasittelya'
 and	p.kyselytyyppi in (:v*:kyselytyypit)
+and	(:hoks-id ::int is null or p.hoks_id = :hoks-id ::int)
+and	(:palaute-id ::int is null or p.id = :palaute-id ::int)
 and	p.heratepvm <= now()
 and	p.deleted_at is null
 order by hoks_id asc

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -75,8 +75,7 @@
      :paikallinen_tutkinnon_osa (:nimi jakso)
      :tutkintonimike            (map :koodiarvo (:tutkintonimike suoritus))
      :osaamisala                (suoritus/get-osaamisalat
-                                  suoritus (:oid opiskeluoikeus)
-                                  (:heratepvm existing-palaute))
+                                  suoritus (:heratepvm existing-palaute))
      :tyopaikkajakson_alkupvm   (str (:alku jakso))
      :tyopaikkajakson_loppupvm  (str (:loppu jakso))
      :rahoituskausi_pvm         (str (:loppu jakso))

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -67,9 +67,7 @@
      :tyonantaja                (:tyopaikan-y-tunnus tjk)
      :tyopaikka                 t-nimi
      :tyopaikka_normalisoitu    (u-str/normalize t-nimi)
-     :tutkintotunnus            (get-in
-                                  suoritus
-                                  [:koulutusmoduuli :tunniste :koodiarvo])
+     :tutkintotunnus            (suoritus/tutkintotunnus suoritus)
      :tutkinnon_osa             (koodiuri->koodi
                                   (:tutkinnon-osa-koodi-uri jakso))
      :paikallinen_tutkinnon_osa (:nimi jakso)

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -52,54 +52,43 @@
   [tunnus]
   (call! :delete (str "/vastauslinkki/v1/" tunnus) {}))
 
+(defn koodiuri->koodi [koodiuri]
+  (some-> koodiuri (string/split #"_") (last)))
+
 (defn build-jaksotunnus-request-body
   "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
-  [{:keys [opiskeluoikeus existing-palaute suoritus koulutustoimija toimipiste
-           niputuspvm]
+  [{:keys [opiskeluoikeus existing-palaute jakso
+           suoritus koulutustoimija toimipiste niputuspvm]
     :as ctx}
    request-id]
-  {:koulutustoimija_oid       koulutustoimija
-   :tyonantaja                (:tyopaikan-y-tunnus existing-palaute)
-   :tyopaikka                 (:tyopaikan-nimi existing-palaute)
-   :tyopaikka_normalisoitu    (u-str/normalize
-                                (:tyopaikan-nimi existing-palaute))
-   :tutkintotunnus            (get-in
-                                suoritus
-                                [:koulutusmoduuli
-                                 :tunniste
-                                 :koodiarvo])
-   :tutkinnon_osa             (when (:tutkinnon-osa-koodi-uri existing-palaute)
-                                (last
-                                  (string/split
-                                    (:tutkinnon-osa-koodi-uri existing-palaute)
-                                    #"_")))
-   :paikallinen_tutkinnon_osa (:tutkinnonosa-nimi existing-palaute)
-   :tutkintonimike            (map
-                                :koodiarvo
-                                (:tutkintonimike suoritus))
-   :osaamisala                (suoritus/get-osaamisalat
-                                suoritus (:oid opiskeluoikeus)
-                                (:heratepvm existing-palaute))
-   :tyopaikkajakson_alkupvm   (str (:alkupvm existing-palaute))
-   :tyopaikkajakson_loppupvm  (str (:loppupvm existing-palaute))
-   :rahoituskausi_pvm         (str (:loppupvm existing-palaute))
-   :osa_aikaisuus             (:osa-aikaisuustieto existing-palaute)
-   :sopimustyyppi             (last
-                                (string/split
-                                  (:osaamisen-hankkimistapa-koodi-uri
-                                    existing-palaute)
-                                  #"_"))
-   :oppisopimuksen_perusta    (when (:oppisopimuksen-perusta-koodi-uri
-                                      existing-palaute)
-                                (last
-                                  (string/split
-                                    (:oppisopimuksen-perusta-koodi-uri
-                                      existing-palaute)
-                                    #"_")))
-   :vastaamisajan_alkupvm     (str niputuspvm)
-   :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
-   :toimipiste_oid            toimipiste
-   :request_id                request-id})
+  (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
+        t-nimi (:tyopaikan-nimi tjk)]
+    {:koulutustoimija_oid       koulutustoimija
+     :tyonantaja                (:tyopaikan-y-tunnus tjk)
+     :tyopaikka                 t-nimi
+     :tyopaikka_normalisoitu    (u-str/normalize t-nimi)
+     :tutkintotunnus            (get-in
+                                  suoritus
+                                  [:koulutusmoduuli :tunniste :koodiarvo])
+     :tutkinnon_osa             (koodiuri->koodi
+                                  (:tutkinnon-osa-koodi-uri jakso))
+     :paikallinen_tutkinnon_osa (:nimi jakso)
+     :tutkintonimike            (map :koodiarvo (:tutkintonimike suoritus))
+     :osaamisala                (suoritus/get-osaamisalat
+                                  suoritus (:oid opiskeluoikeus)
+                                  (:heratepvm existing-palaute))
+     :tyopaikkajakson_alkupvm   (str (:alku jakso))
+     :tyopaikkajakson_loppupvm  (str (:loppu jakso))
+     :rahoituskausi_pvm         (str (:loppu jakso))
+     :osa_aikaisuus             (:osa-aikaisuustieto jakso)
+     :sopimustyyppi             (koodiuri->koodi
+                                  (:osaamisen-hankkimistapa-koodi-uri jakso))
+     :oppisopimuksen_perusta    (koodiuri->koodi
+                                  (:oppisopimuksen-perusta-koodi-uri jakso))
+     :vastaamisajan_alkupvm     (str niputuspvm)
+     :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
+     :toimipiste_oid            toimipiste
+     :request_id                request-id}))
 
 (defn create-jaksotunnus!
   [request]

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -4,6 +4,7 @@
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.utils :as utils]
             [oph.ehoks.utils.string :as u-str])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -52,9 +53,6 @@
   [tunnus]
   (call! :delete (str "/vastauslinkki/v1/" tunnus) {}))
 
-(defn koodiuri->koodi [koodiuri]
-  (some-> koodiuri (string/split #"_") (last)))
-
 (defn build-jaksotunnus-request-body
   "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
   [{:keys [opiskeluoikeus existing-palaute jakso
@@ -68,7 +66,7 @@
      :tyopaikka                 t-nimi
      :tyopaikka_normalisoitu    (u-str/normalize t-nimi)
      :tutkintotunnus            (suoritus/tutkintotunnus suoritus)
-     :tutkinnon_osa             (koodiuri->koodi
+     :tutkinnon_osa             (utils/koodiuri->koodi
                                   (:tutkinnon-osa-koodi-uri jakso))
      :paikallinen_tutkinnon_osa (:nimi jakso)
      :tutkintonimike            (map :koodiarvo (:tutkintonimike suoritus))
@@ -78,9 +76,9 @@
      :tyopaikkajakson_loppupvm  (str (:loppu jakso))
      :rahoituskausi_pvm         (str (:loppu jakso))
      :osa_aikaisuus             (:osa-aikaisuustieto jakso)
-     :sopimustyyppi             (koodiuri->koodi
+     :sopimustyyppi             (utils/koodiuri->koodi
                                   (:osaamisen-hankkimistapa-koodi-uri jakso))
-     :oppisopimuksen_perusta    (koodiuri->koodi
+     :oppisopimuksen_perusta    (utils/koodiuri->koodi
                                   (:oppisopimuksen-perusta-koodi-uri jakso))
      :vastaamisajan_alkupvm     (str niputuspvm)
      :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -55,10 +55,9 @@
 
 (defn build-jaksotunnus-request-body
   "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
-  [{:keys [opiskeluoikeus existing-palaute jakso
+  [{:keys [opiskeluoikeus existing-palaute jakso request-id
            suoritus koulutustoimija toimipiste niputuspvm]
-    :as ctx}
-   request-id]
+    :as ctx}]
   (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
         t-nimi (:tyopaikan-nimi tjk)]
     {:koulutustoimija_oid       koulutustoimija

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -102,8 +102,7 @@
            :ohjaaja-ytunnus-kj-tutkinto (nippu/tunniste ctx)
            :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
            :osaamisala (str (seq (suoritus/get-osaamisalat
-                                   oo-suoritus (:oid opiskeluoikeus)
-                                   (:heratepvm palaute))))
+                                   oo-suoritus (:heratepvm palaute))))
            :request-id request-id
            :toimipiste-oid (str (palaute/toimipiste-oid! oo-suoritus))
            :tpk-niputuspvm "ei_maaritelty"

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -14,8 +14,7 @@
             [oph.ehoks.palaute.opiskelija.kyselylinkki :as kyselylinkki]
             [oph.ehoks.palaute.tyoelama.nippu :as nippu]
             [oph.ehoks.utils :as utils]
-            [oph.ehoks.utils.date :as date]
-            [oph.ehoks.utils.string :as u-str])
+            [oph.ehoks.utils.date :as date])
   (:import (java.time LocalDate)))
 
 (defn send-workplace-periods!
@@ -85,51 +84,6 @@
     (db-hoks/select-tyoelamajaksot-active-between "hato" oppija start end)
     (db-hoks/select-tyoelamajaksot-active-between "hpto" oppija start end)
     (db-hoks/select-tyoelamajaksot-active-between "hyto" oppija start end)))
-
-(defn build-jaksoherate-record-for-heratepalvelu
-  [{:keys [existing-palaute opiskeluoikeus koulutustoimija hoks jakso
-           toimipiste niputuspvm suoritus vastaamisajan-alkupvm
-           request-id arvo-response] :as ctx}]
-  (let [heratepvm (:heratepvm existing-palaute)
-        tjk (:tyopaikalla-jarjestettava-koulutus jakso)
-        ohjaaja (:vastuullinen-tyopaikka-ohjaaja tjk)]
-    (utils/remove-nils
-      {:yksiloiva_tunniste (:jakson-yksiloiva-tunniste existing-palaute)
-       :alkupvm vastaamisajan-alkupvm
-       :hankkimistapa_id (:hankkimistapa-id existing-palaute)
-       :hankkimistapa_tyyppi (arvo/koodiuri->koodi
-                               (:osaamisen-hankkimistapa-koodi-uri jakso))
-       :oppisopimuksen_perusta (arvo/koodiuri->koodi
-                                 (:oppisopimuksen-perusta-koodi-uri jakso))
-       :hoks_id (:hoks-id existing-palaute)
-       :jakso_alkupvm (:alku jakso)
-       :jakso_loppupvm (:loppu jakso)
-       :koulutustoimija koulutustoimija
-       :niputuspvm niputuspvm
-       :ohjaaja_email (:sahkoposti ohjaaja)
-       :ohjaaja_nimi (:nimi ohjaaja)
-       :ohjaaja_puhelinnumero (:puhelinnumero ohjaaja)
-       :ohjaaja_ytunnus_kj_tutkinto (nippu/tunniste ctx)
-       :opiskeluoikeus_oid (:opiskeluoikeus-oid hoks)
-       :oppija_oid (:oppija-oid hoks)
-       :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
-       :osaamisala (str (seq (suoritus/get-osaamisalat suoritus heratepvm)))
-       :osa_aikaisuus (:osa-aikaisuustieto jakso)
-       :rahoituskausi (palaute/rahoituskausi heratepvm)
-       :request_id request-id
-       :tallennuspvm (date/now)
-       :toimipiste_oid toimipiste
-       :tpk-niputuspvm "ei_maaritelty"  ; sic! this has a dash, not underscore
-       :tunnus (:tunnus arvo-response)
-       :tutkinnonosa_koodi (:tutkinnon-osa-koodi-uri jakso)
-       :tutkinnonosa_nimi (:nimi jakso)
-       :tutkinto (suoritus/tutkintotunnus suoritus)
-       :tutkintonimike (str (seq (map :koodiarvo (:tutkintonimike suoritus))))
-       :tyopaikan_nimi (:tyopaikan-nimi tjk)
-       :tyopaikan_normalisoitu_nimi (u-str/normalize (:tyopaikan-nimi tjk))
-       :tyopaikan_ytunnus (:tyopaikan-y-tunnus tjk)
-       :viimeinen_vastauspvm (palaute/vastaamisajan-loppupvm
-                               heratepvm vastaamisajan-alkupvm)})))
 
 ; Helper functions that can be mocked in tests
 (def sync-jakso!*     (partial ddb/sync-item! :jakso))

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -89,18 +89,17 @@
 (defn- add-keys
   [palaute {:keys [opiskeluoikeus niputuspvm vastaamisajan-alkupvm] :as ctx}
    request-id tunnus]
-  (let [niputuspvm      niputuspvm
-        koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
+  (let [koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
         oo-suoritus     (find-first suoritus/ammatillinen?
                                     (:suoritukset opiskeluoikeus))
         tutkinto        (get-in oo-suoritus
                                 [:koulutusmoduuli :tunniste :koodiarvo])]
     (assoc palaute
-           :tallennuspvm (date/now)
-           :alkupvm vastaamisajan-alkupvm
+           :tallennuspvm (str (date/now))
+           :alkupvm (str vastaamisajan-alkupvm)
            :koulutustoimija koulutustoimija
-           :niputuspvm niputuspvm
-           :ohjaaja-ytunnus-kj-tutkinto (nippu/tunniste ctx palaute)
+           :niputuspvm (str niputuspvm)
+           :ohjaaja-ytunnus-kj-tutkinto (nippu/tunniste ctx)
            :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
            :osaamisala (str (seq (suoritus/get-osaamisalat
                                    oo-suoritus (:oid opiskeluoikeus)

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -88,8 +88,8 @@
 
 (defn build-jaksoherate-record-for-heratepalvelu
   [{:keys [existing-palaute opiskeluoikeus koulutustoimija hoks jakso
-           toimipiste niputuspvm suoritus vastaamisajan-alkupvm] :as ctx}
-   request-id tunnus]
+           toimipiste niputuspvm suoritus vastaamisajan-alkupvm
+           request-id arvo-response] :as ctx}]
   (let [heratepvm (:heratepvm existing-palaute)
         tjk (:tyopaikalla-jarjestettava-koulutus jakso)
         ohjaaja (:vastuullinen-tyopaikka-ohjaaja tjk)]
@@ -120,7 +120,7 @@
        :tallennuspvm (str (date/now))
        :toimipiste_oid toimipiste
        :tpk-niputuspvm "ei_maaritelty"  ; sic! this has a dash, not underscore
-       :tunnus tunnus
+       :tunnus (:tunnus arvo-response)
        :tutkinnonosa_koodi (:tutkinnon-osa-koodi-uri jakso)
        :tutkinnonosa_nimi (:nimi jakso)
        :tutkinto (suoritus/tutkintotunnus suoritus)

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -95,17 +95,17 @@
         ohjaaja (:vastuullinen-tyopaikka-ohjaaja tjk)]
     (utils/remove-nils
       {:yksiloiva_tunniste (:jakson-yksiloiva-tunniste existing-palaute)
-       :alkupvm (str vastaamisajan-alkupvm)
+       :alkupvm vastaamisajan-alkupvm
        :hankkimistapa_id (:hankkimistapa-id existing-palaute)
        :hankkimistapa_tyyppi (arvo/koodiuri->koodi
                                (:osaamisen-hankkimistapa-koodi-uri jakso))
        :oppisopimuksen_perusta (arvo/koodiuri->koodi
                                  (:oppisopimuksen-perusta-koodi-uri jakso))
        :hoks_id (:hoks-id existing-palaute)
-       :jakso_alkupvm (str (:alku jakso))
-       :jakso_loppupvm (str (:loppu jakso))
+       :jakso_alkupvm (:alku jakso)
+       :jakso_loppupvm (:loppu jakso)
        :koulutustoimija koulutustoimija
-       :niputuspvm (str niputuspvm)
+       :niputuspvm niputuspvm
        :ohjaaja_email (:sahkoposti ohjaaja)
        :ohjaaja_nimi (:nimi ohjaaja)
        :ohjaaja_puhelinnumero (:puhelinnumero ohjaaja)
@@ -117,7 +117,7 @@
        :osa_aikaisuus (:osa-aikaisuustieto jakso)
        :rahoituskausi (palaute/rahoituskausi heratepvm)
        :request_id request-id
-       :tallennuspvm (str (date/now))
+       :tallennuspvm (date/now)
        :toimipiste_oid toimipiste
        :tpk-niputuspvm "ei_maaritelty"  ; sic! this has a dash, not underscore
        :tunnus (:tunnus arvo-response)

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -135,32 +135,6 @@
 (def sync-jakso!*     (partial ddb/sync-item! :jakso))
 (def sync-tpo-nippu!* (partial ddb/sync-item! :nippu))
 
-;; FIXME: tältä puuttuu yksikkötesti.
-;; test-create-and-save-arvo-vastaajatunnus-for-all-needed! sisältää
-;; ylimalkaisen testin tälle funktiolle.
-(defn sync-jakso!
-  "Update the herätepalvelu jaksotunnustable to have the same content
-  for given heräte as palaute-backend has in its own database.
-  sync-jakso-herate! only updates fields it 'owns': currently that
-  means that the messaging tracking fields are left intact (because
-  herätepalvelu will update those)."
-  [{:keys [existing-palaute] :as ctx} request-id tunnus]
-  {:pre [(some? tunnus)]}
-  (if-not (contains? (set (:heratepalvelu-responsibities config))
-                     :sync-jakso-heratteet)
-    (log/warn "sync-jakso!: configured to not do anything")
-    (try
-      (sync-jakso!* (build-jaksoherate-record-for-heratepalvelu
-                      ctx request-id tunnus))
-      (catch Exception e
-        (throw (ex-info (format (str "Failed to sync jakso `%s` of HOKS "
-                                     "`%d` to Herätepalvelu")
-                                (:jakson-yksiloiva-tunniste existing-palaute)
-                                (:hoks-id existing-palaute))
-                        {:type        ::jakso-sync-failed
-                         :arvo-tunnus tunnus}
-                        e))))))
-
 (defn sync-tpo-nippu!
   "Update the Herätepalvelu nipputable to have the same content for given heräte
   as palaute-backend has in its own database."

--- a/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
+++ b/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
@@ -1,17 +1,10 @@
 (ns oph.ehoks.hoks.osaamisen-hankkimistapa
   (:require [medley.core :refer [find-first]]
+            [oph.ehoks.utils :refer [get-in-and-propagate-fields]]
             [hugsql.core :as hugsql])
   (:import [java.time LocalDate]))
 
 (hugsql/def-db-fns "oph/ehoks/db/sql/hoks/osaamisen_hankkimistapa.sql")
-
-(defn get-in-and-propagate-fields
-  "Hakee tietorakenteesta tietyn (listamuotoisen) kentän ja lisää
-  listan joka kohtaan tietyt kentät alkuperäisestä, eli propagoi
-  tietyt kentät syvemmälle tietorakenteessa."
-  [obj field-to-get fields-to-propagate]
-  (map #(merge % (select-keys obj fields-to-propagate))
-       (get-in obj field-to-get)))
 
 (defn osaamisen-hankkimistavat
   "Hakee HOKSista kaikki osaamisen hankkimistavat."

--- a/src/oph/ehoks/opiskeluoikeus/suoritus.clj
+++ b/src/oph/ehoks/opiskeluoikeus/suoritus.clj
@@ -34,7 +34,7 @@
 
 (defn get-osaamisalat
   "Hakee voimassa olevat osaamisalat suorituksesta haluttuna päivämääränä."
-  [suoritus opiskeluoikeus-oid pvm]
+  [suoritus pvm]
   (->> (:osaamisala suoritus)
        (filter #(and (or (nil? (:loppu %1))
                          (>= (compare (:loppu %1)

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -142,7 +142,7 @@
   (jdbc/with-db-transaction
     [tx db/spec]
     (update! tx {:id (:id existing-palaute) :tila tila})
-    (tapahtuma/build-and-insert! ctx "ei_laheteta" reason lisatiedot)))
+    (tapahtuma/build-and-insert! ctx tila reason lisatiedot)))
 
 (defn feedback-collecting-prevented?
   "Jätetäänkö palaute keräämättä sen vuoksi, että opiskelijan opiskelu on

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -214,25 +214,3 @@
 
       (opiskeluoikeus/linked-to-another? opiskeluoikeus)
       [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus])))
-
-(defn save-arvo-tunniste!
-  [{:keys [tx existing-palaute] :as ctx} arvo-response]
-  {:pre [(:tunnus arvo-response)]}
-  (let [new-state (if (= (:kyselytyyppi existing-palaute)
-                         "tyopaikkajakson_suorittaneet")
-                    :vastaajatunnus-muodostettu :kysely-muodostettu)]
-    (try (-> arvo-response
-             (rename-keys {:kysely_linkki :url})
-             (assoc :id   (:id existing-palaute)
-                    :tila (utils/to-underscore-str new-state))
-             (update :url identity)  ; ensure key exists
-             (->> (update-arvo-tunniste! tx))
-             (assert))
-         (tapahtuma/build-and-insert!
-           ctx new-state :arvo-kutsu-onnistui {:arvo_response arvo-response})
-         (catch Exception e
-           (throw (ex-info "Failed to save Arvo-tunnus to DB"
-                           {:type        :failed-to-save-arvo-tunnus
-                            :arvo-tunnus (:tunnus arvo-response)}
-                           e)))))
-  (:tunnus arvo-response))

--- a/src/oph/ehoks/palaute/handler.clj
+++ b/src/oph/ehoks/palaute/handler.clj
@@ -56,7 +56,7 @@
               :summary "Luo kyselylinkit niille palautteille, jotka
                        odottavat käsittelyä."
               (let [palautteet
-                    (vt/create-and-save-arvo-kyselylinkki-for-all-needed! {})]
+                    (vt/handle-amis-palautteet-on-heratepvm! {})]
                 (-> {:kyselylinkit palautteet}
                     (restful/ok)
                     (assoc ::audit/target {:palautteet palautteet})))))
@@ -70,7 +70,7 @@
               :header-params [caller-id :- s/Str
                               ticket :- s/Str]
               (let [vastaajatunnukset
-                    (vt/handle-all-palautteet-waiting-for-vastaajatunnus! {})]
+                    (vt/handle-tep-palautteet-on-heratepvm! {})]
                 (assoc
                   (restful/ok {:vastaajatunnukset vastaajatunnukset})
                   ::audit/target {:vastaajatunnukset vastaajatunnukset})))

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -263,5 +263,4 @@
    :arvo-caller #'arvo/create-kyselytunnus!
    :heratepalvelu-builder #'build-amisherate-record-for-heratepalvelu
    :heratepalvelu-caller #'dynamodb/sync-amis-herate!
-   :arvo-cleanup-handler #'arvo/delete-kyselytunnus
    :extra-handlers []})

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -197,9 +197,8 @@
 
 (defn build-kyselylinkki-request-body
   "For the given palaute, create Arvo request for creating its kyselylinkki."
-  [{:keys [existing-palaute hoks opiskeluoikeus suoritus
-           koulutustoimija toimipiste hk-toteuttaja] :as ctx}
-   request-id]
+  [{:keys [existing-palaute hoks opiskeluoikeus suoritus request-id
+           koulutustoimija toimipiste hk-toteuttaja] :as ctx}]
   (let [heratepvm (:heratepvm existing-palaute)
         alkupvm (greatest heratepvm (date/now))]
     {:hankintakoulutuksen_toteuttaja @hk-toteuttaja
@@ -215,7 +214,8 @@
      :tutkintotunnus (str (suoritus/tutkintotunnus suoritus))
      :oppilaitos_oid (:oid (:oppilaitos opiskeluoikeus))
      :koulutustoimija_oid (or koulutustoimija "")
-     :heratepvm (:heratepvm existing-palaute)}))
+     :heratepvm (:heratepvm existing-palaute)
+     :request_id request-id}))
 
 (defn build-amisherate-record-for-heratepalvelu
   "Turns the information context into AMISherate in heratepalvelu format."
@@ -251,7 +251,8 @@
        :rahoituskausi rahoituskausi
        :tallennuspvm (date/now)
        :toimija_oppija (str koulutustoimija "/" oppija-oid)
-       :tyyppi_kausi (str kyselytyyppi "/" rahoituskausi)})))
+       :tyyppi_kausi (str kyselytyyppi "/" rahoituskausi)
+       :request-id request-id})))
 
 ;; these use vars (#') because otherwise with-redefs doesn't work on
 ;; them (the map has the original definition even if the function in

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -198,11 +198,10 @@
 (defn build-kyselylinkki-request-body
   "For the given palaute, create Arvo request for creating its kyselylinkki."
   [{:keys [existing-palaute hoks opiskeluoikeus suoritus
-           koulutustoimija toimipiste] :as ctx}]
+           koulutustoimija toimipiste hk-toteuttaja] :as ctx}]
   (let [heratepvm (:heratepvm existing-palaute)
         alkupvm (greatest heratepvm (date/now))]
-    {:hankintakoulutuksen_toteuttaja
-     (palaute/hankintakoulutuksen-toteuttaja! hoks)
+    {:hankintakoulutuksen_toteuttaja @hk-toteuttaja
      :tutkinnon_suorituskieli (or (suoritus/kieli suoritus) "fi")
      :kyselyn_tyyppi (translate-kyselytyyppi (:kyselytyyppi existing-palaute))
      :osaamisala (suoritus/get-osaamisalat suoritus heratepvm)
@@ -224,7 +223,7 @@
 (defn build-amisherate-record-for-heratepalvelu
   "Turns the information context into AMISherate in heratepalvelu format."
   [{:keys [existing-palaute hoks koulutustoimija suoritus kyselylinkki
-           opiskeluoikeus toimipiste] :as ctx}]
+           opiskeluoikeus toimipiste hk-toteuttaja] :as ctx}]
   (let [heratepvm (:heratepvm existing-palaute)
         oppija-oid (:oppija-oid hoks)
         rahoituskausi (palaute/rahoituskausi heratepvm)
@@ -238,8 +237,7 @@
        :toimipiste_oid toimipiste
        :lahetystila "ei_lahetetty"  ; FIXME when it can have other states
        :puhelinnumero (:puhelinnumero hoks)
-       :hankintakoulutuksen_toteuttaja
-       (palaute/hankintakoulutuksen-toteuttaja! hoks)
+       :hankintakoulutuksen_toteuttaja @hk-toteuttaja
        :ehoks_id (:id hoks)
        :herate-source (or (translate-source (:herate-source existing-palaute))
                           "sqs_viesti_ehoksista")

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -252,3 +252,16 @@
        :tallennuspvm (date/now)
        :toimija_oppija (str koulutustoimija "/" oppija-oid)
        :tyyppi_kausi (str kyselytyyppi "/" rahoituskausi)})))
+
+;; these use vars (#') because otherwise with-redefs doesn't work on
+;; them (the map has the original definition even if the function in
+;; its namespace is redef'd)
+
+(def handlers
+  {:check-palaute #'initial-palaute-state-and-reason
+   :arvo-builder #'build-kyselylinkki-request-body
+   :arvo-caller #'arvo/create-kyselytunnus!
+   :heratepalvelu-builder #'build-amisherate-record-for-heratepalvelu
+   :heratepalvelu-caller #'dynamodb/sync-amis-herate!
+   :arvo-cleanup-handler #'arvo/delete-kyselytunnus
+   :extra-handlers []})

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -187,7 +187,7 @@
   [ohts]
   (->> ohts
        (map (juxt (comp keyword
-                        arvo/koodiuri->koodi
+                        utils/koodiuri->koodi
                         :osaamisen-hankkimistapa-koodi-uri)
                   :tutkinnon-osa-koodi-uri))
        (filter second)  ; ei paikallisia (joilta tutkinnonosakoodi puuttuu)

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -10,6 +10,7 @@
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.external.aws-sqs :as sqs]
             [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.utils :as utils]

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -1,15 +1,14 @@
 (ns oph.ehoks.palaute.scheduler
   (:require [chime.core :as chime]
             [clojure.tools.logging :as log]
-            [oph.ehoks.palaute.opiskelija :as amis]
-            [oph.ehoks.palaute.tyoelama :as tep])
+            [oph.ehoks.palaute.vastaajatunnus :as palaute])
   (:import (java.lang AutoCloseable)))
 
-(defn- run-sequence
-  "Run these tasks sequentially."
+(defn daily-actions!
+  "Run all palaute checks that need to be run on a daily basis."
   [opts]
-  (amis/create-and-save-arvo-kyselylinkki-for-all-needed! opts)
-  (tep/handle-all-palautteet-waiting-for-vastaajatunnus! opts))
+  (palaute/handle-palautteet-waiting-for-heratepvm! opts)
+  true)
 
 (defn run-scheduler!
   "Simple (daily) scheduler for palaute scheduled tasks. Will be replaced with
@@ -20,7 +19,7 @@
              rate)
   (let [scheduler
         (chime/chime-at (chime/periodic-seq start-time rate)
-                        run-sequence
+                        daily-actions!
                         {:on-finished
                          (fn []
                            (log/info "Palaute scheduler stopped."))

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -7,7 +7,9 @@
 (defn daily-actions!
   "Run all palaute checks that need to be run on a daily basis."
   [opts]
-  (palaute/handle-palautteet-waiting-for-heratepvm! opts)
+  (palaute/handle-palautteet-waiting-for-heratepvm!
+    ["aloittaneet" "valmistuneet" "osia_suorittaneet"
+     "tyopaikkajakson_suorittaneet"])
   true)
 
 (defn run-scheduler!

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -156,9 +156,9 @@
       {:yksiloiva_tunniste (:jakson-yksiloiva-tunniste existing-palaute)
        :alkupvm vastaamisajan-alkupvm
        :hankkimistapa_id (:hankkimistapa-id existing-palaute)
-       :hankkimistapa_tyyppi (arvo/koodiuri->koodi
+       :hankkimistapa_tyyppi (utils/koodiuri->koodi
                                (:osaamisen-hankkimistapa-koodi-uri jakso))
-       :oppisopimuksen_perusta (arvo/koodiuri->koodi
+       :oppisopimuksen_perusta (utils/koodiuri->koodi
                                  (:oppisopimuksen-perusta-koodi-uri jakso))
        :hoks_id (:hoks-id existing-palaute)
        :jakso_alkupvm (:alku jakso)

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -200,5 +200,4 @@
    :arvo-caller #'arvo/create-jaksotunnus!
    :heratepalvelu-builder #'build-jaksoherate-record-for-heratepalvelu
    :heratepalvelu-caller #'heratepalvelu/sync-jakso!*
-   :arvo-cleanup-handler #'arvo/delete-kyselytunnus
    :extra-handlers [#'ensure-tpo-nippu!]})

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -74,10 +74,12 @@
   state of the palaute (or nil if it cannot be formed at all), the field the
   decision was based on, and the reason for picking that state."
   [{:keys [jakso] :as ctx} kysely-type]
-  {:pre [(some? jakso)]}
   (or
     (palaute/initial-palaute-state-and-reason-if-not-kohderyhma ctx :loppu)
     (cond
+      (nil? jakso)
+      [nil :osaamisen-hankkimistapa :ei-ole]
+
       (not (oht/palautteenkeruu-allowed-tyopaikkajakso? jakso))
       [:ei-laheteta :tyopaikalla-jarjestettava-koulutus :puuttuva-yhteystieto]
 

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -12,7 +12,9 @@
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.tyoelama.nippu :as nippu]
-            [oph.ehoks.utils.date :as date])
+            [oph.ehoks.utils :as utils]
+            [oph.ehoks.utils.date :as date]
+            [oph.ehoks.utils.string :as u-str])
   (:import (clojure.lang ExceptionInfo)
            (java.time LocalDate)
            (java.util UUID)))
@@ -142,3 +144,61 @@
   (heratepalvelu/sync-tpo-nippu!
     (nippu/build-tpo-nippu-for-heratepalvelu ctx)
     (:tunnus arvo-response)))
+
+(defn build-jaksoherate-record-for-heratepalvelu
+  [{:keys [existing-palaute opiskeluoikeus koulutustoimija hoks jakso
+           toimipiste niputuspvm suoritus vastaamisajan-alkupvm
+           request-id arvo-response] :as ctx}]
+  (let [heratepvm (:heratepvm existing-palaute)
+        tjk (:tyopaikalla-jarjestettava-koulutus jakso)
+        ohjaaja (:vastuullinen-tyopaikka-ohjaaja tjk)]
+    (utils/remove-nils
+      {:yksiloiva_tunniste (:jakson-yksiloiva-tunniste existing-palaute)
+       :alkupvm vastaamisajan-alkupvm
+       :hankkimistapa_id (:hankkimistapa-id existing-palaute)
+       :hankkimistapa_tyyppi (arvo/koodiuri->koodi
+                               (:osaamisen-hankkimistapa-koodi-uri jakso))
+       :oppisopimuksen_perusta (arvo/koodiuri->koodi
+                                 (:oppisopimuksen-perusta-koodi-uri jakso))
+       :hoks_id (:hoks-id existing-palaute)
+       :jakso_alkupvm (:alku jakso)
+       :jakso_loppupvm (:loppu jakso)
+       :koulutustoimija koulutustoimija
+       :niputuspvm niputuspvm
+       :ohjaaja_email (:sahkoposti ohjaaja)
+       :ohjaaja_nimi (:nimi ohjaaja)
+       :ohjaaja_puhelinnumero (:puhelinnumero ohjaaja)
+       :ohjaaja_ytunnus_kj_tutkinto (nippu/tunniste ctx)
+       :opiskeluoikeus_oid (:opiskeluoikeus-oid hoks)
+       :oppija_oid (:oppija-oid hoks)
+       :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
+       :osaamisala (str (seq (suoritus/get-osaamisalat suoritus heratepvm)))
+       :osa_aikaisuus (:osa-aikaisuustieto jakso)
+       :rahoituskausi (palaute/rahoituskausi heratepvm)
+       :request_id request-id
+       :tallennuspvm (date/now)
+       :toimipiste_oid toimipiste
+       :tpk-niputuspvm "ei_maaritelty"  ; sic! this has a dash, not underscore
+       :tunnus (:tunnus arvo-response)
+       :tutkinnonosa_koodi (:tutkinnon-osa-koodi-uri jakso)
+       :tutkinnonosa_nimi (:nimi jakso)
+       :tutkinto (suoritus/tutkintotunnus suoritus)
+       :tutkintonimike (str (seq (map :koodiarvo (:tutkintonimike suoritus))))
+       :tyopaikan_nimi (:tyopaikan-nimi tjk)
+       :tyopaikan_normalisoitu_nimi (u-str/normalize (:tyopaikan-nimi tjk))
+       :tyopaikan_ytunnus (:tyopaikan-y-tunnus tjk)
+       :viimeinen_vastauspvm (palaute/vastaamisajan-loppupvm
+                               heratepvm vastaamisajan-alkupvm)})))
+
+;; these use vars (#') because otherwise with-redefs doesn't work on
+;; them (the map has the original definition even if the function in
+;; its namespace is redef'd)
+
+(def handlers
+  {:check-palaute #'initial-palaute-state-and-reason
+   :arvo-builder #'arvo/build-jaksotunnus-request-body
+   :arvo-caller #'arvo/create-jaksotunnus!
+   :heratepalvelu-builder #'build-jaksoherate-record-for-heratepalvelu
+   :heratepalvelu-caller #'heratepalvelu/sync-jakso!*
+   :arvo-cleanup-handler #'arvo/delete-kyselytunnus
+   :extra-handlers [#'ensure-tpo-nippu!]})

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -40,11 +40,7 @@
   "Takes `hoks` as an input and extracts from it all osaamisen hankkimistavat
   that are tyopaikkajaksos. Returns a lazy sequence."
   [hoks]
-  (->> (mapcat :osa-alueet (:hankittavat-yhteiset-tutkinnon-osat hoks))
-       (concat (:hankittavat-ammat-tutkinnon-osat hoks)
-               (:hankittavat-paikalliset-tutkinnon-osat hoks))
-       (mapcat :osaamisen-hankkimistavat)
-       (filter oht/tyopaikkajakso?)))
+  (filter oht/tyopaikkajakso? (oht/osaamisen-hankkimistavat hoks)))
 
 (defn next-niputus-date
   "Palauttaa seuraavan niputuspäivämäärän annetun päivämäärän jälkeen.

--- a/src/oph/ehoks/palaute/tyoelama/nippu.clj
+++ b/src/oph/ehoks/palaute/tyoelama/nippu.clj
@@ -1,10 +1,11 @@
 (ns oph.ehoks.palaute.tyoelama.nippu
-  (:require [oph.ehoks.utils :as utils]))
+  (:require [oph.ehoks.utils :as utils]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]))
 
 (defn build-tpo-nippu-for-heratepalvelu
   [{:keys [jakso suoritus koulutustoimija niputuspvm] :as ctx}]
   {:pre [(:tyopaikalla-jarjestettava-koulutus jakso)]}
-  (let [tutkinto (get-in suoritus [:koulutusmoduuli :tunniste :koodiarvo])
+  (let [tutkinto           (suoritus/tutkintotunnus suoritus)
         tjk                (:tyopaikalla-jarjestettava-koulutus jakso)
         tyopaikan-nimi     (:tyopaikan-nimi tjk)
         tyopaikan-y-tunnus (:tyopaikan-y-tunnus tjk)

--- a/src/oph/ehoks/palaute/tyoelama/nippu.clj
+++ b/src/oph/ehoks/palaute/tyoelama/nippu.clj
@@ -1,31 +1,19 @@
 (ns oph.ehoks.palaute.tyoelama.nippu
   (:require [oph.ehoks.utils :as utils]))
 
-(defn tunniste
-  [ctx tep-palaute]
-  {:pre [(or (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
-             (:ohjaaja-nimi tep-palaute))
-         (or (:tyopaikan-y-tunnus tep-palaute)
-             (:tyopaikan-ytunnus tep-palaute))
-         (:koulutustoimija ctx)
-         (get-in (:suoritus ctx) [:koulutusmoduuli :tunniste :koodiarvo])]}
-  (format "%s/%s/%s/%s"
-          (or (:vastuullinen-tyopaikka-ohjaaja-nimi tep-palaute)
-              (:ohjaaja-nimi tep-palaute))
-          (or (:tyopaikan-y-tunnus tep-palaute)
-              (:tyopaikan-ytunnus tep-palaute))
-          (:koulutustoimija ctx)
-          (get-in (:suoritus ctx) [:koulutusmoduuli :tunniste :koodiarvo])))
-
 (defn build-tpo-nippu-for-heratepalvelu
-  [{:keys [existing-palaute suoritus koulutustoimija niputuspvm] :as ctx}]
-  {:pre [(:tyopaikan-nimi existing-palaute)]}
+  [{:keys [jakso suoritus koulutustoimija niputuspvm] :as ctx}]
+  {:pre [(:tyopaikalla-jarjestettava-koulutus jakso)]}
   (let [tutkinto (get-in suoritus [:koulutusmoduuli :tunniste :koodiarvo])
-        tyopaikan-nimi     (:tyopaikan-nimi existing-palaute)
-        tyopaikan-y-tunnus (:tyopaikan-y-tunnus existing-palaute)
-        ohjaaja            (:vastuullinen-tyopaikka-ohjaaja-nimi
-                             existing-palaute)]
-    (-> {:ohjaaja-ytunnus-kj-tutkinto (tunniste ctx existing-palaute)
+        tjk                (:tyopaikalla-jarjestettava-koulutus jakso)
+        tyopaikan-nimi     (:tyopaikan-nimi tjk)
+        tyopaikan-y-tunnus (:tyopaikan-y-tunnus tjk)
+        ohjaaja            (:nimi (:vastuullinen-tyopaikka-ohjaaja tjk))]
+    (-> {:ohjaaja-ytunnus-kj-tutkinto (format "%s/%s/%s/%s"
+                                              ohjaaja
+                                              tyopaikan-y-tunnus
+                                              koulutustoimija
+                                              tutkinto)
          :ohjaaja                     ohjaaja
          :tyopaikka                   tyopaikan-nimi
          :ytunnus                     tyopaikan-y-tunnus
@@ -36,3 +24,6 @@
          :niputuspvm                  niputuspvm}
         (utils/remove-nils)
         (utils/to-underscore-keys))))
+
+(defn tunniste [ctx]
+  (:ohjaaja_ytunnus_kj_tutkinto (build-tpo-nippu-for-heratepalvelu ctx)))

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.palaute.vastaajatunnus
   (:require [medley.core :refer [find-first map-vals]]
             [clojure.walk :refer [walk]]
+            [clojure.set]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.heratepalvelu :as heratepalvelu]
             [oph.ehoks.hoks :as hoks]

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -25,10 +25,11 @@
         suoritus (find-first suoritus/ammatillinen?
                              (:suoritukset opiskeluoikeus))]
     (assoc ctx
-           :opiskeluoikeus        opiskeluoikeus
-           :suoritus              suoritus
-           :koulutustoimija       (palaute/koulutustoimija-oid! opiskeluoikeus)
-           :toimipiste            (palaute/toimipiste-oid! suoritus))))
+           :opiskeluoikeus opiskeluoikeus
+           :suoritus suoritus
+           :hk-toteuttaja (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
+           :koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
+           :toimipiste (palaute/toimipiste-oid! suoritus))))
 
 (defn- handle-exception
   "Handles an ExceptionInfo `ex` based on `:type` in `ex-data`. If `ex` doesn't

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -1,0 +1,12 @@
+(ns oph.ehoks.palaute.vastaajatunnus
+  (:require [oph.ehoks.palaute.opiskelija :as amis]
+            [oph.ehoks.palaute.tyoelama :as tep]))
+
+(defn handle-palautteet-waiting-for-heratepvm!
+  "Fetch all unhandled palautteet whose heratepvm has come, check that
+  they are part of kohderyhmä now (on their handling date) and create
+  and save vastaajatunnus if so."
+  [opts]
+  (amis/create-and-save-arvo-kyselylinkki-for-all-needed! opts)
+  (tep/handle-all-palautteet-waiting-for-vastaajatunnus! opts))
+

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -64,6 +64,7 @@
       (::arvo-kutsu-epaonnistui ::tunnus-tallennus-epaonnistui)
       (let [cause (ex-cause ex)]
         (log/error "Error" ex-type "because of" (ex-message cause)
+                   "with error body" (:body (ex-data cause))
                    "for palaute" (:id existing-palaute))
         (tapahtuma/build-and-insert!
           ctx ex-type {:errormsg (ex-message cause)
@@ -73,8 +74,7 @@
       (let [ddb-ex (ex-cause ex)]
         (log/errorf (str "%s. Trying to delete jakso corresponding to "
                          "palaute `%d` from Herätepalvelu")
-                    (ex-message ex)
-                    (:id existing-palaute))
+                    (ex-message ddb-ex) (:id existing-palaute))
         (tapahtuma/build-and-insert!
           ctx ex-type {:errormsg (ex-message ddb-ex)
                        :body     (ex-data ddb-ex)})

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -148,7 +148,8 @@
   (let [[state field reason]
         (check-palaute ctx (make-kysely-type existing-palaute))]
     (if (not= :odottaa-kasittelya state)
-      (->> (map-vals str (select-keys (or hoks jakso) [field]))
+      (->> (select-keys (or hoks jakso) [field])
+           (map-vals str)
            (palaute/update-tila! ctx "ei_laheteta" reason))
       (let [request-id (str (UUID/randomUUID))
             arvo-req (arvo-builder ctx request-id)

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -96,7 +96,8 @@
                 (:jakson-yksiloiva-tunniste palaute)
                 (oht/osaamisen-hankkimistapa-by-yksiloiva-tunniste hoks))]
     (enrich-ctx! {:hoks hoks :jakso jakso :existing-palaute palaute
-                  :tapahtumatyyppi :arvo-luonti})))
+                  :tapahtumatyyppi :arvo-luonti
+                  :request-id (str (UUID/randomUUID))})))
 
 (defn make-kysely-type
   "Map DB-level kyselytyyppi back into what is expected by
@@ -135,8 +136,7 @@
 (defn create-and-save-tunnus!
   "Create and save vastaajatunnus for given palaute context."
   [ctx {:keys [arvo-builder arvo-caller] :as handlers}]
-  (let [request-id (str (UUID/randomUUID))
-        arvo-req (arvo-builder ctx request-id)
+  (let [arvo-req (arvo-builder ctx)
         response
         (try (arvo-caller arvo-req)
              (catch ExceptionInfo e
@@ -144,10 +144,7 @@
                                {:type ::arvo-kutsu-epaonnistui :ctx ctx}
                                e))))
         tunnus (save-arvo-tunniste! ctx response)]
-    (assoc ctx
-           :arvo-tunnus tunnus
-           :arvo-response response
-           :request-id request-id)))
+    (assoc ctx :arvo-tunnus tunnus :arvo-response response)))
 
 (defn sync-to-heratepalvelu!
   "Replicate information about just formed vastaajatunnus to heratepalvelu."

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -206,7 +206,8 @@
   (log/info "Creating vastaajatunnukset for kyselytyypit" kyselytyypit)
   (doall (map handle-palaute-waiting-for-heratepvm!
               (palaute/get-palautteet-waiting-for-vastaajatunnus!
-                db/spec {:kyselytyypit kyselytyypit}))))
+                db/spec {:kyselytyypit kyselytyypit
+                         :hoks-id nil :palaute-id nil}))))
 
 (defn handle-amis-palautteet-on-heratepvm!
   "Create kyselylinkki for palautteet whose herätepvm has come but

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -164,7 +164,7 @@
                (assoc (ex-data e)
                       :type ::heratepalvelu-sync-epaonnistui
                       :arvo-tunnus arvo-tunnus)
-                     e))))
+               e))))
   arvo-tunnus)
 
 (defn palaute-check-call-arvo-save-and-sync!
@@ -179,7 +179,8 @@
       (->> (select-keys (merge jakso hoks) [field])
            (map-vals str)
            (palaute/update-tila! ctx "ei_laheteta" reason))
-      (-> (create-and-save-tunnus! ctx handlers)
+      (-> ctx
+          (create-and-save-tunnus! handlers)
           (sync-to-heratepalvelu! handlers)))))
 
 (defn handle-palaute-waiting-for-heratepvm!

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -1,12 +1,151 @@
 (ns oph.ehoks.palaute.vastaajatunnus
-  (:require [oph.ehoks.palaute.opiskelija :as amis]
-            [oph.ehoks.palaute.tyoelama :as tep]))
+  (:require [medley.core :refer [find-first]]
+            [clojure.walk :refer [walk]]
+            [oph.ehoks.external.arvo :as arvo]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.heratepalvelu :as heratepalvelu]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.db :as db]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.palaute.opiskelija :as amis]
+            [oph.ehoks.palaute.tyoelama :as tep])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn get-in-and-propagate-fields
+  "Hakee tietorakenteesta tietyn (listamuotoisen) kentän ja lisää
+  listan joka kohtaan tietyt kentät alkuperäisestä, eli propagoi
+  tietyt kentät syvemmälle tietorakenteessa."
+  [obj field-to-get fields-to-propagate]
+  (map #(merge % (select-keys obj fields-to-propagate))
+       (get-in obj field-to-get)))
+
+(defn osaamisen-hankkimistavat
+  "Hakee HOKSista kaikki osaamisen hankkimistavat."
+  [hoks]
+  (let [propagated-fields [:tutkinnon-osa-koodi-uri :nimi]]
+    (->>
+      (:hankittavat-yhteiset-tutkinnon-osat hoks)
+      (mapcat #(get-in-and-propagate-fields % [:osa-alueet] propagated-fields))
+      (concat (:hankittavat-paikalliset-tutkinnon-osat hoks))
+      (concat (:hankittavat-ammat-tutkinnon-osat hoks))
+      (mapcat #(get-in-and-propagate-fields
+                 % [:osaamisen-hankkimistavat] propagated-fields)))))
+
+(defn osaamisen-hankkimistapa-by-yksiloiva-tunniste
+  "Hakee HOKSista yhden osaamisen hankkimistavan yksilöivän tunnisteen
+  perusteella."
+  [hoks yks_tunn]
+  (find-first #(= yks_tunn (:yksiloiva-tunniste %))
+              (osaamisen-hankkimistavat hoks)))
+
+(defn- enrich-ctx!
+  "Lisää muista palveluista saatavia tietoja kontekstiin myöhempää
+  käsittelyä varten."
+  [{:keys [hoks] :as ctx}]
+  (let [opiskeluoikeus (koski/get-existing-opiskeluoikeus!
+                         (:opiskeluoikeus-oid hoks))
+        suoritus (find-first suoritus/ammatillinen?
+                             (:suoritukset opiskeluoikeus))]
+    (assoc ctx
+           :opiskeluoikeus        opiskeluoikeus
+           :suoritus              suoritus
+           :koulutustoimija       (palaute/koulutustoimija-oid! opiskeluoikeus)
+           :toimipiste            (palaute/toimipiste-oid! suoritus))))
+
+(defn- handle-exception
+  "Handles an ExceptionInfo `ex` based on `:type` in `ex-data`. If `ex` doesn't
+  match any of the cases below, re-throws `ex`."
+  [{:keys [existing-palaute] :as ctx} ex]
+  (let [ex-data (ex-data ex)
+        ex-type (:type ex-data)
+        tunnus  (:arvo-tunnus ex-data)]
+    (when tunnus
+      (log/infof "Trying to delete jaksotunnus `%s` from Arvo" tunnus)
+      (arvo/delete-jaksotunnus tunnus))
+    (case ex-type
+      ::koski/opiskeluoikeus-not-found
+      (do (log/warnf "%s. Setting `tila` to \"ei_laheteta\" for palaute `%d`."
+                     (ex-message ex)
+                     (:id existing-palaute))
+          (palaute/update-tila!
+            ctx "ei_laheteta" ex-type (select-keys existing-palaute
+                                                   [:opiskeluoikeus-oid])))
+
+      ::tep/jakso-keskeytynyt
+      (do (log/warnf "%s. Setting `tila` to `ei_laheteta` for palaute `%d`. "
+                     (ex-message ex)
+                     (:id existing-palaute))
+          (palaute/update-tila!
+            ctx "ei_laheteta" ex-type
+            (walk (fn [[k v]] [(name k) (str v)])
+                  identity
+                  (select-keys ex-data [:keskeytymisajanjaksot]))))
+
+      ::arvo/no-jaksotunnus-created
+      (log/logf (if (:configured-to-call-arvo? ex-data) :error :warn)
+                (str (ex-message ex) " Skipping processing for palaute `%d`")
+                (:id existing-palaute))
+
+      ::heratepalvelu/tpo-nippu-sync-failed
+      (do (log/errorf (str "%s. Trying to delete jakso corresponding to "
+                           "palaute `%d` from Herätepalvelu")
+                      (ex-message ex)
+                      (:id existing-palaute))
+          (heratepalvelu/delete-jakso-herate! existing-palaute)
+          (throw ex))
+
+      ;; FIXME: tapahtuma
+      (throw ex))))
+
+(defn handle-palaute-waiting-for-heratepvm!
+  "Check that palaute is part of kohderyhmä and create and save
+  vastaajatunnus if so."
+  [palaute]
+  (jdbc/with-db-transaction
+    [tx db/spec]
+    (try
+      (let [hoks (hoks/get-by-id (:hoks-id palaute))
+            jakso (some->>
+                    (:jakson-yksiloiva-tunniste palaute)
+                    (osaamisen-hankkimistapa-by-yksiloiva-tunniste hoks))
+            ctx (enrich-ctx! {:hoks hoks :jakso jakso :tx tx
+                              :existing-palaute palaute
+                              :tapahtumatyyppi :arvo-luonti})]
+        (log/info "Creating vastaajatunnus for" (:kyselytyyppi palaute)
+                  "palaute" (:id palaute))
+        (if (:jakson-yksiloiva-tunniste palaute)
+          (tep/handle-palaute-waiting-for-vastaajatunnus! ctx)
+          (amis/create-and-save-arvo-kyselylinkki! palaute)))
+      (catch ExceptionInfo e
+        (handle-exception
+          {:existing-palaute palaute :tx tx :tapahtumatyyppi :arvo-luonti} e))
+      (catch Exception e
+        (log/warn e "Error processing palaute" palaute)
+        (throw e)))))
 
 (defn handle-palautteet-waiting-for-heratepvm!
   "Fetch all unhandled palautteet whose heratepvm has come, check that
   they are part of kohderyhmä now (on their handling date) and create
   and save vastaajatunnus if so."
-  [opts]
-  (amis/create-and-save-arvo-kyselylinkki-for-all-needed! opts)
-  (tep/handle-all-palautteet-waiting-for-vastaajatunnus! opts))
+  [kyselytyypit]
+  (log/info "Creating vastaajatunnukset for kyselytyypit" kyselytyypit)
+  (doall (map handle-palaute-waiting-for-heratepvm!
+              (palaute/get-palautteet-waiting-for-vastaajatunnus!
+                db/spec {:kyselytyypit kyselytyypit}))))
 
+(defn create-and-save-arvo-kyselylinkki-for-all-needed!
+  "Create kyselylinkki for palautteet whose herätepvm has come but
+  which don't have a kyselylinkki yet."
+  [_]
+  (handle-palautteet-waiting-for-heratepvm!
+    ["aloittaneet" "valmistuneet" "osia_suorittaneet"]))
+
+(defn handle-all-palautteet-waiting-for-vastaajatunnus!
+  "Creates vastaajatunnus for all herates that are waiting for processing,
+  do not have vastaajatunnus and have heratepvm today or in the past."
+  [_]
+  (handle-palautteet-waiting-for-heratepvm! ["tyopaikkajakson_suorittaneet"]))

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -38,6 +38,7 @@
   (let [ex-data (ex-data ex)
         ex-type (:type ex-data)
         tunnus  (:arvo-tunnus ex-data)]
+    (log/infof ex "Handling exception in tunnus handling")
     (when tunnus
       (log/infof "Trying to delete jaksotunnus `%s` from Arvo" tunnus)
       (arvo/delete-jaksotunnus tunnus))

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -208,14 +208,14 @@
               (palaute/get-palautteet-waiting-for-vastaajatunnus!
                 db/spec {:kyselytyypit kyselytyypit}))))
 
-(defn create-and-save-arvo-kyselylinkki-for-all-needed!
+(defn handle-amis-palautteet-on-heratepvm!
   "Create kyselylinkki for palautteet whose herätepvm has come but
   which don't have a kyselylinkki yet."
   [_]
   (handle-palautteet-waiting-for-heratepvm!
     ["aloittaneet" "valmistuneet" "osia_suorittaneet"]))
 
-(defn handle-all-palautteet-waiting-for-vastaajatunnus!
+(defn handle-tep-palautteet-on-heratepvm!
   "Creates vastaajatunnus for all herates that are waiting for processing,
   do not have vastaajatunnus and have heratepvm today or in the past."
   [_]

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -44,3 +44,6 @@
   [obj field-to-get fields-to-propagate]
   (map #(merge % (select-keys obj fields-to-propagate))
        (get-in obj field-to-get)))
+
+(defn koodiuri->koodi [koodiuri]
+  (some-> koodiuri (clojure.string/split #"_") (last)))

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -1,5 +1,6 @@
 (ns oph.ehoks.utils
-  (:require [medley.core :refer [dissoc-in map-keys]]))
+  (:require [medley.core :refer [dissoc-in map-keys]]
+            [clojure.string]))
 
 (defn apply-when
   "Apply function `f` to value `v` if predicate `(pred v)` returns `true`.

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -36,3 +36,11 @@
   "Return same map, but without keys pointing to nil values"
   [m]
   (into {} (filter (fn [[k v]] (some? v)) m)))
+
+(defn get-in-and-propagate-fields
+  "Hakee tietorakenteesta tietyn (listamuotoisen) kentän ja lisää
+  listan joka kohtaan tietyt kentät alkuperäisestä, eli propagoi
+  tietyt kentät syvemmälle tietorakenteessa."
+  [obj field-to-get fields-to-propagate]
+  (map #(merge % (select-keys obj fields-to-propagate))
+       (get-in obj field-to-get)))

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.db.dynamodb-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [oph.ehoks.db.db-operations.db-helpers :as db-ops]
+            [oph.ehoks.db :as db]
             [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.koski-test :as koski-test]
@@ -8,6 +9,8 @@
             [oph.ehoks.hoks.handler :as hoks-handler]
             [oph.ehoks.oppijaindex :as oi]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.opiskelija :as opiskelija]
+            [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.test-utils :as test-utils]
             [taoensso.faraday :as far])
   (:import (java.time LocalDate)))
@@ -15,24 +18,11 @@
 (use-fixtures :once test-utils/migrate-database)
 (use-fixtures :each test-utils/empty-database-after-test)
 
-(deftest amis-field-mapping
-  (testing "map-keys-to-ddb maps correctly"
-    (is (= (ddb/map-keys-to-ddb :foo) :foo))
-    (is (= (ddb/map-keys-to-ddb :toimija-oppija) :toimija_oppija))
-    (is (= (ddb/map-keys-to-ddb :sahkoposti) :sahkoposti))))
-
 (deftest missing-sync-test
   (testing "sync-item! fails when not enough information is available
   for identifying the item"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"item key missing"
-                          (ddb/sync-item! :amis {}))))
-  (testing "sync-amis-herate! fails when there is no information in db"
-    (is (thrown-with-msg?
-          clojure.lang.ExceptionInfo
-          #"palaute not found"
-          (ddb/sync-amis-herate!
-            {:existing-palaute {:hoks-id 54343
-                                :kyselytyyppi "aloittaneet"}})))))
+                          (ddb/sync-item! :amis {})))))
 
 (def hoks-data {:opiskeluoikeus-oid "1.2.246.562.15.10000000009"
                 :oppija-oid "1.2.246.562.24.12312312319"
@@ -40,7 +30,7 @@
                 :osaamisen-hankkimisen-tarve true
                 :sahkoposti "irma.isomerkki@esimerkki.com"})
 
-(deftest sync-herate-to-dynamodb
+(deftest test-sync-herate-to-dynamodb
   (with-redefs [koski/get-opiskeluoikeus-info-raw
                 koski-test/mock-get-opiskeluoikeus-raw]
 
@@ -56,11 +46,14 @@
             saved-hoks (hoks-handler/save-hoks-and-initiate-all-palautteet!
                          {:hoks           hoks-data
                           :opiskeluoikeus opiskeluoikeus})
-            hoks (hoks/get-by-id (:id saved-hoks))]
-        (is (= (:sahkoposti hoks) "irma.isomerkki@esimerkki.com"))
-        (ddb/sync-amis-herate!
-          {:existing-palaute {:hoks-id      (:id saved-hoks)
-                              :kyselytyyppi "aloittaneet"}})
+            herate (first (palaute/get-by-hoks-id-and-kyselytyypit!
+                            db/spec {:hoks-id (:id saved-hoks)
+                                     :kyselytyypit ["aloittaneet"]}))
+            ctx (vt/build-ctx herate)
+            amis-herate
+            (opiskelija/build-amisherate-record-for-heratepalvelu ctx)]
+        (is (= (:sahkoposti (:hoks ctx)) "irma.isomerkki@esimerkki.com"))
+        (ddb/sync-amis-herate! ctx amis-herate)
         (let [ddb-key {:tyyppi_kausi
                        (str "aloittaneet/"
                             (palaute/rahoituskausi (LocalDate/now)))
@@ -75,15 +68,8 @@
                             :expr-attr-names {"#2" "viestintapalvelu-id"}
                             :expr-attr-vals {":1" "lahetetty"
                                              ":2" "2027-05-06"}})
-          (hoks-handler/change-hoks-and-initiate-all-palautteet!
-            {:hoks           (assoc hoks-data
-                                    :id (:id saved-hoks)
-                                    :sahkoposti "foo@bar.com")
-             :opiskeluoikeus opiskeluoikeus}
-            hoks/update!)
           (ddb/sync-amis-herate!
-            {:existing-palaute {:hoks-id      (:id saved-hoks)
-                                :kyselytyyppi "aloittaneet"}})
+            ctx (assoc amis-herate :sahkoposti "foo@bar.com"))
           ; fields that are owned by herätepalvelu are not overwritten
           (let [new-ddb-item
                 (far/get-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -53,7 +53,7 @@
             amis-herate
             (opiskelija/build-amisherate-record-for-heratepalvelu ctx)]
         (is (= (:sahkoposti (:hoks ctx)) "irma.isomerkki@esimerkki.com"))
-        (ddb/sync-amis-herate! ctx amis-herate)
+        (ddb/sync-amis-herate! amis-herate)
         (let [ddb-key {:tyyppi_kausi
                        (str "aloittaneet/"
                             (palaute/rahoituskausi (LocalDate/now)))
@@ -68,8 +68,7 @@
                             :expr-attr-names {"#2" "viestintapalvelu-id"}
                             :expr-attr-vals {":1" "lahetetty"
                                              ":2" "2027-05-06"}})
-          (ddb/sync-amis-herate!
-            ctx (assoc amis-herate :sahkoposti "foo@bar.com"))
+          (ddb/sync-amis-herate! (assoc amis-herate :sahkoposti "foo@bar.com"))
           ; fields that are owned by herätepalvelu are not overwritten
           (let [new-ddb-item
                 (far/get-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -145,11 +145,11 @@
                :osa-alueet [] :tyoelama-osaamisen-arvioijat [])]
     (eq (test-utils/dissoc-module-ids ttn-after-update) ttn-patch-values)))
 
-(defn create-hoks-in-the-past! []
+(defn create-hoks-in-the-past! [& [transform]]
   (with-redefs [date/now #(LocalDate/of 2023 8 1)]
     (mock-st-post (create-app nil)
                   base-url
-                  (dissoc hoks-test/hoks-1 :id))))
+                  (dissoc ((or transform identity) hoks-test/hoks-1) :id))))
 
 (defn palautteet []
   (db-helpers/query ["select * from palautteet"]))

--- a/test/oph/ehoks/opiskeluoikeus/suoritus_test.clj
+++ b/test/oph/ehoks/opiskeluoikeus/suoritus_test.clj
@@ -18,7 +18,7 @@
                                   :loppu "2022-01-25"
                                   :koodiarvo "lkhlkhjl"}]}
           expected ["test1" "test2"]]
-      (is (= (suoritus/get-osaamisalat
-               suoritus "1.2.3.4" (LocalDate/of 2022 2 2)) expected))
+      (is (= (suoritus/get-osaamisalat suoritus (LocalDate/of 2022 2 2))
+             expected))
       (is (empty? (suoritus/get-osaamisalat
-                    {:osaamisala []} "1.2.3.4" (LocalDate/of 2022 2 2)))))))
+                    {:osaamisala []} (LocalDate/of 2022 2 2)))))))

--- a/test/oph/ehoks/palaute/handler_test.clj
+++ b/test/oph/ehoks/palaute/handler_test.clj
@@ -101,8 +101,10 @@
             (let [resp (post! palaute-app
                               "/tyoelamapalaute/7/vastaajatunnus")
                   data (:data (test-utils/parse-body (:body resp)))]
-              (is (= (:status resp) 200))
+              (is (= (:status resp) 200) data)
               (is (not (nil? (:vastaajatunnus data))))
+              ;; TODO: test here that the palaute is synced to DDB with
+              ;; hankkimistapa-id
               (is (= (count (hoks-utils/palautteet-joissa-vastaajatunnus)) 1))))
 
           (testing (str "POST /tyoelamapalaute/vastaajatunnukset creates "
@@ -110,7 +112,7 @@
             (let [resp (post! palaute-app
                               "/tyoelamapalaute/vastaajatunnukset")
                   data (:data (test-utils/parse-body (:body resp)))]
-              (is (= (:status resp) 200))
+              (is (= (:status resp) 200) data)
               (is (= (count (:vastaajatunnukset data)) 4))
               (is (= (count (hoks-utils/palautteet-joissa-vastaajatunnus)) 5))))
 
@@ -120,5 +122,5 @@
             (let [resp (post! palaute-app
                               "/tyoelamapalaute/vastaajatunnukset")
                   data (:data (test-utils/parse-body (:body resp)))]
-              (is (= (:status resp) 200))
+              (is (= (:status resp) 200) data)
               (is (= (count (:vastaajatunnukset data)) 0)))))))))

--- a/test/oph/ehoks/palaute/handler_test.clj
+++ b/test/oph/ehoks/palaute/handler_test.clj
@@ -80,11 +80,11 @@
           (is (= (:error body) "Caller-Id header is missing"))))
 
       (testing (str "POST /tyoelamapalaute/:palaute-id/vastaajatunnus with "
-                    "non-existing palaute id returns Palaute not found")
+                    "non-existing palaute id returns empty list")
         (let [resp (post! palaute-app "/tyoelamapalaute/10/vastaajatunnus")
               body (test-utils/parse-body (:body resp))]
-          (is (= (:status resp) 404))
-          (is (= (:message body) "Palaute not found"))))
+          (is (= (:status resp) 200))
+          (is (= (get-in body [:data :vastaajatunnukset]) []) body)))
 
       (testing "Creating vastaajatunnus with"
         (with-redefs [organisaatio/get-organisaatio!
@@ -102,7 +102,7 @@
                               "/tyoelamapalaute/7/vastaajatunnus")
                   data (:data (test-utils/parse-body (:body resp)))]
               (is (= (:status resp) 200) data)
-              (is (not (nil? (:vastaajatunnus data))))
+              (is (not (empty? (:vastaajatunnukset data))))
               ;; TODO: test here that the palaute is synced to DDB with
               ;; hankkimistapa-id
               (is (= (count (hoks-utils/palautteet-joissa-vastaajatunnus)) 1))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -318,7 +318,8 @@
                   :opiskeluoikeus oo-test/opiskeluoikeus-1})
           heratteet
           (palaute/get-palautteet-waiting-for-vastaajatunnus!
-            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]})]
+            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]
+                     :hoks-id nil :palaute-id nil})]
       (testing "HOKS creation marks correct palautteet as actionable"
         (is (= [["odottaa_kasittelya" "aloittaneet"]
                 ["odottaa_kasittelya" "valmistuneet"]]
@@ -386,7 +387,8 @@
           vastauslinkki-counter (atom 0)
           heratteet
           (palaute/get-palautteet-waiting-for-vastaajatunnus!
-            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]})]
+            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]
+                     :hoks-id nil :palaute-id nil})]
       (testing "successful Arvo call for amispalaute"
         (client/set-post!
           (fn [^String url options]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -295,7 +295,7 @@
   [palaute]
   (-> palaute
       (vt/build-ctx)
-      (op/build-kyselylinkki-request-body "request-id")
+      (op/build-kyselylinkki-request-body)
       (arvo/create-kyselytunnus!)))
 
 (deftest test-create-arvo-kyselylinkki!
@@ -394,6 +394,7 @@
           (fn [^String url options]
             (when (.endsWith url "/api/vastauslinkki/v1")
               (swap! vastauslinkki-counter inc)
+              (is (not (empty? (get-in options [:form-params :request_id]))))
               {:status 200
                :body {:tunnus (str "foo" @vastauslinkki-counter)
                       :kysely_linkki (str "https://arvovastaus.csc.fi/v/foo"
@@ -455,6 +456,7 @@
                          @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]
           (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
           (is (= "https://arvovastaus.csc.fi/v/foo1" (:kyselylinkki ddb-item)))
+          (is (not (empty? (:request-id ddb-item))))
           (is (= 351407 (:tutkintotunnus ddb-item)))))
       (testing "unsuccessful Arvo call for amispalaute"
         (client/set-post!

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -483,7 +483,7 @@
                     (map (juxt :vanha-tila :uusi-tila :lisatiedot)))))
         (client/reset-functions!)))))
 
-(deftest test-create-and-save-arvo-kyselylinkki-for-all-needed!
+(deftest test-handle-amis-palautteet-on-heratepvm!
   (with-redefs [date/now (constantly (LocalDate/of 2024 12 18))
                 koski/get-oppija-opiskeluoikeudet
                 (fn [_]
@@ -502,7 +502,7 @@
                  {:hoks hoks-test/hoks-4
                   :opiskeluoikeus oo-test/opiskeluoikeus-1})
           vastauslinkki-counter (atom 0)]
-      (testing "create-and-save-arvo-kyselylinkki-for-all-needed!"
+      (testing "handle-amis-palautteet-on-heratepvm!"
         (client/set-post!
           (fn [^String url options]
             (when (.endsWith url "/api/vastauslinkki/v1")
@@ -512,7 +512,7 @@
                       :kysely_linkki (str "https://arvovastaus.csc.fi/v/bar"
                                           @vastauslinkki-counter)
                       :voimassa_loppupvm "2024-10-10"}})))
-        (vt/create-and-save-arvo-kyselylinkki-for-all-needed! {})
+        (vt/handle-amis-palautteet-on-heratepvm! {})
         (is (= [["kysely_muodostettu" "aloittaneet"]
                 ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -24,6 +24,7 @@
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.opiskelija :as op]
+            [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.test-utils :as test-utils]
             [oph.ehoks.utils.date :as date])
   (:import (java.time LocalDate LocalDateTime)))
@@ -507,7 +508,7 @@
                       :kysely_linkki (str "https://arvovastaus.csc.fi/v/bar"
                                           @vastauslinkki-counter)
                       :voimassa_loppupvm "2024-10-10"}})))
-        (op/create-and-save-arvo-kyselylinkki-for-all-needed! {})
+        (vt/create-and-save-arvo-kyselylinkki-for-all-needed! {})
         (is (= [["kysely_muodostettu" "aloittaneet"]
                 ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -400,7 +400,7 @@
         (is (->> heratteet
                  (find-first (comp (partial = "valmistuneet") :kyselytyyppi))
                  (call-create-and-save-arvo-kyselylinkki!-with-palaute)
-                 (nil?)))
+                 (some?)))
         (is (= [["odottaa_kasittelya" "aloittaneet"]
                 ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)

--- a/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
@@ -1,5 +1,6 @@
 (ns oph.ehoks.palaute.tyoelama.nippu-test
   (:require [clojure.test :refer [deftest is testing]]
+            [oph.ehoks.test-utils :as util]
             [oph.ehoks.palaute.tyoelama.nippu :as nippu])
   (:import [java.time LocalDate]))
 ;
@@ -16,14 +17,17 @@
    :niputuspvm                  (LocalDate/of 2024 12 16)})
 
 (deftest test-build-tpo-nippu-for-heratepalvelu
-  (let [tep-palaute
-        {:vastuullinen-tyopaikka-ohjaaja-nimi "Matti Meikäläinen"
-         :tyopaikan-y-tunnus                  "1234567-1"
-         :tyopaikan-nimi                      "Meikäläisen Murkinat Oy"}
-        ctx {:existing-palaute tep-palaute
+  (let [jakso
+        {:tyopaikalla-jarjestettava-koulutus
+         {:tyopaikan-nimi "Meikäläisen Murkinat Oy"
+          :tyopaikan-y-tunnus "1234567-1"
+          :vastuullinen-tyopaikka-ohjaaja
+          {:nimi "Matti Meikäläinen"
+           :sahkoposti "poks@foks"}}}
+        ctx {:jakso           jakso
              :koulutustoimija "1.2.246.562.10.346830761110"
              :suoritus        {:koulutusmoduuli
                                {:tunniste {:koodiarvo "12345"}}}
              :niputuspvm      (LocalDate/of 2024 12 16)}]
-    (is (= (nippu/build-tpo-nippu-for-heratepalvelu ctx)
-           expected-tpo-nippu-data))))
+    (util/eq (nippu/build-tpo-nippu-for-heratepalvelu ctx)
+             expected-tpo-nippu-data)))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -68,7 +68,6 @@
     :jakso_loppupvm "2023-12-05"
     :ohjaaja_puhelinnumero "0401111111"
     :osaamisala "(\"test-osaamisala\")"
-    :tutkinnonosa_tyyppi "hato"
     :yksiloiva_tunniste "1"
     :tutkinnonosa_koodi "tutkinnonosat_300268"
     :tpk-niputuspvm "ei_maaritelty"
@@ -76,7 +75,6 @@
     :oppilaitos "1.2.246.562.10.12944436166"
     :ohjaaja_ytunnus_kj_tutkinto
     "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
-    :tutkinnonosa_id 1
     :niputuspvm "2024-07-01"
     :tyopaikan_normalisoitu_nimi "ohjaus_oy"
     :toimipiste_oid "1.2.246.562.10.12345678903"
@@ -85,12 +83,10 @@
     :koulutustoimija "1.2.246.562.10.346830761110"
     :jakso_alkupvm "2023-12-01"
     :ohjaaja_email "olli.ohjaaja@esimerkki.com"
-    :hankkimistapa_id 12
     :oppija_oid "1.2.246.562.24.12312312319"
     :rahoituskausi "2023-2024"
     :tutkintonimike "(\"12345\" \"23456\")"
-    :viimeinen_vastauspvm "2024-02-14"
-    :kasittelytila "ei_niputettu"}
+    :viimeinen_vastauspvm "2024-01-14"}
    {:osa_aikaisuus 100
     :ohjaaja_nimi "Olli Ohjaaja"
     :tutkinnonosa_nimi "Testiosa"
@@ -102,14 +98,12 @@
     :jakso_loppupvm "2024-01-06"
     :ohjaaja_puhelinnumero "0401111111"
     :osaamisala "(\"test-osaamisala\")"
-    :tutkinnonosa_tyyppi "hpto"
     :yksiloiva_tunniste "4"
     :tpk-niputuspvm "ei_maaritelty"
     :tallennuspvm "2024-06-30"
     :oppilaitos "1.2.246.562.10.12944436166"
     :ohjaaja_ytunnus_kj_tutkinto
     "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
-    :tutkinnonosa_id 1
     :niputuspvm "2024-07-01"
     :tyopaikan_normalisoitu_nimi "ohjaus_oy"
     :toimipiste_oid "1.2.246.562.10.12345678903"
@@ -118,12 +112,10 @@
     :koulutustoimija "1.2.246.562.10.346830761110"
     :jakso_alkupvm "2024-01-01"
     :ohjaaja_email "olli.ohjaaja@esimerkki.com"
-    :hankkimistapa_id 10
     :oppija_oid "1.2.246.562.24.12312312319"
     :rahoituskausi "2023-2024"
     :tutkintonimike "(\"12345\" \"23456\")"
-    :viimeinen_vastauspvm "2024-03-16"
-    :kasittelytila "ei_niputettu"}
+    :viimeinen_vastauspvm "2024-02-14"}
    {:osa_aikaisuus 80
     :ohjaaja_nimi "Matti Meikäläinen"
     :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
@@ -134,7 +126,6 @@
     :jakso_loppupvm "2023-11-25"
     :ohjaaja_puhelinnumero "0402222222"
     :osaamisala "(\"test-osaamisala\")"
-    :tutkinnonosa_tyyppi "hato"
     :yksiloiva_tunniste "3"
     :tutkinnonosa_koodi "tutkinnonosat_300269"
     :tpk-niputuspvm "ei_maaritelty"
@@ -142,7 +133,6 @@
     :oppilaitos "1.2.246.562.10.12944436166"
     :ohjaaja_ytunnus_kj_tutkinto
     "Matti Meikäläinen/5523718-7/1.2.246.562.10.346830761110/123456"
-    :tutkinnonosa_id 2
     :niputuspvm "2024-07-01"
     :tyopaikan_normalisoitu_nimi "ohjaus_oy"
     :toimipiste_oid "1.2.246.562.10.12345678903"
@@ -151,12 +141,10 @@
     :koulutustoimija "1.2.246.562.10.346830761110"
     :jakso_alkupvm "2023-11-01"
     :ohjaaja_email "matti.meikalainen@esimerkki.com"
-    :hankkimistapa_id 14
     :oppija_oid "1.2.246.562.24.12312312319"
     :rahoituskausi "2023-2024"
     :tutkintonimike "(\"12345\" \"23456\")"
-    :viimeinen_vastauspvm "2024-01-30"
-    :kasittelytila "ei_niputettu"}
+    :viimeinen_vastauspvm "2023-12-30"}
    {:osa_aikaisuus 60
     :ohjaaja_nimi "Matti Meikäläinen"
     :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
@@ -167,7 +155,6 @@
     :jakso_loppupvm "2024-01-25"
     :ohjaaja_puhelinnumero "0402222222"
     :osaamisala "(\"test-osaamisala\")"
-    :tutkinnonosa_tyyppi "hyto"
     :yksiloiva_tunniste "7"
     :tutkinnonosa_koodi "tutkinnonosat_300270"
     :tpk-niputuspvm "ei_maaritelty"
@@ -175,7 +162,6 @@
     :oppilaitos "1.2.246.562.10.12944436166"
     :ohjaaja_ytunnus_kj_tutkinto
     "Matti Meikäläinen/5523718-7/1.2.246.562.10.346830761110/123456"
-    :tutkinnonosa_id 4
     :niputuspvm "2024-07-01"
     :tyopaikan_normalisoitu_nimi "ohjaus_oy"
     :toimipiste_oid "1.2.246.562.10.12345678903"
@@ -184,12 +170,10 @@
     :koulutustoimija "1.2.246.562.10.346830761110"
     :jakso_alkupvm "2024-01-01"
     :ohjaaja_email "matti.meikalainen@esimerkki.com"
-    :hankkimistapa_id 16
     :oppija_oid "1.2.246.562.24.12312312319"
     :rahoituskausi "2023-2024"
     :tutkintonimike "(\"12345\" \"23456\")"
-    :viimeinen_vastauspvm "2024-04-01"
-    :kasittelytila "ei_niputettu"}
+    :viimeinen_vastauspvm "2024-03-01"}
    {:osa_aikaisuus 80
     :ohjaaja_nimi "Olli Ohjaaja"
     :opiskeluoikeus_oid "1.2.246.562.15.10000000009"
@@ -201,7 +185,6 @@
     :jakso_loppupvm "2024-04-05"
     :ohjaaja_puhelinnumero "0401111111"
     :osaamisala "(\"test-osaamisala\")"
-    :tutkinnonosa_tyyppi "hyto"
     :yksiloiva_tunniste "9"
     :tutkinnonosa_koodi "tutkinnonosat_300271"
     :tpk-niputuspvm "ei_maaritelty"
@@ -209,7 +192,6 @@
     :oppilaitos "1.2.246.562.10.12944436166"
     :ohjaaja_ytunnus_kj_tutkinto
     "Olli Ohjaaja/5523718-7/1.2.246.562.10.346830761110/123456"
-    :tutkinnonosa_id 6
     :niputuspvm "2024-07-01"
     :tyopaikan_normalisoitu_nimi "ohjaus_oy"
     :toimipiste_oid "1.2.246.562.10.12345678903"
@@ -218,12 +200,10 @@
     :koulutustoimija "1.2.246.562.10.346830761110"
     :jakso_alkupvm "2024-04-01"
     :ohjaaja_email "olli.ohjaaja@esimerkki.com"
-    :hankkimistapa_id 18
     :oppija_oid "1.2.246.562.24.12312312319"
     :rahoituskausi "2023-2024"
     :tutkintonimike "(\"12345\" \"23456\")"
-    :viimeinen_vastauspvm "2024-06-15"
-    :kasittelytila "ei_niputettu"}])
+    :viimeinen_vastauspvm "2024-05-15"}])
 
 (def expected-ddb-niput
   [{:tyopaikka                   "Ohjaus Oy"
@@ -486,22 +466,19 @@
     :opiskeluoikeus_oid
     :oppija_oid
     :hoks_id
-    :yksiloiva_tunniste
     :hankkimistapa_tyyppi
+    :yksiloiva_tunniste
     :tyopaikan_nimi
     :tyopaikan_ytunnus
     :jakso_loppupvm
     :ohjaaja_puhelinnumero
     :osaamisala
     :osa_aikaisuus
-    :tutkinnonosa_tyyppi
     :tpk-niputuspvm
     :tallennuspvm
     :oppilaitos
     :tunnus
     :ohjaaja_ytunnus_kj_tutkinto
-    :kasittelytila
-    :tutkinnonosa_id
     :niputuspvm
     :tyopaikan_normalisoitu_nimi
     :toimipiste_oid
@@ -519,6 +496,9 @@
 (def optional-jakso-keys
   #{:tutkinnonosa_koodi
     :tutkinnonosa_nimi
+    :tutkinnonosa_id
+    :kasittelytila
+    :tutkinnonosa_tyyppi
     :oppisopimuksen_perusta})
 
 (deftest test-handle-all-palautteet-waiting-for-vastaajatunnus!
@@ -545,14 +525,18 @@
                                "'vastaajatunnus_muodostettu'")])]
         (is (= (count palautteet) 5))
         (is (= (count ddb-jaksot) 5))
-        (is (= (map #(dissoc % :tunnus :request_id) ddb-jaksot)
-               expected-ddb-jaksot))
+        (test-utils/eq
+          (sort-by :yksiloiva_tunniste
+                   (map #(dissoc % :tunnus :request_id :hankkimistapa_id)
+                        ddb-jaksot))
+          (sort-by :yksiloiva_tunniste expected-ddb-jaksot))
         (is (= ddb-niput expected-ddb-niput))
         (is (= (count tapahtumat) 5))
         (is (= (set (map :arvo_tunniste palautteet))
                (set (map :tunnus ddb-jaksot))))
         (doseq [jakso ddb-jaksot]
-          (is (every? some? (map #(get jakso %) required-jakso-keys)))
+          (is (every? some? (map #(get jakso %) required-jakso-keys))
+              (map #(vector % (get jakso %)) required-jakso-keys))
           (is (empty? (s/difference
                         (set (keys jakso))
                         (set (concat required-jakso-keys

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -573,7 +573,8 @@
 
   (let [initial-palautteet (hoks-utils/palautteet)
         palautteet
-        (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]}
+        (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]
+              :hoks-id nil :palaute-id nil}
              (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec))
         tep-palaute (find-first
                       #(= (:jakson-yksiloiva-tunniste %) "4") palautteet)

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -512,7 +512,7 @@
     :tutkinnonosa_tyyppi
     :oppisopimuksen_perusta})
 
-(deftest test-handle-all-palautteet-waiting-for-vastaajatunnus!
+(deftest test-handle-tep-palautteet-on-heratepvm!
   (clear-ddb-jakso-table!)
   (clear-ddb-tpo-nippu-table!)
   (testing (str "create-and-save-arvo-vastaajatunnus-for-all-needed! "
@@ -526,7 +526,7 @@
                   arvo/create-jaksotunnus! hoks-utils/mock-create-jaksotunnus
                   date/now #(LocalDate/of 2024 6 30)]
       (is (= (:status (hoks-utils/create-hoks-in-the-past!)) 200))
-      (vt/handle-all-palautteet-waiting-for-vastaajatunnus! {})
+      (vt/handle-tep-palautteet-on-heratepvm! {})
       (let [palautteet (hoks-utils/palautteet-joissa-vastaajatunnus)
             ddb-jaksot (far/scan @ddb/faraday-opts @(ddb/tables :jakso) {})
             ddb-niput  (far/scan @ddb/faraday-opts @(ddb/tables :nippu) {})

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -19,6 +19,7 @@
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.tyoelama :as tep]
+            [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.test-utils :as test-utils]
             [oph.ehoks.utils.date :as date]
             [taoensso.faraday :as far])
@@ -534,7 +535,7 @@
                   arvo/create-jaksotunnus! hoks-utils/mock-create-jaksotunnus
                   date/now #(LocalDate/of 2024 6 30)]
       (is (= (:status (hoks-utils/create-hoks-in-the-past!)) 200))
-      (tep/handle-all-palautteet-waiting-for-vastaajatunnus! {})
+      (vt/handle-all-palautteet-waiting-for-vastaajatunnus! {})
       (let [palautteet (hoks-utils/palautteet-joissa-vastaajatunnus)
             ddb-jaksot (far/scan @ddb/faraday-opts @(ddb/tables :jakso) {})
             ddb-niput  (far/scan @ddb/faraday-opts @(ddb/tables :nippu) {})
@@ -561,12 +562,21 @@
   (clear-ddb-jakso-table!)
   (clear-ddb-tpo-nippu-table!)
   ; Test initialization
-  (is (= (:status (hoks-utils/create-hoks-in-the-past!)) 200))
+  (is (-> #(assoc-in % [:hankittavat-ammat-tutkinnon-osat 0
+                        :osaamisen-hankkimistavat 0
+                        :keskeytymisajanjaksot]
+                     [{:alku  (LocalDate/of 2023 11 1)
+                       :loppu (LocalDate/of 2023 11 16)}
+                      {:alku  (LocalDate/of 2024 02 5)}])
+          (hoks-utils/create-hoks-in-the-past!)
+          :status
+          (= 200)))
 
-  (let [initial-palautteet  (hoks-utils/palautteet)
-        tep-palaute (nth
-                      (palaute/get-tep-palautteet-waiting-for-vastaajatunnus!
-                        db/spec {:heratepvm (str (date/now))}) 1)
+  (let [initial-palautteet (hoks-utils/palautteet)
+        palautteet
+        (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]}
+             (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec))
+        tep-palaute (second palautteet)
         create-jaksotunnus-counter (atom 0)
         arvo-tunnukset (atom [])
         check-current-state-is-same-as-initial-state
@@ -595,8 +605,7 @@
             (is (thrown-with-msg?
                   ExceptionInfo
                   #"Arvo error"
-                  (tep/handle-palaute-waiting-for-vastaajatunnus!
-                    tep-palaute))))
+                  (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
           (check-current-state-is-same-as-initial-state))
         (testing "jakso sync to Herätepalvelu fails."
           (with-redefs [heratepalvelu/sync-jakso!*
@@ -604,8 +613,7 @@
             (is (thrown-with-msg?
                   ExceptionInfo
                   #"Failed to sync jakso"
-                  (tep/handle-palaute-waiting-for-vastaajatunnus!
-                    tep-palaute))))
+                  (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
           (check-current-state-is-same-as-initial-state))
         (testing "nippu sync to Herätepalvelu fails."
           (with-redefs
@@ -614,8 +622,7 @@
             (is (thrown-with-msg?
                   ExceptionInfo
                   #"Failed to sync TPO-nippu"
-                  (tep/handle-palaute-waiting-for-vastaajatunnus!
-                    tep-palaute))))
+                  (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
           (check-current-state-is-same-as-initial-state)))
       (let [counter-value-before-fn-call @create-jaksotunnus-counter]
         (testing (str "When getting other than \"404 Not found\" error from "
@@ -631,25 +638,21 @@
             (is (thrown-with-msg?
                   ExceptionInfo
                   #"Error while fetching opiskeluoikeus"
-                  (tep/handle-palaute-waiting-for-vastaajatunnus! tep-palaute)))
+                  (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)))
             (is (= counter-value-before-fn-call @create-jaksotunnus-counter)))
           (check-current-state-is-same-as-initial-state))
         (testing (str "When opiskeluoikeus for palaute is not found from from "
                       "Koski, `tila` for it should be marked as `ei_laheteta`. "
                       "No call to Arvo should be made.")
           (with-redefs [koski/get-opiskeluoikeus! (fn [_] nil)]
-            (tep/handle-palaute-waiting-for-vastaajatunnus! tep-palaute)
+            (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)
             (is (= counter-value-before-fn-call @create-jaksotunnus-counter))
             (is (= (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)}))
                    "ei_laheteta"))))
         (testing (str "Palaute should be marked as \"ei_laheteta\" when there "
                       "are one or more open keskeytymisajanjakso. No call to "
                       "Arvo should be made.")
-          (with-redefs [oht/get-keskeytymisajanjaksot!
-                        (fn [_ __] [{:alku  (LocalDate/of 2023 11 1)
-                                     :loppu (LocalDate/of 2023 11 16)}
-                                    {:alku  (LocalDate/of 2024 02 5)}])]
-            (tep/handle-palaute-waiting-for-vastaajatunnus! tep-palaute)
-            (is (= counter-value-before-fn-call @create-jaksotunnus-counter))
-            (is (= (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)}))
-                   "ei_laheteta"))))))))
+          (vt/handle-palaute-waiting-for-heratepvm! (first palautteet))
+          (is (= counter-value-before-fn-call @create-jaksotunnus-counter))
+          (is (= (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)}))
+                 "ei_laheteta")))))))

--- a/test/oph/ehoks/palaute_test.clj
+++ b/test/oph/ehoks/palaute_test.clj
@@ -8,8 +8,13 @@
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.oppijaindex-test :as oppijaindex-test]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.scheduler :as schedule]
             [oph.ehoks.utils.date :as date])
   (:import [java.time LocalDate]))
+
+(deftest test-scheduler-runs
+  (testing "Can be called"
+    (is (schedule/daily-actions! {}))))
 
 (deftest test-valid-herate-date?
   (testing "True if heratepvm is >= [rahoituskausi start year]-07-01"


### PR DESCRIPTION
## Kuvaus muutoksista

Tämä PR on osa EH-1732:sta: siinä toteutetaan se osa, että herätepäivänä haetaan HOKSin ja opiskeluoikeuden tiedot ja tarkistetaan niiden perusteella, kuuluuko palaute kohderyhmään.  Samalla siinä toteutetaan EH-1737:a sillä jos EH-1737:n tekisi ensin, joutuisi refaktoroimaan koodia joka tulee muuttumaan tyystin, mutta jos EH-1732:n tekee ensin, joutuu tekemään käytännössä samat muutokset kahteen eri koodiin (AMIS- ja TEP-vastaajatunnusten luontiin).

https://jira.eduuni.fi/browse/EH-1732
https://jira.eduuni.fi/browse/EH-1737

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
