### PR TITLE
Fix `kysely-type` in opiskelijapalaute logging

### DIFF
--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -120,7 +120,7 @@
          (palaute/upsert! tx)
          (tapahtuma/build-and-insert! ctx state reason lisatiedot))
     (when (= :odottaa-kasittelya state)
-      (log/info "Making" type "heräte for HOKS" (:id hoks))
+      (log/info "Making" kysely-type "heräte for HOKS" (:id hoks))
       (sqs/send-amis-palaute-message
         {:ehoks-id           (:id hoks)
          :kyselytyyppi       (translate-kyselytyyppi


### PR DESCRIPTION
## Kuvaus muutoksista

Huomasin opiskelijapalautteen lokituksessa pikkuhäikän, tässä korjaus.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
