### PR TITLE
Increase `reinit-palautteet-for-uninitiated-hokses!` batch size

### DIFF
--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -25,7 +25,7 @@
   initiate all palautteet for those HOKSes."
   [opts]
   (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
-  (palaute/reinit-palautteet-for-uninitiated-hokses! 500))
+  (palaute/reinit-palautteet-for-uninitiated-hokses! 2500))
 
 (defn time->instant
   "Converts a specific time of day into an instant on today"


### PR DESCRIPTION
## Kuvaus muutoksista

Kasvatetaan batch size 500 -> 2500 jotta hoksien palautteet tulee käsiteltyä nopeammin.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
