### PR TITLE
Add `palaute_handled_at` column to `hoksit` table

### DIFF
--- a/src/db/migration/V1_1745394959342__Add_palaute_initiated_at_column_to_hoksit.sql
+++ b/src/db/migration/V1_1745394959342__Add_palaute_initiated_at_column_to_hoksit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hoksit ADD COLUMN palaute_handled_at TIMESTAMP WITH TIME ZONE;

--- a/src/oph/ehoks/db/db_operations/db_helpers.clj
+++ b/src/oph/ehoks/db/db_operations/db_helpers.clj
@@ -116,7 +116,10 @@
   "Remove keys corresponding to columns used for internal purposes, keeping
   columns listed in keep-columns."
   [m keep-columns]
-  (let [remove-columns (difference #{:created_at :updated_at :deleted_at}
+  (let [remove-columns (difference #{:created_at
+                                     :updated_at
+                                     :deleted_at
+                                     :palaute_handled_at}
                                    keep-columns)]
     (apply
       dissoc m remove-columns)))

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -370,11 +370,12 @@
 
 (defn select-hoks-by-id
   "Hakee yhden HOKSin tietokannasta sen ID:n perusteella."
-  [id]
-  (first
-    (db-ops/query
-      [queries/select-hoksit-by-id id]
-      {:row-fn hoks-from-sql})))
+  ([id]
+    (select-hoks-by-id id nil))
+  ([id keep-columns]
+    (first (db-ops/query
+             [queries/select-hoksit-by-id id]
+             {:row-fn #(hoks-from-sql % keep-columns)}))))
 
 (defn select-hokses-greater-than-id
   "Hakee tietokannasta tietyn määrän HOKSeja, joiden ID:t ovat annettu arvo tai

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -107,13 +107,10 @@ where h.oppija_oid = :oppija-oid
   and p.deleted_at is null
   and h.deleted_at is null
 
--- :name get-hokses-without-palaute! :? :*
+-- :name get-hokses-with-unhandled-palautteet! :? :*
 -- :doc List all HOKSes that do not have any palaute records.
 select	id from hoksit
-where	id not in (
-	select hoks_id from palautteet where deleted_at is null
-)
-and	deleted_at is null
+where deleted_at is null and palaute_handled_at is null
 order by id desc  -- process newer HOKSes first
 limit	:batchsize
 

--- a/src/oph/ehoks/palaute/initiation.clj
+++ b/src/oph/ehoks/palaute/initiation.clj
@@ -14,13 +14,10 @@
   "Initialise all palautteet (opiskelija & tyoelama) that should be."
   [{:keys [hoks] :as ctx}]
   (try
-    (jdbc/with-db-transaction
-      [tx db/spec]
-      (let [ctx (assoc ctx :tx tx)]
-        (op/initiate-if-needed! ctx :aloituskysely)
-        (op/initiate-if-needed! ctx :paattokysely)
-        (tep/initiate-all-uninitiated! ctx)
-        (hoks/update! (assoc hoks :palaute-handled-at (date/now)))))
+    (op/initiate-if-needed! ctx :aloituskysely)
+    (op/initiate-if-needed! ctx :paattokysely)
+    (tep/initiate-all-uninitiated! ctx)
+    (hoks/update! (assoc hoks :palaute-handled-at (date/now)))
     (catch clojure.lang.ExceptionInfo e
       (if (= ::organisaatio/organisation-not-found (:type (ex-data e)))
         (throw (ex-info (str "HOKS contains an unknown organisation"

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -627,6 +627,9 @@
               tep-palautteet-after-creation)
           (eq (set (map (juxt :kyselytyyppi :heratepvm :uusi-tila :syy) tap))
               palaute-tapahtumat-after-creation)
+          (is (some? (-> (:id hoks-db)
+                         (db-hoks/select-hoks-by-id #{:palaute_handled_at})
+                         :palaute-handled-at)))
           (is (true? (test-utils/wait-for
                        (fn [_] (= @sqs-call-counter 2)) 5000)))
           ;; with changed HOKS


### PR DESCRIPTION
## Kuvaus muutoksista

Lisätään `hoksit`-tauluun `palaute_handled_at` kenttä. Uudelleenkäsittelyn yhteydessä tarkastetaan, onko kyseiseen kenttään asetettu timestamp, ja jos on, ei käsitellä palautteita uudelleen hoksille.

https://jira.eduuni.fi/browse/EH-1812

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
