### PR TITLE
EH-1798: fix exception and dummies in vastaajatunnus handling

### DIFF
--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -45,7 +45,7 @@
   [kyselylinkki-params]
   (if-not (contains? (set (:arvo-responsibilities config)) :create-kyselytunnus)
     (do (log/info "create-kyselytunnus!: configured to not call Arvo")
-        {:tunnus "<nothing>"})
+        {:tunnus (str "<dummy-" (java.util.UUID/randomUUID) ">")})
     (call! :post "/vastauslinkki/v1"
            {:form-params kyselylinkki-params :content-type :json})))
 
@@ -90,7 +90,7 @@
   [request]
   (if-not (contains? (set (:arvo-responsibilities config)) :create-jaksotunnus)
     (do (log/info "create-jaksotunnus!: configured to not call Arvo")
-        {:tunnus "<nothing>"})
+        {:tunnus (str "<dummy-" (java.util.UUID/randomUUID) ">")})
     (call! :post "/tyoelamapalaute/v1/vastaajatunnus"
            {:form-params request :content-type :json})))
 

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -7,9 +7,14 @@
 (defn daily-actions!
   "Run all palaute checks that need to be run on a daily basis."
   [opts]
-  (palaute/handle-palautteet-waiting-for-heratepvm!
-    ["aloittaneet" "valmistuneet" "osia_suorittaneet"
-     "tyopaikkajakson_suorittaneet"])
+  (log/info "Commencing palaute daily actions.")
+  (try
+    (log/info "Handling palautteet that have reached their heratepvm.")
+    (palaute/handle-palautteet-waiting-for-heratepvm!
+      ["aloittaneet" "valmistuneet" "osia_suorittaneet"
+       "tyopaikkajakson_suorittaneet"])
+    (catch Exception e
+      (log/error e "Unhandled exception in daily-actions!.")))
   true)
 
 (defn run-scheduler!

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -49,9 +49,12 @@
         (if (:jakson-yksiloiva-tunniste existing-palaute)
           arvo/delete-jaksotunnus arvo/delete-kyselytunnus)]
     (log/infof ex "Handling exception in tunnus handling")
-    (when tunnus
-      (log/infof "Trying to delete jaksotunnus `%s` from Arvo" tunnus)
-      (tunnus-cleanup-handler tunnus))
+    (when (and tunnus (not (.startsWith ^String tunnus "<dummy-")))
+      (try
+        (log/infof "Trying to delete vastaajatunnus `%s` from Arvo" tunnus)
+        (tunnus-cleanup-handler tunnus)
+        (catch Exception e
+          (log/error e "While trying to clean up tunnus from Arvo"))))
     (case ex-type
       (::koski/opiskeluoikeus-not-found ::arvossa-ei-kyselya)
       (do (log/warnf "%s. Setting `tila` to `ei_laheteta` for palaute `%d`."

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -81,7 +81,10 @@
         (tapahtuma/build-and-insert!
           ctx ex-type {:errormsg (ex-message ddb-ex)
                        :body     (ex-data ddb-ex)})
-        (heratepalvelu/delete-jakso-herate! existing-palaute))
+        (try
+          (heratepalvelu/delete-jakso-herate! existing-palaute)
+          (catch Exception e
+            (log/error e "While cleaning up jakso from Herätepalvelu"))))
 
       (let [cause-ex (ex-cause ex)]
         (log/error "Unknown exception while processing palaute "


### PR DESCRIPTION
## Kuvaus muutoksista

-    muodostetaan pseudotunnukset uniikkeita, mutta esim. dummy-etuliitteellä.
-    ei yritetä poistaa pseudotunnuksia Arvosta.
-    käsitellään poikkeukset myös handle-exceptionissa
-    suojataan daily-actions! poikkeuskäsittelijällä, ettei se kaada scheduleria
-    (Tehdään lokiviesti daily-actions!in alkuun)

https://jira.eduuni.fi/browse/EH-1798

TODO: PR:iin liittyvä Jira-tiketti (tunniste ja linkki)

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
