### PR TITLE
Handle nil opiskeluoikeus properly in koulutustoimija

### DIFF
--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -45,12 +45,15 @@
   "Hakee koulutustoimijan OID:n opiskeluoikeudesta, tai organisaatiopalvelusta
   jos sitä ei löydy opiskeluoikeudesta."
   [opiskeluoikeus]
-  (or (:oid (:koulutustoimija opiskeluoikeus))
-      (do
-        (log/info "Ei koulutustoimijaa opiskeluoikeudessa "
-                  (:oid opiskeluoikeus) ", haetaan Organisaatiopalvelusta")
-        (:parentOid (organisaatio/get-organisaatio!
-                      (get-in opiskeluoikeus [:oppilaitos :oid]))))))
+  (if-not opiskeluoikeus
+    (log/warn "Ei opiskeluoikeutta, ei haeta koulutustoimijaa")
+    (or (:oid (:koulutustoimija opiskeluoikeus))
+        (do
+          (log/info "Ei koulutustoimijaa opiskeluoikeudessa "
+                    (:oid opiskeluoikeus) ", haetaan Organisaatiopalvelusta")
+          (some-> (get-in opiskeluoikeus [:oppilaitos :oid])
+                  (organisaatio/get-organisaatio!)
+                  :parentOid)))))
 
 (defn toimipiste-oid!
   "Palauttaa toimipisteen OID jos sen organisaatiotyyppi on toimipiste. Tämä

--- a/test/oph/ehoks/palaute_test.clj
+++ b/test/oph/ehoks/palaute_test.clj
@@ -32,6 +32,7 @@
     (with-redefs
      [organisaatio/get-organisaatio! organisaatio-test/mock-get-organisaatio!]
       (do
+        (is (nil? (palaute/koulutustoimija-oid! nil)))
         (is (= "1.2.246.562.10.346830761110"
                (palaute/koulutustoimija-oid!
                  {:oid "1.2.246.562.15.43634207518"


### PR DESCRIPTION
## Kuvaus muutoksista

Tällainen tuli vastaan, kun tutkin lokeja.  Näyttäisi toimivan nykyiselläänkin, mutta tässä versiossa ei kutsuta turhaan organisaatiopalvelua ja lisätään erillinen varoitus siitä, että funktiota on kutsuttu `nil`:llä.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
