### PR TITLE
EH-1732: if initial-state is based on opiskeluoikeus, handle later again

### DIFF
--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -182,17 +182,17 @@
    herate-date-field]
   (let [herate-date (get (or jakso hoks) herate-date-field)]
     (cond
-      (not (nil-or-unhandled? existing-palaute))
-      [nil (if jakso :yksiloiva-tunniste :id) :jo-lahetetty]
-
-      (not opiskeluoikeus)
-      [nil :opiskeluoikeus-oid :ei-loydy]
-
       (not herate-date)
       [nil herate-date-field :ei-ole]
 
       (not (valid-herate-date? herate-date))
       [:ei-laheteta herate-date-field :eri-rahoituskaudella]
+
+      (hoks/tuva-related? hoks)
+      [:ei-laheteta :tuva-opiskeluoikeus-oid :tuva-opiskeluoikeus]
+
+      (not opiskeluoikeus)
+      [nil :opiskeluoikeus-oid :ei-loydy]
 
       (not-any? suoritus/ammatillinen? (:suoritukset opiskeluoikeus))
       [:ei-laheteta :opiskeluoikeus-oid :ei-ammatillinen]
@@ -208,9 +208,6 @@
 
       (opiskeluoikeus/tuva? opiskeluoikeus)
       [:ei-laheteta :opiskeluoikeus-oid :tuva-opiskeluoikeus]
-
-      (hoks/tuva-related? hoks)
-      [:ei-laheteta :tuva-opiskeluoikeus-oid :tuva-opiskeluoikeus]
 
       (opiskeluoikeus/linked-to-another? opiskeluoikeus)
       [:ei-laheteta :opiskeluoikeus-oid :liittyva-opiskeluoikeus])))

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -43,17 +43,19 @@
   opiskelijapalautekysely should be initiated.  Returns the initial state
   of the palaute (or nil if it cannot be formed at all), the field the
   decision was based on, and the reason for picking that state."
-  [{:keys [hoks] :as ctx} kysely-type]
+  [{:keys [hoks existing-palaute] :as ctx} kysely-type]
   (let [herate-basis (herate-date-basis kysely-type)]
-    (or
-      (palaute/initial-palaute-state-and-reason-if-not-kohderyhma
-        ctx herate-basis)
-      (cond
-        (not (:osaamisen-hankkimisen-tarve hoks))
-        [:ei-laheteta :osaamisen-hankkimisen-tarve :ei-ole]
+    (cond
+      (not (palaute/nil-or-unhandled? existing-palaute))
+      [nil herate-basis :jo-lahetetty]
 
-        :else
-        [:odottaa-kasittelya herate-basis :hoks-tallennettu]))))
+      (not (:osaamisen-hankkimisen-tarve hoks))
+      [:ei-laheteta :osaamisen-hankkimisen-tarve :ei-ole]
+
+      :else
+      (or (palaute/initial-palaute-state-and-reason-if-not-kohderyhma
+            ctx herate-basis)
+          [:odottaa-kasittelya herate-basis :hoks-tallennettu]))))
 
 (def kysely-kasittely-field-mapping
   {:aloituskysely :aloitusherate_kasitelty

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -147,8 +147,10 @@
                 :tx              tx
                 :koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
                 :existing-palaute (existing-palaute! tx ctx kysely-type))
-          [state field reason]
+          [proposed-state field reason]
           (initial-palaute-state-and-reason ctx kysely-type)
+          state
+          (if (= field :opiskeluoikeus-oid) :odottaa-kasittelya proposed-state)
           lisatiedot (map-vals str (select-keys hoks [field]))]
       (log/info "Initial state for" kysely-type "for HOKS" (:id hoks)
                 "will be" (or state :ei-luoda-ollenkaan)

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -120,8 +120,10 @@
                      (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
                        tx {:hoks-id            (:id hoks)
                            :yksiloiva-tunniste (:yksiloiva-tunniste jakso)}))
-          [state field reason]
+          [proposed-state field reason]
           (initial-palaute-state-and-reason ctx :ohjaajakysely)
+          state
+          (if (= field :opiskeluoikeus-oid) :odottaa-kasittelya proposed-state)
           lisatiedot (map-vals str (select-keys (merge jakso hoks) [field]))]
       (log/info "Initial state for jakso" (:yksiloiva-tunniste jakso)
                 "of HOKS" (:id hoks) "will be" (or state :ei-luoda-ollenkaan)

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -279,10 +279,11 @@
             "valmistuneet" :osaamisen-saavuttamisen-pvm
             "2024-02-05"   "2024-03-05"))
 
-        (testing "doesn't initiate kysely if opiskeluoikeus is not found"
-          (are [kysely-type] (nil? (op/initiate-if-needed!
-                                     (assoc ctx :opiskeluoikeus nil)
-                                     kysely-type))
+        (testing "if opiskeluoikeus is not found, will wait for heratepvm"
+          (are [kysely-type]
+               (= :odottaa-kasittelya
+                  (op/initiate-if-needed! (assoc ctx :opiskeluoikeus nil)
+                                          kysely-type))
             :aloituskysely :paattokysely))
 
         (testing "doesn't initiate kysely if one already exists for HOKS"


### PR DESCRIPTION
## Kuvaus muutoksista

This is the change agreed on in the team about handling palautteet based on handling date (käsittelypäivä) information.  Because opiskeluoikeus data is external and can change without notification to eHOKS, we put palautteet in :odottaa-kasittelya state when the verdict is based on opiskeluoikeus fields.  This causes them to be handled on their heratepvm (or later), using the information in Koski on that date.  This means that the opiskeluoikeus information can be corrected during this time.

When heratepvm has gone, the only way to retrigger palaute handling is to resave the HOKS.  This usually makes sense because the only way to change the heratepvm is also to resave.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
