### PR TITLE
EH-1711: mark all palautteet as 'heratepalvelussa' just once

### DIFF
--- a/src/db/migration/V1_1741784392017__Add_heratepalvelu_palautetila.sql
+++ b/src/db/migration/V1_1741784392017__Add_heratepalvelu_palautetila.sql
@@ -1,0 +1,2 @@
+ALTER TYPE palautetilat
+ADD VALUE IF NOT EXISTS 'heratepalvelussa';

--- a/src/db/migration/V1_1741785725557__Mark_palautteet_as_heratepalvelussa.sql
+++ b/src/db/migration/V1_1741785725557__Mark_palautteet_as_heratepalvelussa.sql
@@ -1,0 +1,10 @@
+UPDATE palautteet
+SET tila = 'heratepalvelussa'
+WHERE tila in (
+	'ei_laheteta',
+	'odottaa_kasittelya',
+	'kysely_muodostettu',
+	'vastaajatunnus_muodostettu')
+AND (kyselytyyppi in ('aloittaneet', 'valmistuneet', 'osia_suorittaneet')
+	OR (kyselytyyppi = 'tyopaikkajakson_suorittaneet'
+		AND heratepvm <= now()));


### PR DESCRIPTION
## Kuvaus muutoksista

Jotta herätepalveluun jo lähetettyjä herätteitä ei käsiteltäisi uudelleen, merkitään ne kaikki tilaan "herätepalvelussa".  Tämä tila aiheuttaa sen, että (unhandled? palaute) on epätosi, jolloin palaute käsitellään aina kuin se olisi jo lähetetty (eli tallennetaan vain tieto, että HOKS tallennettiin jälleen mutta tila ei muutu).

Asennusvaiheessa pitää sitten huolehtia, että :heratepalvelu-responsibities ja :arvo-responsibilities päivitetään samaan aikaan, sillä periaatteessa tässä merkitään muistiin sitä että mitkä palautteet on muodostettu silloin kun :heratepalvelu-responsibities ja :arvo-responsibilities olivat vielä tyhjiä eli konffattu pois päältä.

Vanha tila on tallessa palaute_tapahtumat-taulussa, jos sille on vielä tarvetta.

Pitäisiköhän tälle tehdä testejä ja jos, niin minkälaisia?

https://jira.eduuni.fi/browse/EH-1711

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
