### PR TITLE
EH-1706: run palaute creation in serializable transactions

### DIFF
--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -140,7 +140,7 @@
   `nil` otherwise."
   [{:keys [hoks opiskeluoikeus] :as ctx} kysely-type]
   (jdbc/with-db-transaction
-    [tx db/spec]
+    [tx db/spec {:isolation :serializable}]
     (let [ctx (assoc
                 ctx
                 :tapahtumatyyppi :hoks-tallennus

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -113,7 +113,7 @@
 (defn initiate-if-needed!
   [{:keys [hoks] :as ctx} jakso]
   (jdbc/with-db-transaction
-    [tx db/spec]
+    [tx db/spec {:isolation :serializable}]
     (let [ctx (assoc ctx
                      :tapahtumatyyppi :hoks-tallennus
                      :tx              tx


### PR DESCRIPTION
... because saving the same HOKS twice very quickly may miss the already existing palaute from each other, potentially causing two palaute records to be formed for the same palaute.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
