### PR TITLE
EH-1831: update palaute_handled_at without updating updated_at

### DIFF
--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -114,6 +114,13 @@ where deleted_at is null and palaute_handled_at is null
 order by id desc  -- process newer HOKSes first
 limit	:batchsize
 
+-- :name mark-hoks-palaute-initiated! :? :1
+-- :doc Mark all palautteet as initiated for given HOKS
+update hoksit
+set palaute_handled_at = now()
+where id = :hoks-id
+returning *
+
 -- :name get-by-id! :? :1
 -- :doc Get palaute by palaute id.
 select * from palautteet

--- a/src/oph/ehoks/palaute/initiation.clj
+++ b/src/oph/ehoks/palaute/initiation.clj
@@ -17,7 +17,7 @@
     (op/initiate-if-needed! ctx :aloituskysely)
     (op/initiate-if-needed! ctx :paattokysely)
     (tep/initiate-all-uninitiated! ctx)
-    (hoks/update! (assoc hoks :palaute-handled-at (date/now)))
+    (palaute/mark-hoks-palaute-initiated! db/spec {:hoks-id (:id hoks)})
     (catch clojure.lang.ExceptionInfo e
       (if (= ::organisaatio/organisation-not-found (:type (ex-data e)))
         (throw (ex-info (str "HOKS contains an unknown organisation"

--- a/test/oph/ehoks/palaute/initiation_test.clj
+++ b/test/oph/ehoks/palaute/initiation_test.clj
@@ -86,9 +86,11 @@
               ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
               ["ei_laheteta" "tyopaikkajakson_suorittaneet"]
               ["ei_laheteta" "tyopaikkajakson_suorittaneet"]]))
-      (is (some? (-> (:id hoks-test/hoks-1)
-                     (db-hoks/select-hoks-by-id #{:palaute_handled_at})
-                     :palaute-handled-at))))
+      (is (-> (:id hoks-test/hoks-1)
+              (db-hoks/select-hoks-by-id #{:palaute_handled_at})
+              :palaute-handled-at
+              (inst-ms)
+              (> (inst-ms #inst "2025-05-20")))))
     (testing "reinit-palautteet-for-uninitiated-hokses! is idemponent"
       (init/reinit-palautteet-for-uninitiated-hokses! 7)
       (is (= (->> {:hoks-id (:id hoks-test/hoks-1)


### PR DESCRIPTION
## Kuvaus muutoksista

Koska palaute_handled_at:n päivittäminen ei oikeasti ole HOKSin päivitys, ei merkitä HOKSia päivitetyksi kun merkitään sen palautteet luoduiksi.

https://jira.eduuni.fi/browse/EH-1831

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
