### PR TITLE
EH-1732: handle the *-responsibilities config correctly

### DIFF
--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -100,4 +100,10 @@
                      {:update-expr update-expr :expr-attr-names attr-names
                       :expr-attr-vals attr-values})))
 
-(def sync-amis-herate! (partial sync-item! :amis))
+(defn sync-amis-herate!
+  "Put information for single opiskelijapalaute to herätepalvelu DDB."
+  [kyselyrecord]
+  (if-not (contains? (set (:heratepalvelu-responsibities config))
+                     :sync-amis-heratteet)
+    (log/info "sync-amis-herate!: configured to not write to DDB.")
+    (sync-item! :amis kyselyrecord)))

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -44,7 +44,8 @@
   "Luo kyselylinkin Arvoon."
   [kyselylinkki-params]
   (if-not (contains? (set (:arvo-responsibilities config)) :create-kyselytunnus)
-    (log/warn "create-kyselytunnus!: configured to not do anything")
+    (do (log/info "create-kyselytunnus!: configured to not call Arvo")
+        {:tunnus "<nothing>"})
     (call! :post "/vastauslinkki/v1"
            {:form-params kyselylinkki-params :content-type :json})))
 
@@ -85,23 +86,13 @@
      :request_id                request-id}))
 
 (defn create-jaksotunnus!
+  "Create new työelämäpalaute-vastaajatunnus in Arvo."
   [request]
-  (let [configured-to-call-arvo? (contains?
-                                   (set (:arvo-responsibilities config))
-                                   :create-jaksotunnus)
-        response (when configured-to-call-arvo?
-                   (call! :post "/tyoelamapalaute/v1/vastaajatunnus"
-                          {:form-params request :content-type :json}))]
-    (if (:tunnus response)
-      response
-      (throw (ex-info
-               (if configured-to-call-arvo?
-                 (format (str "No jaksotunnus got from Arvo with request %s. "
-                              "Response from Arvo was %s.")
-                         request response)
-                 "create-jaksotunnus!: configured to not do anything.")
-               {:type                     ::no-jaksotunnus-created
-                :configured-to-call-arvo? configured-to-call-arvo?})))))
+  (if-not (contains? (set (:arvo-responsibilities config)) :create-jaksotunnus)
+    (do (log/info "create-jaksotunnus!: configured to not call Arvo")
+        {:tunnus "<nothing>"})
+    (call! :post "/tyoelamapalaute/v1/vastaajatunnus"
+           {:form-params request :content-type :json})))
 
 (defn delete-jaksotunnus
   [tunnus]

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -89,6 +89,14 @@
 (def sync-jakso!*     (partial ddb/sync-item! :jakso))
 (def sync-tpo-nippu!* (partial ddb/sync-item! :nippu))
 
+(defn sync-jakso!
+  "Put information about single työelämäpalaute to herätepalvelu DDB."
+  [jaksorecord]
+  (if-not (contains? (set (:heratepalvelu-responsibities config))
+                     :sync-jakso-heratteet)
+    (log/info "sync-jakso!: configured to not write to DDB.")
+    (sync-jakso!* jaksorecord)))
+
 (defn sync-tpo-nippu!
   "Update the Herätepalvelu nipputable to have the same content for given heräte
   as palaute-backend has in its own database."

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -201,5 +201,5 @@
    :arvo-builder #'arvo/build-jaksotunnus-request-body
    :arvo-caller #'arvo/create-jaksotunnus!
    :heratepalvelu-builder #'build-jaksoherate-record-for-heratepalvelu
-   :heratepalvelu-caller #'heratepalvelu/sync-jakso!*
+   :heratepalvelu-caller #'heratepalvelu/sync-jakso!
    :extra-handlers [#'ensure-tpo-nippu!]})


### PR DESCRIPTION
## Kuvaus muutoksista

#669 broke heratepalvelu-responsibilities.  Fix that and also unify the way to handle Arvo calls not made.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
