### PR TITLE
EH-1704: create tapahtuma for existing-palaute when it prevents new palaute

### DIFF
--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -155,10 +155,12 @@
       (log/info "Initial state for" kysely-type "for HOKS" (:id hoks)
                 "will be" (or state :ei-luoda-ollenkaan)
                 "because of" reason "in" field)
-      (when state
+      (if state
         (initiate!
           (assoc ctx :state state :reason reason :lisatiedot lisatiedot)
-          kysely-type))
+          kysely-type)
+        (when (:existing-palaute ctx)
+          (tapahtuma/build-and-insert! ctx reason lisatiedot)))
       state)))
 
 (defn initiate-every-needed!

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -130,11 +130,13 @@
       (log/info "Initial state for jakso" (:yksiloiva-tunniste jakso)
                 "of HOKS" (:id hoks) "will be" (or state :ei-luoda-ollenkaan)
                 "because of" reason "in" field)
-      (when state
+      (if state
         (->> (build! ctx state)
              (palaute/upsert! tx)
              (tapahtuma/build-and-insert! ctx state reason lisatiedot))
-        state))))
+        (when (:existing-palaute ctx)
+          (tapahtuma/build-and-insert! ctx reason lisatiedot)))
+      state)))
 
 (defn initiate-all-uninitiated!
   "Takes a `hoks` and `opiskeluoikeus` and initiates tyoelamapalaute for all


### PR DESCRIPTION
## Kuvaus muutoksista

Tää on yksi case, jossa on tähän asti unohtunut luoda tapahtuma palautekantaan: kun olemassa oleva palaute estää uuden palautteen muodostamisen (tai vanhan päivittämisen).

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
