### PR TITLE
EH-1804: prevent handling of palautteet already in Herätepalvelu

### DIFF
--- a/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
+++ b/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
@@ -34,3 +34,4 @@ WHERE p.kyselytyyppi IN ('aloittaneet', 'valmistuneet', 'osia_suorittaneet')
   AND h.oppija_oid = ?
   AND p.voimassa_alkupvm <= now()
   AND p.kyselylinkki IS NOT NULL
+  AND p.deleted_at IS NULL

--- a/resources/dev/demo-data/jaksotunnus-schema.json
+++ b/resources/dev/demo-data/jaksotunnus-schema.json
@@ -12,6 +12,10 @@
       "AttributeType": "N"
     },
     {
+      "AttributeName": "hoks_id",
+      "AttributeType": "N"
+    },
+    {
       "AttributeName": "jakso_loppupvm",
       "AttributeType": "S"
     },
@@ -34,6 +38,10 @@
     {
       "AttributeName": "tunnus",
       "AttributeType": "S"
+    },
+    {
+      "AttributeName": "yksiloiva_tunniste",
+      "AttributeType": "S"
     }
   ],
   "GlobalSecondaryIndexes": [
@@ -51,6 +59,22 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
+      }
+    },
+    {
+      "IndexName": "yksiloivaTunnisteIndex",
+      "KeySchema": [
+	{
+	  "AttributeName": "hoks_id",
+	  "KeyType": "HASH"
+	},
+	{
+	  "AttributeName": "yksiloiva_tunniste",
+	  "KeyType": "RANGE"
+	}
+      ],
+      "Projection": {
+	"ProjectionType": "ALL"
       }
     },
     {

--- a/resources/dev/src/oph/ehoks/dev_server.clj
+++ b/resources/dev/src/oph/ehoks/dev_server.clj
@@ -97,7 +97,7 @@
   (log/info "Not safe for production or public environments.")
   (populate-oppijaindex)
   (when (= app-name "ehoks-palaute")
-    (scheduler/run-scheduler! (Instant/now) (Duration/ofSeconds 60)))
+    (scheduler/run-schedulers! (Instant/now) (Duration/ofSeconds 60)))
   (jetty/run-jetty app
                    {:port (:port config)
                     :join? false

--- a/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
+++ b/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
@@ -1,0 +1,1 @@
+UPDATE palautteet SET deleted_at=now();  -- yep, every palaute

--- a/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
+++ b/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
@@ -1,3 +1,7 @@
+-- This migration might need to be done again when we actually enable
+-- Arvo calls and Herätepalvelu sync for palaute-backend.  It depends on
+-- the perceived quality of palautteet bookkeeping after its
+-- installation.
 UPDATE palautteet
 SET deleted_at=now()
 WHERE deleted_at IS NULL;  -- yep, every palaute

--- a/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
+++ b/src/db/migration/V1_1742311147193__Mark_old_palautteet_as_deleted.sql
@@ -1,1 +1,3 @@
-UPDATE palautteet SET deleted_at=now();  -- yep, every palaute
+UPDATE palautteet
+SET deleted_at=now()
+WHERE deleted_at IS NULL;  -- yep, every palaute

--- a/src/db/migration/V1_1742370906697__Add_palautetila_heratepalvelussa.sql
+++ b/src/db/migration/V1_1742370906697__Add_palautetila_heratepalvelussa.sql
@@ -1,0 +1,1 @@
+ALTER TYPE palautetilat ADD VALUE IF NOT EXISTS 'heratepalvelussa';

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -111,3 +111,11 @@
                      :sync-amis-heratteet)
     (log/info "sync-amis-herate!: configured to not write to DDB.")
     (sync-item! :amis kyselyrecord)))
+
+(defn get-jakso-by-hoks-id-and-yksiloiva-tunniste!
+  "Get työelämäjakso from DDB."
+  [hoks-id yksiloiva-tunniste]
+  (far/query @faraday-opts @(tables :jakso)
+             {:hoks_id [:eq hoks-id]
+              :yksiloiva_tunniste [:eq yksiloiva-tunniste]}
+             {:index "yksiloivaTunnisteIndex"}))

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -65,15 +65,19 @@
 (defn jaksot [] (far/scan @faraday-opts @(tables :jakso) {}))
 (defn niput  [] (far/scan @faraday-opts @(tables :nippu) {}))
 
-(defn get-item!
-  "A wrapper for `taoensso.faraday/get-item`."
-  [table prim-kvs]
-  (far/get-item @faraday-opts @(tables table) prim-kvs))
+(defn table-handler [operation]
+  (fn [table record-or-keys]
+    (operation @faraday-opts
+               @(tables table)
+               (select-keys record-or-keys (table-keys table)))))
 
-(defn delete-item!
+(def get-item!
+  "A wrapper for `taoensso.faraday/get-item`."
+  (table-handler far/get-item))
+
+(def delete-item!
   "A wrapper for `taoensso.faraday/delete-item`."
-  [table prim-kvs]
-  (far/delete-item @faraday-opts @(tables table) prim-kvs))
+  (table-handler far/delete-item))
 
 (defn sync-item!
   "Does a partial upsert on item in DDB: if the item doesn't exist,

--- a/src/oph/ehoks/db/sql.clj
+++ b/src/oph/ehoks/db/sql.clj
@@ -23,7 +23,7 @@
   a SET clause (part of UPDATE command) as a string, e.g.,
   \"set key1 = 1,key2 = 'val2'\" when `params` is {:key1 1 :key2 \"val2\"})`."
   [params options]
-  (str "set "
+  (str "set updated_at = now(), "
        (str/join "," (for [[field _] params]
                        (-> (utils/to-underscore-str field)
                            (identifier-param-quote options)

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -92,7 +92,9 @@ returning *
 -- :name get-by-hoks-id-and-kyselytyypit! :? :*
 -- :doc Get opiskelijapalaute information by HOKS ID and kyselytyyppi
 select * from palautteet
-where hoks_id = :hoks-id and kyselytyyppi in (:v*:kyselytyypit)
+where hoks_id = :hoks-id
+  and kyselytyyppi in (:v*:kyselytyypit)
+  and deleted_at is null
 
 -- :name get-by-kyselytyyppi-oppija-and-koulutustoimija! :? :*
 -- :doc Get kyselyt by kyselytyyppi, oppija OID, and koulutustoimija.
@@ -102,6 +104,8 @@ join hoksit h on (h.id = p.hoks_id)
 where h.oppija_oid = :oppija-oid  -- FIXME: should probably have deleted_at cond
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and (p.koulutustoimija = :koulutustoimija or (:koulutustoimija)::text is null)
+  and p.deleted_at is null
+  and h.deleted_at is null
 
 -- :name get-by-id! :? :1
 -- :doc Get palaute by palaute id.
@@ -111,5 +115,7 @@ where id = :id
 -- :name get-by-hoks-id-and-yksiloiva-tunniste! :? :1
 -- :doc Get palaute information for työpaikkajakso by HOKS ID and yksiloiva
 --      tunniste.
-select * from palautteet
-where hoks_id = :hoks-id AND jakson_yksiloiva_tunniste = :yksiloiva-tunniste
+SELECT * FROM palautteet
+WHERE hoks_id = :hoks-id
+  AND jakson_yksiloiva_tunniste = :yksiloiva-tunniste
+  AND deleted_at is null

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -114,7 +114,7 @@ where	id not in (
 	select hoks_id from palautteet where deleted_at is null
 )
 and	deleted_at is null
-order by id asc
+order by id desc  -- process newer HOKSes first
 limit	:batchsize
 
 -- :name get-by-id! :? :1

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -101,11 +101,21 @@ where hoks_id = :hoks-id
 select p.id, p.heratepvm, p.tila
 from palautteet p
 join hoksit h on (h.id = p.hoks_id)
-where h.oppija_oid = :oppija-oid  -- FIXME: should probably have deleted_at cond
+where h.oppija_oid = :oppija-oid
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and (p.koulutustoimija = :koulutustoimija or (:koulutustoimija)::text is null)
   and p.deleted_at is null
   and h.deleted_at is null
+
+-- :name get-hokses-without-palaute! :? :*
+-- :doc List all HOKSes that do not have any palaute records.
+select	id from hoksit
+where	id not in (
+	select hoks_id from palautteet where deleted_at is null
+)
+and	deleted_at is null
+order by id asc
+limit	:batchsize
 
 -- :name get-by-id! :? :1
 -- :doc Get palaute by palaute id.

--- a/src/oph/ehoks/db/sql/palautetapahtuma.sql
+++ b/src/oph/ehoks/db/sql/palautetapahtuma.sql
@@ -21,5 +21,7 @@ returning id
 select p.kyselytyyppi, p.heratepvm, pt.*
 from palaute_tapahtumat pt
 join palautteet p on (pt.palaute_id = p.id)
-where p.hoks_id = :hoks-id and p.kyselytyyppi in (:v*:kyselytyypit)
+where p.hoks_id = :hoks-id
+  and p.kyselytyyppi in (:v*:kyselytyypit)
+  and p.deleted_at is null
 

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -105,19 +105,16 @@
   (if-not (contains? (set (:heratepalvelu-responsibities config))
                      :sync-jakso-heratteet)
     (log/warn "sync-tpo-nippu!: configured to not do anything")
-    (let [tunnisteet (select-keys nippu [:ohjaaja_ytunnus_kj_tutkinto
-                                         :niputuspvm])]
-      (try
-        (if (ddb/get-item! :nippu tunnisteet)
-          (log/infof "Nippu `%s` already exists" tunnisteet)
-          (sync-tpo-nippu!* nippu))
-        (catch Exception e
-          (throw (ex-info (format (str "Failed to sync TPO-nippu with "
-                                       "tunnisteet %s to Herätepalvelu")
-                                  tunnisteet)
-                          {:type        ::tpo-nippu-sync-failed
-                           :arvo-tunnus tunnus}
-                          e)))))))
+    (try
+      (if (ddb/get-item! :nippu nippu)
+        (log/infof "Nippu already exists:" nippu)
+        (sync-tpo-nippu!* nippu))
+      (catch Exception e
+        (throw (ex-info (str "Failed to sync TPO-nippu to Herätepalvelu: "
+                             nippu)
+                        {:type        ::tpo-nippu-sync-failed
+                         :arvo-tunnus tunnus}
+                        e))))))
 
 (defn delete-jakso-herate!
   [tep-palaute]

--- a/src/oph/ehoks/main.clj
+++ b/src/oph/ehoks/main.clj
@@ -10,8 +10,7 @@
             [oph.ehoks.logging.audit :as audit]
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.palaute.scheduler :as scheduler]
-            [ring.adapter.jetty :as jetty])
-  (:import (java.time Instant LocalTime ZonedDateTime ZoneId Period)))
+            [ring.adapter.jetty :as jetty]))
 
 (defn has-arg?
   "Is arg present"
@@ -51,12 +50,7 @@
       (when audit/enabled?
         (audit/start-heartbeat!))
       (when (= app-name "ehoks-palaute")
-        (scheduler/run-scheduler! (-> (LocalTime/of 6 0 0)
-                                      (.adjustInto
-                                        (ZonedDateTime/now
-                                          (ZoneId/of "Europe/Helsinki")))
-                                      Instant/from)
-                                  (Period/ofDays 1)))
+        (scheduler/run-schedulers!))
       (jetty/run-jetty hoks-app {:port (:port config)
                                  :join? true
                                  :async? true}))))

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -181,10 +181,13 @@
   "Partial function; returns initial state, field causing it, and why the
   field causes the initial state - but only if the palaute is not to be
   collected because it's not part of kohderyhmä; otherwise returns nil."
-  [{:keys [hoks opiskeluoikeus jakso existing-palaute] :as ctx}
+  [{:keys [hoks opiskeluoikeus jakso existing-ddb-herate
+           existing-palaute] :as ctx}
    herate-date-field]
   (let [herate-date (get (or jakso hoks) herate-date-field)]
     (cond
+      ;; do more efficient checks first
+
       (not herate-date)
       [nil herate-date-field :ei-ole]
 
@@ -193,6 +196,12 @@
 
       (hoks/tuva-related? hoks)
       [:ei-laheteta :tuva-opiskeluoikeus-oid :tuva-opiskeluoikeus]
+
+      ;; this is for the transition period with herätepalvelu
+      (and existing-ddb-herate (seq @existing-ddb-herate))
+      [:heratepalvelussa herate-date-field :heratepalvelun-vastuulla]
+
+      ;; order dependency: :opiskeluoikeus-oid rules should come last
 
       (not opiskeluoikeus)
       [nil :opiskeluoikeus-oid :ei-loydy]

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -188,9 +188,6 @@
     (cond
       ;; do more efficient checks first
 
-      (not herate-date)
-      [nil herate-date-field :ei-ole]
-
       (not (valid-herate-date? herate-date))
       [:ei-laheteta herate-date-field :eri-rahoituskaudella]
 

--- a/src/oph/ehoks/palaute/initiation.clj
+++ b/src/oph/ehoks/palaute/initiation.clj
@@ -1,0 +1,22 @@
+(ns oph.ehoks.palaute.initiation
+  (:require [clojure.tools.logging :as log]
+            [oph.ehoks.external.organisaatio :as organisaatio]
+            [oph.ehoks.palaute.opiskelija :as op]
+            [oph.ehoks.palaute.tyoelama :as tep]))
+
+(defn initiate-all-palautteet!
+  "Initialise all palautteet (opiskelija & tyoelama) that should be."
+  [ctx]
+  (try
+    (op/initiate-if-needed! ctx :aloituskysely)
+    (op/initiate-if-needed! ctx :paattokysely)
+    (tep/initiate-all-uninitiated! ctx)
+    (catch clojure.lang.ExceptionInfo e
+      (if (= ::organisaatio/organisation-not-found (:type (ex-data e)))
+        (throw (ex-info (str "HOKS contains an unknown organisation"
+                             (:organisation-oid (ex-data e)))
+                        (assoc (ex-data e) :type ::disallowed-update)))
+        (log/error e "exception in heräte initiation with" (ex-data e))))
+    (catch Exception e
+      (log/error e "exception in heräte initiation"))))
+

--- a/src/oph/ehoks/palaute/initiation.clj
+++ b/src/oph/ehoks/palaute/initiation.clj
@@ -1,6 +1,10 @@
 (ns oph.ehoks.palaute.initiation
   (:require [clojure.tools.logging :as log]
+            [oph.ehoks.db :as db]
+            [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.organisaatio :as organisaatio]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.opiskelija :as op]
             [oph.ehoks.palaute.tyoelama :as tep]))
 
@@ -20,3 +24,24 @@
     (catch Exception e
       (log/error e "exception in heräte initiation"))))
 
+(defn initiate-all-palautteet-for-hoks-ids!
+  "Call initiate-all-palautteet! for the hokses with hoks-id's"
+  [hoks-ids]
+  (doseq [hoks-id hoks-ids]
+    (log/info "initiate-all-palautteet-for-hoks-ids!: HOKS id" hoks-id)
+    (let [hoks (hoks/get-by-id hoks-id)
+          opiskeluoikeus (koski/get-opiskeluoikeus! (:opiskeluoikeus-oid hoks))
+          ctx {:hoks hoks :opiskeluoikeus opiskeluoikeus}]
+      (initiate-all-palautteet! ctx))))
+
+(defn reinit-palautteet-for-uninitiated-hokses!
+  "Fetch <batchsize> HOKSes from DB that do not have corresponding palaute
+  records, and initiate palautteet for them to make sure that their
+  palautteet will be handled when they are due (their heratepvm)."
+  [batchsize]
+  (log/info "reinit-palautteet-for-uninitiated-hokses!: making batch of"
+            batchsize "HOKSes")
+  (->> {:batchsize batchsize}
+       (palaute/get-hokses-without-palaute! db/spec)
+       (map :id)
+       (initiate-all-palautteet-for-hoks-ids!)))

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -49,6 +49,10 @@
       (not (palaute/nil-or-unhandled? existing-palaute))
       [nil herate-basis :jo-lahetetty]
 
+      (and (:hoks-id existing-palaute)
+           (not= (:hoks-id existing-palaute) (:id hoks)))
+      [nil :id :ei-palautteen-alkuperainen-hoks]
+
       (not (get hoks herate-basis))
       [nil herate-basis :ei-ole]
 

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -64,7 +64,7 @@
 (defn existing-palaute!
   "Returns an existing palaute if one already exists for `kysely-type` and
   for rahoituskausi corresponding to herate date."
-  [tx {:keys [hoks koulutustoimija] :as ctx} kysely-type]
+  [{:keys [tx hoks koulutustoimija] :as ctx} kysely-type]
   (let [rahoituskausi (palaute/rahoituskausi
                         (get hoks (herate-date-basis kysely-type)))
         kyselytyypit  (case kysely-type
@@ -132,6 +132,25 @@
          :puhelinnumero      (:puhelinnumero hoks)
          :alkupvm            (str heratepvm)}))))
 
+(defn enrich-ctx!
+  "Add information needed by opiskelijapalaute initiation into context."
+  [{:keys [hoks opiskeluoikeus tx] :as ctx} kysely-type]
+  (let [koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
+        heratepvm (get hoks (herate-date-basis kysely-type))
+        toimija-oppija (str koulutustoimija "/" (:oppija-oid hoks))
+        kyselytyyppi (translate-kyselytyyppi
+                       (palaute/kyselytyyppi kysely-type opiskeluoikeus))
+        rahoituskausi (palaute/rahoituskausi heratepvm)
+        tyyppi-kausi (str kyselytyyppi "/" rahoituskausi)
+        ddb-key {:toimija_oppija toimija-oppija :tyyppi_kausi tyyppi-kausi}
+        existing-palaute-ctx (assoc ctx :koulutustoimija koulutustoimija)]
+    (assoc existing-palaute-ctx
+           :tapahtumatyyppi :hoks-tallennus
+           :existing-ddb-key ddb-key
+           :existing-ddb-herate (delay (dynamodb/get-item! :amis ddb-key))
+           :existing-palaute (existing-palaute!
+                               existing-palaute-ctx kysely-type))))
+
 (defn initiate-if-needed!
   "Saves heräte data required for opiskelijapalautekysely
   (`:aloituskysely` or `:paattokysely`) to database and sends it to
@@ -141,12 +160,7 @@
   [{:keys [hoks opiskeluoikeus] :as ctx} kysely-type]
   (jdbc/with-db-transaction
     [tx db/spec {:isolation :serializable}]
-    (let [ctx (assoc
-                ctx
-                :tapahtumatyyppi :hoks-tallennus
-                :tx              tx
-                :koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)
-                :existing-palaute (existing-palaute! tx ctx kysely-type))
+    (let [ctx (enrich-ctx! (assoc ctx :tx tx) kysely-type)
           [proposed-state field reason]
           (initial-palaute-state-and-reason ctx kysely-type)
           state

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -49,6 +49,11 @@
       (not (palaute/nil-or-unhandled? existing-palaute))
       [nil herate-basis :jo-lahetetty]
 
+      (not (get hoks herate-basis))
+      [nil herate-basis :ei-ole]
+
+      ;; order dependency: nil rules must come first
+
       (not (:osaamisen-hankkimisen-tarve hoks))
       [:ei-laheteta :osaamisen-hankkimisen-tarve :ei-ole]
 

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -1,7 +1,8 @@
 (ns oph.ehoks.palaute.scheduler
   (:require [chime.core :as chime]
             [clojure.tools.logging :as log]
-            [oph.ehoks.palaute.vastaajatunnus :as palaute])
+            [oph.ehoks.palaute.initiation :as palaute]
+            [oph.ehoks.palaute.vastaajatunnus :as vt])
   (:import (java.lang AutoCloseable)
            (java.time Instant LocalTime ZonedDateTime ZoneId Period Duration)))
 
@@ -11,7 +12,7 @@
   (log/info "Commencing palaute daily actions.")
   (try
     (log/info "Handling palautteet that have reached their heratepvm.")
-    (palaute/handle-palautteet-waiting-for-heratepvm!
+    (vt/handle-palautteet-waiting-for-heratepvm!
       ["aloittaneet" "valmistuneet" "osia_suorittaneet"
        "tyopaikkajakson_suorittaneet"])
     (catch Exception e
@@ -24,7 +25,7 @@
   initiate all palautteet for those HOKSes."
   [opts]
   (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
-  )
+  (palaute/reinit-palautteet-for-uninitiated-hokses! 500))
 
 (defn time->instant
   "Converts a specific time of day into an instant on today"

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [oph.ehoks.palaute.vastaajatunnus :as palaute])
   (:import (java.lang AutoCloseable)
-           (java.time Instant LocalTime ZonedDateTime ZoneId Period)))
+           (java.time Instant LocalTime ZonedDateTime ZoneId Period Duration)))
 
 (defn daily-actions!
   "Run all palaute checks that need to be run on a daily basis."
@@ -19,16 +19,25 @@
   (log/info "Done palaute daily actions.")
   true)
 
+(defn reinit-uninitiated-hoksen!
+  "Look for HOKSes that are missing corresponding palaute records and
+  initiate all palautteet for those HOKSes."
+  [opts]
+  (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
+  )
+
 (defn time->instant
   "Converts a specific time of day into an instant on today"
   [hour minute sec]
   (-> (LocalTime/of hour minute sec)
       (.adjustInto (ZonedDateTime/now (ZoneId/of "Europe/Helsinki")))
-      Instant/from))
+      (Instant/from)))
 
 (def schedules
   [{:action daily-actions!
-    :start (time->instant 6 0 0) :period (Period/ofDays 1)}])
+    :start (time->instant 6 0 0) :period (Period/ofDays 1)}
+   {:action reinit-uninitiated-hoksen!
+    :start (time->instant 0 0 0) :period (Duration/ofHours 1)}])
 
 (defn run-scheduler!
   "Run a given action periodically starting at start-time and repeating

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -2,7 +2,8 @@
   (:require [chime.core :as chime]
             [clojure.tools.logging :as log]
             [oph.ehoks.palaute.vastaajatunnus :as palaute])
-  (:import (java.lang AutoCloseable)))
+  (:import (java.lang AutoCloseable)
+           (java.time Instant LocalTime ZonedDateTime ZoneId Period)))
 
 (defn daily-actions!
   "Run all palaute checks that need to be run on a daily basis."
@@ -18,23 +19,39 @@
   (log/info "Done palaute daily actions.")
   true)
 
+(defn time->instant
+  "Converts a specific time of day into an instant on today"
+  [hour minute sec]
+  (-> (LocalTime/of hour minute sec)
+      (.adjustInto (ZonedDateTime/now (ZoneId/of "Europe/Helsinki")))
+      Instant/from))
+
+(def schedules
+  [{:action daily-actions!
+    :start (time->instant 6 0 0) :period (Period/ofDays 1)}])
+
 (defn run-scheduler!
-  "Simple (daily) scheduler for palaute scheduled tasks. Will be replaced with
-  more configurable one later on."
-  ^AutoCloseable [start-time rate]
-  (log/infof "Starting palaute scheduler with start time %s and rate %s."
-             start-time
-             rate)
+  "Run a given action periodically starting at start-time and repeating
+  at rate."
+  ^AutoCloseable [action start-time rate]
+  (log/info "Starting palaute scheduler with start time" start-time
+            "and rate" rate)
   (let [scheduler
-        (chime/chime-at (chime/periodic-seq start-time rate)
-                        daily-actions!
-                        {:on-finished
-                         (fn []
-                           (log/info "Palaute scheduler stopped."))
-                         :error-handler
-                         (fn [e]
-                           (log/warn e "Error in scheduler"))})]
-    (.addShutdownHook (Runtime/getRuntime)
-                      (Thread. (fn []
-                                 (log/info "Stopping palaute scheduler.")
-                                 (.close scheduler))))))
+        (chime/chime-at
+          (chime/periodic-seq start-time rate)
+          action
+          {:on-finished (fn [] (log/info "Palaute scheduler stopped."))
+           :error-handler (fn [e] (log/warn e "Error in scheduler"))})]
+    (.addShutdownHook
+      (Runtime/getRuntime)
+      (Thread. (fn []
+                 (log/info "Stopping palaute scheduler.")
+                 (.close scheduler))))))
+
+(defn run-schedulers!
+  "Run all schedulers used by palaute-backend, possibly overriding
+  the timing."
+  [& [override-start override-rate]]
+  (doseq [{:keys [action start period]} schedules]
+    (run-scheduler!
+      action (or override-start start) (or override-rate period))))

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -51,7 +51,9 @@
           (chime/periodic-seq start-time rate)
           action
           {:on-finished (fn [] (log/info "Palaute scheduler stopped."))
-           :error-handler (fn [e] (log/warn e "Error in scheduler"))})]
+           :error-handler (fn [e]
+                            (log/error e "Error in scheduler")
+                            true)})]
     (.addShutdownHook
       (Runtime/getRuntime)
       (Thread. (fn []

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -79,7 +79,7 @@
     [nil :yksiloiva-tunniste :jo-lahetetty]
 
     (nil? jakso)
-    [nil :osaamisen-hankkimistapa :ei-ole]
+    [nil :osaamisen-hankkimistapa :poistunut]
 
     (not (oht/palautteenkeruu-allowed-tyopaikkajakso? jakso))
     [:ei-laheteta :tyopaikalla-jarjestettava-koulutus :puuttuva-yhteystieto]

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -110,18 +110,21 @@
            :voimassa-loppupvm         (palaute/vastaamisajan-loppupvm
                                         heratepvm alkupvm))))
 
+(defn enrich-ctx!
+  "Add information needed by työelämäpalaute initiation into context."
+  [{:keys [tx hoks jakso] :as ctx}]
+  (assoc ctx
+         :tapahtumatyyppi :hoks-tallennus
+         :existing-palaute
+         (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
+           tx {:hoks-id            (:id hoks)
+               :yksiloiva-tunniste (:yksiloiva-tunniste jakso)})))
+
 (defn initiate-if-needed!
   [{:keys [hoks] :as ctx} jakso]
   (jdbc/with-db-transaction
     [tx db/spec {:isolation :serializable}]
-    (let [ctx (assoc ctx
-                     :tapahtumatyyppi :hoks-tallennus
-                     :tx              tx
-                     :jakso           jakso
-                     :existing-palaute
-                     (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
-                       tx {:hoks-id            (:id hoks)
-                           :yksiloiva-tunniste (:yksiloiva-tunniste jakso)}))
+    (let [ctx (enrich-ctx! (assoc ctx :tx tx :jakso jakso))
           [proposed-state field reason]
           (initial-palaute-state-and-reason ctx :ohjaajakysely)
           state

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -4,6 +4,7 @@
             [medley.core :refer [find-first map-vals]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
+            [oph.ehoks.db.dynamodb :as dynamodb]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.heratepalvelu :as heratepalvelu]
@@ -115,6 +116,9 @@
   [{:keys [tx hoks jakso] :as ctx}]
   (assoc ctx
          :tapahtumatyyppi :hoks-tallennus
+         :existing-ddb-herate
+         (delay (dynamodb/get-jakso-by-hoks-id-and-yksiloiva-tunniste!
+                  (:id hoks) (:yksiloiva-tunniste jakso)))
          :existing-palaute
          (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
            tx {:hoks-id            (:id hoks)

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -82,6 +82,11 @@
     (nil? jakso)
     [nil :osaamisen-hankkimistapa :poistunut]
 
+    (not (get jakso :loppu))
+    [nil :loppu :ei-ole]
+
+    ;; order dependency: nil rules must come first
+
     (not (oht/palautteenkeruu-allowed-tyopaikkajakso? jakso))
     [:ei-laheteta :tyopaikalla-jarjestettava-koulutus :puuttuva-yhteystieto]
 

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -15,7 +15,7 @@
             [taoensso.faraday :as far])
   (:import (java.time LocalDate)))
 
-(use-fixtures :once test-utils/migrate-database)
+(use-fixtures :once test-utils/with-clean-database-and-clean-dynamodb)
 (use-fixtures :each test-utils/empty-database-after-test)
 
 (deftest missing-sync-test

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -59,8 +59,7 @@
                             (palaute/rahoituskausi (LocalDate/now)))
                        :toimija_oppija
                        "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"}
-              ddb-item (far/get-item
-                         @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]
+              ddb-item (ddb/get-item! :amis ddb-key)]
           (is (= (:sahkoposti ddb-item) "irma.isomerkki@esimerkki.com"))
           (is (= (:herate-source ddb-item) "sqs_viesti_ehoksista"))
           (far/update-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key
@@ -70,8 +69,7 @@
                                              ":2" "2027-05-06"}})
           (ddb/sync-amis-herate! (assoc amis-herate :sahkoposti "foo@bar.com"))
           ; fields that are owned by herätepalvelu are not overwritten
-          (let [new-ddb-item
-                (far/get-item @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]
+          (let [new-ddb-item (ddb/get-item! :amis ddb-key)]
             (is (= (:sahkoposti new-ddb-item) "foo@bar.com"))
             (is (= (:viestintapalvelu-id new-ddb-item) "2027-05-06"))
             (is (= (:lahetystila new-ddb-item) "ei_lahetetty"))))))))

--- a/test/oph/ehoks/hoks/hoks_handler_test.clj
+++ b/test/oph/ehoks/hoks/hoks_handler_test.clj
@@ -17,7 +17,7 @@
             [oph.ehoks.test-utils :as test-utils :refer [eq]]
             [ring.mock.request :as mock]))
 
-(use-fixtures :once test-utils/migrate-database)
+(use-fixtures :once test-utils/with-clean-database-and-clean-dynamodb)
 (use-fixtures :each test-utils/empty-database-after-test)
 
 (defn add-empty-hoks-values [hoks]

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -22,7 +22,7 @@
             [schema.core :as s])
   (:import [java.time LocalDate]))
 
-(use-fixtures :once test-utils/migrate-database)
+(use-fixtures :once test-utils/with-clean-database-and-clean-dynamodb)
 (use-fixtures :each test-utils/empty-database-after-test)
 
 (def ahato-data

--- a/test/oph/ehoks/palaute/handler_test.clj
+++ b/test/oph/ehoks/palaute/handler_test.clj
@@ -7,13 +7,18 @@
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.organisaatio :as organisaatio]
             [oph.ehoks.palaute.handler :as handler]
+            [oph.ehoks.palaute.scheduler :as schedule]
             [oph.ehoks.test-utils :as test-utils]
             [oph.ehoks.utils.date :as date]
             [ring.mock.request :as mock])
   (:import (java.time LocalDate)))
 
 (use-fixtures :once test-utils/migrate-database)
-(use-fixtures :each test-utils/empty-database-after-test)
+(use-fixtures :each test-utils/empty-both-dbs-after-test)
+
+(deftest test-scheduler-runs
+  (testing "Can be called"
+    (is (schedule/daily-actions! {}))))
 
 (def base-url "/ehoks-palaute-backend/api/v1")
 

--- a/test/oph/ehoks/palaute/initiation_test.clj
+++ b/test/oph/ehoks/palaute/initiation_test.clj
@@ -7,10 +7,44 @@
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.external.koski-test :as koski-test]
             [oph.ehoks.palaute :as palaute]
-            [oph.ehoks.palaute.initiation :as init]))
+            [oph.ehoks.palaute.tapahtuma :as tapahtuma]
+            [oph.ehoks.palaute.initiation :as init]
+            [oph.ehoks.utils.date :as date])
+  (:import (java.time LocalDate)))
 
 (use-fixtures :once test-utils/migrate-database)
 (use-fixtures :each test-utils/empty-both-dbs-after-test)
+
+(deftest test-missing-opiskeluoikeus-reinit-palautteet-for-uninitiated-hokses!
+  (hoks/save! hoks-test/hoks-1)
+  (testing "palaute reinitiation succeeds with missing opiskeluoikeus"
+    (with-redefs [koski/get-opiskeluoikeus! (fn [oid] nil)
+                  date/now (constantly (LocalDate/of 2021 7 1))]
+      (init/reinit-palautteet-for-uninitiated-hokses! 2)
+      (is (= (->> {:hoks-id (:id hoks-test/hoks-1)
+                   :kyselytyypit ["aloittaneet" "valmistuneet"
+                                  "tyopaikkajakson_suorittaneet"]}
+                  (tapahtuma/get-all-by-hoks-id-and-kyselytyypit! db/spec)
+                  (map (juxt :uusi-tila :syy)))
+             [["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]
+              ["odottaa_kasittelya" "ei_loydy"]]))
+      (is (= (->> {:hoks-id (:id hoks-test/hoks-1)
+                   :kyselytyypit ["aloittaneet" "valmistuneet"
+                                  "tyopaikkajakson_suorittaneet"]}
+                  (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                  (map (juxt :tila :kyselytyyppi)))
+             [["odottaa_kasittelya" "aloittaneet"]
+              ["odottaa_kasittelya" "valmistuneet"]
+              ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"]
+              ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"]
+              ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"]
+              ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"]
+              ["odottaa_kasittelya" "tyopaikkajakson_suorittaneet"]])))))
 
 (deftest test-reinit-palautteet-for-uninitiated-hokses!
   (with-redefs [koski/get-opiskeluoikeus-info-raw

--- a/test/oph/ehoks/palaute/initiation_test.clj
+++ b/test/oph/ehoks/palaute/initiation_test.clj
@@ -1,0 +1,59 @@
+(ns oph.ehoks.palaute.initiation-test
+  (:require [clojure.test :refer [use-fixtures deftest testing is]]
+            [oph.ehoks.test-utils :as test-utils]
+            [oph.ehoks.db :as db]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.hoks-test :as hoks-test]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.external.koski-test :as koski-test]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.initiation :as init]))
+
+(use-fixtures :once test-utils/migrate-database)
+(use-fixtures :each test-utils/empty-both-dbs-after-test)
+
+(deftest test-reinit-palautteet-for-uninitiated-hokses!
+  (with-redefs [koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw]
+    (testing "saved HOKS doesn't have palautteet"
+      (hoks/save! hoks-test/hoks-1)
+      (is (= (palaute/get-by-hoks-id-and-kyselytyypit!
+               db/spec {:hoks-id (:id hoks-test/hoks-1)
+                        :kyselytyypit ["aloittaneet" "valmistuneet"
+                                       "tyopaikkajakson_suorittaneet"]})
+             [])))
+    (testing "batchsize is honored"
+      (init/reinit-palautteet-for-uninitiated-hokses! 0)
+      (is (= (palaute/get-by-hoks-id-and-kyselytyypit!
+               db/spec {:hoks-id (:id hoks-test/hoks-1)
+                        :kyselytyypit ["aloittaneet" "valmistuneet"
+                                       "tyopaikkajakson_suorittaneet"]})
+             [])))
+    (testing "reinit-palautteet-for-uninitiated-hokses! makes palautteet"
+      (init/reinit-palautteet-for-uninitiated-hokses! 7)
+      (is (= (->> {:hoks-id (:id hoks-test/hoks-1)
+                   :kyselytyypit ["aloittaneet" "valmistuneet"
+                                  "tyopaikkajakson_suorittaneet"]}
+                  (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                  (map (juxt :tila :kyselytyyppi)))
+             [["ei_laheteta" "aloittaneet"]
+              ["ei_laheteta" "valmistuneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]])))
+    (testing "reinit-palautteet-for-uninitiated-hokses! is idemponent"
+      (init/reinit-palautteet-for-uninitiated-hokses! 7)
+      (is (= (->> {:hoks-id (:id hoks-test/hoks-1)
+                   :kyselytyypit ["aloittaneet" "valmistuneet"
+                                  "tyopaikkajakson_suorittaneet"]}
+                  (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                  (map (juxt :tila :kyselytyyppi)))
+             [["ei_laheteta" "aloittaneet"]
+              ["ei_laheteta" "valmistuneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
+              ["ei_laheteta" "tyopaikkajakson_suorittaneet"]])))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -71,6 +71,15 @@
                                  :opiskeluoikeus oo-test/opiskeluoikeus-1}
                                 :ei-ole)))
 
+        (testing (str "`osaamisen-hankkimisen-tarve` is false _and_"
+                      "there is no heratepvm.")
+          (test-not-initiated {:hoks (assoc hoks-test/hoks-1
+                                            :osaamisen-hankkimisen-tarve false
+                                            :ensikertainen-hyvaksyminen nil
+                                            :osaamisen-saavuttamisen-pvm nil)
+                               :opiskeluoikeus oo-test/opiskeluoikeus-1}
+                              :ei-ole))
+
         (testing "there are no ammatillinen suoritus in opiskeluoikeus"
           (test-not-initiated {:hoks           hoks-test/hoks-1
                                :opiskeluoikeus oo-test/opiskeluoikeus-2}

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -30,21 +30,20 @@
   (:import (java.time LocalDate LocalDateTime)))
 
 (use-fixtures :once test-utils/migrate-database)
-(use-fixtures :each test-utils/empty-database-after-test)
+(use-fixtures :each test-utils/empty-both-dbs-after-test)
 
 (def sqs-msg (atom nil))
 
 (defn test-not-initiated
   ([ctx reason]
     (test-not-initiated nil ctx reason))
-  ([kysely-type ctx reason]
-    (doseq [kysely-type (if kysely-type
-                          [kysely-type]
-                          [:aloituskysely :paattokysely])]
-      (let [state-and-reason (op/initial-palaute-state-and-reason
-                               ctx kysely-type)]
-        (is (contains? #{:ei-laheteta nil} (first state-and-reason)))
-        (is (= (last state-and-reason) reason))))))
+  ([kysely-type ctx expected-reason]
+    (doseq [kysely-type
+            (if kysely-type [kysely-type] [:aloituskysely :paattokysely])]
+      (let [[state _ reason]
+            (op/initial-palaute-state-and-reason ctx kysely-type)]
+        (is (contains? #{:ei-laheteta :heratepalvelussa nil} state))
+        (is (= reason expected-reason))))))
 
 (deftest test-initial-palaute-state-and-reason
   (with-redefs [date/now (constantly (LocalDate/of 2023 1 1))]
@@ -54,8 +53,16 @@
           (test-not-initiated
             {:hoks                hoks-test/hoks-1
              :opiskeluoikeus      oo-test/opiskeluoikeus-1
-             :existing-palaute {:tila "kysely_muodostettu"}}
+             :existing-palaute    {:tila "kysely_muodostettu"}}
             :jo-lahetetty))
+
+        (testing "there is an existing heräte in herätepalvelu."
+          (test-not-initiated
+            {:hoks                hoks-test/hoks-1
+             :opiskeluoikeus      oo-test/opiskeluoikeus-1
+             :existing-ddb-herate (delay {:lahetystila "ei_lahetetty"})}
+            :heratepalvelun-vastuulla))
+
         (testing "`osaamisen-hankkimisen-tarve` is missing or is `false`."
           (doseq [hoks (map #(assoc hoks-test/hoks-1
                                     :osaamisen-hankkimisen-tarve %)
@@ -191,32 +198,27 @@
     (testing
      (str "Kysely is considered already initiated if it is for same "
           "oppija with same koulutustoimija and within same rahoituskausi.")
-      (are [kysely-type] (= (:tila (op/existing-palaute!
-                                     db/spec
-                                     {:hoks hoks-test/hoks-3
-                                      :koulutustoimija
-                                      "1.2.246.562.10.346830761110"}
-                                     kysely-type))
-                            "lahetetty")
+      (are [kysely-type]
+           (= "lahetetty"
+              (-> {:hoks hoks-test/hoks-3 :tx db/spec
+                   :koulutustoimija "1.2.246.562.10.346830761110"}
+                  (op/existing-palaute! kysely-type)
+                  :tila))
         :aloituskysely :paattokysely))
 
     (testing "Kysely is not considered already initiated when"
       (testing "koulutustoimija differs."
-        (are [kysely-type] (nil? (op/existing-palaute!
-                                   db/spec
-                                   {:hoks hoks-test/hoks-3
-                                    :koulutustoimija
-                                    "1.2.246.562.10.45678901237"}
-                                   kysely-type))
+        (are [kysely-type]
+             (nil? (-> {:hoks hoks-test/hoks-3 :tx db/spec
+                        :koulutustoimija "1.2.246.562.10.45678901237"}
+                       (op/existing-palaute! kysely-type)))
           :aloituskysely :paattokysely))
 
       (testing "heratepvm is within different rahoituskausi."
-        (are [kysely-type] (nil? (op/existing-palaute!
-                                   db/spec
-                                   {:hoks hoks-test/hoks-4
-                                    :koulutustoimija
-                                    "1.2.246.562.10.346830761110"}
-                                   kysely-type))
+        (are [kysely-type]
+             (nil? (-> {:hoks hoks-test/hoks-4 :tx db/spec
+                        :koulutustoimija "1.2.246.562.10.346830761110"}
+                       (op/existing-palaute! kysely-type)))
           :aloituskysely :paattokysely)))))
 
 (deftest test-initiate-if-needed!
@@ -284,6 +286,29 @@
                (= :odottaa-kasittelya
                   (op/initiate-if-needed! (assoc ctx :opiskeluoikeus nil)
                                           kysely-type))
+            :aloituskysely :paattokysely))
+
+        (testing "doesn't initiate if it is already handled by herätepalvelu"
+          (ddb/sync-amis-herate!
+            (op/build-amisherate-record-for-heratepalvelu
+              (assoc ctx
+                     :koulutustoimija "1.2.246.562.10.346830761110"
+                     :hk-toteuttaja (delay nil)
+                     :existing-palaute
+                     {:kyselytyyppi "aloittaneet"
+                      :heratepvm (:ensikertainen-hyvaksyminen
+                                   hoks-test/hoks-1)})))
+          (ddb/sync-amis-herate!
+            (op/build-amisherate-record-for-heratepalvelu
+              (assoc ctx
+                     :koulutustoimija "1.2.246.562.10.346830761110"
+                     :hk-toteuttaja (delay nil)
+                     :existing-palaute
+                     {:kyselytyyppi "valmistuneet"
+                      :heratepvm (:osaamisen-saavuttamisen-pvm
+                                   hoks-test/hoks-1)})))
+          (are [kysely-type]
+               (= :heratepalvelussa (op/initiate-if-needed! ctx kysely-type))
             :aloituskysely :paattokysely))
 
         (testing "doesn't initiate kysely if one already exists for HOKS"

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -56,6 +56,14 @@
              :existing-palaute    {:tila "kysely_muodostettu"}}
             :jo-lahetetty))
 
+        (testing "there is existing palaute for another HOKS."
+          (test-not-initiated
+            {:hoks                hoks-test/hoks-1
+             :opiskeluoikeus      oo-test/opiskeluoikeus-1
+             :existing-palaute    {:tila "odottaa_kasittelya"
+                                   :hoks-id 343434}}
+            :ei-palautteen-alkuperainen-hoks))
+
         (testing "there is an existing heräte in herätepalvelu."
           (test-not-initiated
             {:hoks                hoks-test/hoks-1

--- a/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/nippu_test.clj
@@ -3,7 +3,7 @@
             [oph.ehoks.test-utils :as util]
             [oph.ehoks.palaute.tyoelama.nippu :as nippu])
   (:import [java.time LocalDate]))
-;
+
 (def expected-tpo-nippu-data
   {:ohjaaja_ytunnus_kj_tutkinto (str "Matti Meikäläinen/1234567-1/"
                                      "1.2.246.562.10.346830761110/12345")

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -28,7 +28,7 @@
            (java.util UUID)))
 
 (use-fixtures :once test-utils/migrate-database)
-(use-fixtures :each test-utils/empty-database-after-test)
+(use-fixtures :each test-utils/empty-both-dbs-after-test)
 
 ;; FIXME: there is some kind of misunderstanding in the format of this
 ;; data.  It's fed to initiate-if-needed! and

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -278,6 +278,13 @@
                                        :tila "vastaajatunnus_muodostettu"}}
                    :ohjaajakysely)
                  [nil :yksiloiva-tunniste :jo-lahetetty])))
+        (testing "the jakso has been deleted from HOKS"
+          (is (= (tep/initial-palaute-state-and-reason
+                   {:hoks           hoks-test/hoks-1
+                    :opiskeluoikeus oo-test/opiskeluoikeus-5
+                    :jakso nil}
+                   :ohjaajakysely)
+                 [nil :osaamisen-hankkimistapa :poistunut])))
         (testing "opiskeluoikeus is in terminal state."
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -278,6 +278,14 @@
                                        :tila "vastaajatunnus_muodostettu"}}
                    :ohjaajakysely)
                  [nil :yksiloiva-tunniste :jo-lahetetty])))
+        (testing "a corresponding heräte exists in herätepalvelu."
+          (is (= (tep/initial-palaute-state-and-reason
+                   {:hoks           hoks-test/hoks-1
+                    :opiskeluoikeus oo-test/opiskeluoikeus-1
+                    :jakso          test-jakso
+                    :existing-ddb-herate (delay {:hankkimistapa_id 12343254})}
+                   :ohjaajakysely)
+                 [:heratepalvelussa :loppu :heratepalvelun-vastuulla])))
         (testing "the jakso has been deleted from HOKS"
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
@@ -310,7 +318,7 @@
                    :ohjaajakysely)
                  [:ei-laheteta :tyopaikalla-jarjestettava-koulutus
                   :puuttuva-yhteystieto])))
-        (testing "työpaikkajakso is interrupted on it's end date"
+        (testing "työpaikkajakso is interrupted on its end date"
           (is (= (tep/initial-palaute-state-and-reason
                    {:hoks           hoks-test/hoks-1
                     :opiskeluoikeus oo-test/opiskeluoikeus-1
@@ -429,8 +437,43 @@
                   :syy          "hoks_tallennettu"
                   :lisatiedot   {:request-id nil
                                  :loppu "2023-12-15"}}))))
-      (testing
-       "doesn't initiate tyoelamapalaute if it has already been initiated"
+      (testing "doesn't initiate if it is found in herätepalvelu"
+        (let [existing-palaute
+              (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
+                db/spec
+                {:hoks-id (:id hoks-test/hoks-1)
+                 :yksiloiva-tunniste (:yksiloiva-tunniste test-jakso)})
+              ctx {:hoks           hoks-test/hoks-1
+                   :existing-palaute (assoc existing-palaute
+                                            :hankkimistapa-id 123)
+                   :vastaamisajan-alkupvm (LocalDate/of 2020 5 13)
+                   :jakso          test-jakso
+                   :opiskeluoikeus oo-test/opiskeluoikeus-1}]
+          (heratepalvelu/sync-jakso!
+            (tep/build-jaksoherate-record-for-heratepalvelu ctx))
+          (tep/initiate-if-needed! {:hoks           hoks-test/hoks-1
+                                    :opiskeluoikeus oo-test/opiskeluoikeus-1}
+                                   test-jakso)
+          (is (= (map (juxt :vanha-tila :uusi-tila)
+                      (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                        db/spec
+                        {:hoks-id      (:id hoks-test/hoks-1)
+                         :kyselytyypit ["tyopaikkajakson_suorittaneet"]}))
+                 [["odottaa_kasittelya" "odottaa_kasittelya"]
+                  ["odottaa_kasittelya" "heratepalvelussa"]]))
+          (tep/initiate-if-needed! {:hoks           hoks-test/hoks-1
+                                    :opiskeluoikeus oo-test/opiskeluoikeus-1}
+                                   test-jakso)
+          (is (= (map (juxt :vanha-tila :uusi-tila :syy)
+                      (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                        db/spec
+                        {:hoks-id      (:id hoks-test/hoks-1)
+                         :kyselytyypit ["tyopaikkajakson_suorittaneet"]}))
+                 [["odottaa_kasittelya" "odottaa_kasittelya" "hoks_tallennettu"]
+                  ["odottaa_kasittelya" "heratepalvelussa"
+                   "heratepalvelun_vastuulla"]
+                  ["heratepalvelussa" "heratepalvelussa" "jo_lahetetty"]]))))
+      (testing "doesn't initiate if it has already been initiated"
         (with-log
           (let [existing
                 (palaute/get-by-hoks-id-and-yksiloiva-tunniste!
@@ -443,22 +486,18 @@
             (tep/initiate-if-needed! {:hoks           hoks-test/hoks-1
                                       :opiskeluoikeus oo-test/opiskeluoikeus-1}
                                      test-jakso)
-            (is (= (db-helpers/query
-                     [(str "select vanha_tila, uusi_tila, tyyppi, syy "
-                           " from palaute_tapahtumat where palaute_id = "
-                           (:id existing))])
-                   [{:vanha_tila "odottaa_kasittelya",
-                     :uusi_tila "odottaa_kasittelya",
-                     :tyyppi "hoks_tallennus",
-                     :syy "hoks_tallennettu"}
-                    {:vanha_tila "odottaa_kasittelya",
-                     :uusi_tila "lahetetty",
-                     :tyyppi "arvo_luonti",
-                     :syy "arvo_kutsu_onnistui"}
-                    {:vanha_tila "lahetetty",
-                     :uusi_tila "lahetetty",
-                     :tyyppi "hoks_tallennus",
-                     :syy "jo_lahetetty"}]))
+            (is (= (map (juxt :vanha-tila :uusi-tila :syy)
+                        (tapahtuma/get-all-by-hoks-id-and-kyselytyypit!
+                          db/spec
+                          {:hoks-id      (:id hoks-test/hoks-1)
+                           :kyselytyypit ["tyopaikkajakson_suorittaneet"]}))
+                   [["odottaa_kasittelya" "odottaa_kasittelya"
+                     "hoks_tallennettu"]
+                    ["odottaa_kasittelya" "heratepalvelussa"
+                     "heratepalvelun_vastuulla"]
+                    ["heratepalvelussa" "heratepalvelussa" "jo_lahetetty"]
+                    ["heratepalvelussa" "lahetetty" "arvo_kutsu_onnistui"]
+                    ["lahetetty" "lahetetty" "jo_lahetetty"]]))
             (is (logged? 'oph.ehoks.palaute.tyoelama
                          :info
                          #":jo-lahetetty"))))))))

--- a/test/oph/ehoks/palaute_test.clj
+++ b/test/oph/ehoks/palaute_test.clj
@@ -8,13 +8,8 @@
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.oppijaindex-test :as oppijaindex-test]
             [oph.ehoks.palaute :as palaute]
-            [oph.ehoks.palaute.scheduler :as schedule]
             [oph.ehoks.utils.date :as date])
   (:import [java.time LocalDate]))
-
-(deftest test-scheduler-runs
-  (testing "Can be called"
-    (is (schedule/daily-actions! {}))))
 
 (deftest test-valid-herate-date?
   (testing "True if heratepvm is >= [rahoituskausi start year]-07-01"


### PR DESCRIPTION
## Kuvaus muutoksista

Palaute-backend ei saa tehdä Arvo-kutsuja niille palautteille, joille herätepalvelu voi tehdä Arvo-kutsuja (jottei samalle palautteelle muodosteta kahta vastaajatunnusta).  Tämä PR estää niiden palautteiden käsittelyn, jotka ovat jo herätepalvelussa.

https://jira.eduuni.fi/browse/EH-1804

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
