### PR TITLE
EH-1816: fix kyselylinkki found check in a way that doesn't break audit logging

### DIFF
--- a/src/oph/ehoks/hoks/handler.clj
+++ b/src/oph/ehoks/hoks/handler.clj
@@ -319,8 +319,8 @@
           :summary "Lisää lähetystietoja kyselylinkille"
           :body [data hoks-schema/kyselylinkki-lahetys]
           (assoc
-            (if-let [old-data (first
-                                (select-kyselylinkki (:kyselylinkki data)))]
+            (if-let [old-data
+                     (not-empty (select-kyselylinkki (:kyselylinkki data)))]
               (do (kyselylinkki/update! data)
                   (assoc (response/no-content)
                          ::audit/changes


### PR DESCRIPTION
## Kuvaus muutoksista

Viime yritys (#703) rikkoi audit-lokituksen siinä mielessä, että vanha ja uusi kyselylinkkidata eivät ole enää samassa muodossa ja siksi diff niiden välillä ei toimi.

https://jira.eduuni.fi/browse/EH-1816

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
