### PR TITLE
EH-1805: Asetetaan dummy-tunnukselliset palautteet takaisin `odottaa_kasittelya` tilaan

### DIFF
--- a/src/db/migration/V1_1748793635101__Reset_palautteet_with_dummy_tunnus.sql
+++ b/src/db/migration/V1_1748793635101__Reset_palautteet_with_dummy_tunnus.sql
@@ -1,0 +1,3 @@
+update palautteet
+set tila = 'odottaa_kasittelya', arvo_tunniste = null
+where deleted_at is null and arvo_tunniste like '<dummy-%>';

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -143,7 +143,8 @@
   [{:keys [existing-palaute] :as ctx} tila reason lisatiedot]
   (jdbc/with-db-transaction
     [tx db/spec]
-    (update! tx {:id (:id existing-palaute) :tila tila})
+    (update! tx {:id   (:id existing-palaute)
+                 :tila (utils/to-underscore-str tila)})
     (tapahtuma/build-and-insert! ctx tila reason lisatiedot)))
 
 (defn feedback-collecting-prevented?

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -77,7 +77,7 @@
     [nil :yksiloiva-tunniste :jo-lahetetty]
 
     (nil? jakso)
-    [nil :osaamisen-hankkimistapa :poistunut]
+    [:ei-laheteta :osaamisen-hankkimistapa :poistunut]
 
     (not (get jakso :loppu))
     [nil :loppu :ei-ole]


### PR DESCRIPTION
## Kuvaus muutoksista

Palautetaan dummy-tunnukselliset palautteet takaisin `odottaa_kasittelya` tilaan. Varmistetaan, että Herätepalvelussa oleville palautteille ei muodosteta uutta tunnusta/kyselylinkkiä, jos syystä taikka toisesta tällainen on jo Herätepalvelussa.

https://jira.eduuni.fi/browse/EH-1805

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
