### PR TITLE
Revert "Fix `PATCH /hoks/kyselylinkki`"

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -319,8 +319,7 @@
           :summary "Lisää lähetystietoja kyselylinkille"
           :body [data hoks-schema/kyselylinkki-lahetys]
           (assoc
-            (if-let [old-data (first
-                                (select-kyselylinkki (:kyselylinkki data)))]
+            (if-let [old-data (select-kyselylinkki (:kyselylinkki data))]
               (do (kyselylinkki/update! data)
                   (assoc (response/no-content)
                          ::audit/changes


### PR DESCRIPTION
This fix only affects audit logging, and also that it affects in the wrong direction (breaking its diffs).

Reverts Opetushallitus/ehoks#703