### PR TITLE
EH-1798: don't reconstruct HOKSen from DB for each palaute

### DIFF
--- a/src/oph/ehoks/external/koski.clj
+++ b/src/oph/ehoks/external/koski.clj
@@ -5,6 +5,7 @@
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
             [oph.ehoks.external.oph-url :as u]
+            [oph.ehoks.utils :as utils]
             [ring.util.http-status :as status])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -14,16 +15,9 @@
   (update values :henkilö select-keys
           [:oid :hetu :syntymäaika :etunimet :kutsumanimi :sukunimi]))
 
-(defn- with-fifo-ttl-cache
-  [f ttl-millis fifo-threshold seed]
-  (let [cache (-> {}
-                  (cache/fifo-cache-factory :threshold fifo-threshold)
-                  (cache/ttl-cache-factory :ttl ttl-millis))]
-    (memo/memoizer f cache seed)))
-
 (def get-oppijat-opiskeluoikeudet
   "Palauttaa annettujen oppijoiden kaikki opiskeluoikeudet"
-  (with-fifo-ttl-cache
+  (utils/with-fifo-ttl-cache
     (fn [oppija-oids]
       (:body
         (c/with-api-headers
@@ -61,7 +55,7 @@
 
 (def get-opiskeluoikeus-info-raw
   "Get opiskeluoikeus info"
-  (with-fifo-ttl-cache
+  (utils/with-fifo-ttl-cache
     (fn [oid]
       (:body
         (c/with-api-headers

--- a/src/oph/ehoks/utils.clj
+++ b/src/oph/ehoks/utils.clj
@@ -1,5 +1,7 @@
 (ns oph.ehoks.utils
   (:require [medley.core :refer [dissoc-in map-keys]]
+            [clojure.core.cache :as cache]
+            [clojure.core.memoize :as memo]
             [clojure.string]))
 
 (defn apply-when
@@ -32,6 +34,13 @@
     (if-let [value (get-in m sks)]
       (dissoc-in (assoc-in m dks value) sks)
       m)))
+
+(defn with-fifo-ttl-cache
+  [f ttl-millis fifo-threshold seed]
+  (let [cache (-> {}
+                  (cache/fifo-cache-factory :threshold fifo-threshold)
+                  (cache/ttl-cache-factory :ttl ttl-millis))]
+    (memo/memoizer f cache seed)))
 
 (defn remove-nils
   "Return same map, but without keys pointing to nil values"

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -12,9 +12,9 @@
             [oph.ehoks.external.organisaatio :as organisaatio]
             [oph.ehoks.external.organisaatio-test :as organisaatio-test]
             [oph.ehoks.heratepalvelu :as heratepalvelu]
+            [oph.ehoks.hoks :as hoks]
             [oph.ehoks.hoks-test :as hoks-test]
             [oph.ehoks.hoks.hoks-test-utils :as hoks-utils]
-            [oph.ehoks.hoks.osaamisen-hankkimistapa :as oht]
             [oph.ehoks.opiskeluoikeus-test :as oo-test]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
@@ -591,6 +591,8 @@
           (is (= @arvo-tunnukset [])))]
     (with-redefs [organisaatio/get-organisaatio!
                   hoks-utils/mock-get-organisaatio!
+                  vt/get-hoks-by-id!
+                  hoks/get-by-id
                   koski/get-opiskeluoikeus-info-raw
                   hoks-utils/mock-get-opiskeluoikeus!
                   arvo/create-jaksotunnus!


### PR DESCRIPTION
## Kuvaus muutoksista

Multiple palautteet may share the same HOKS they come from.  Because fetching the HOKS from DB is quite a heavy operation, when handling palautteet that have reached their heratepvm, cache the last HOKS in case the next palaute is for the same HOKS.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
