### PR TITLE
EH-1846: process palaute more often (once an hour)

### DIFF
--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -28,7 +28,7 @@
   (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
   (let [result (util/with-timeout
                  (* 45 60 1000)
-                 #(palaute/reinit-palautteet-for-uninitiated-hokses! 3000))]
+                 #(palaute/reinit-palautteet-for-uninitiated-hokses! 300))]
     (log/info "reinit-palautteet-for-uninitiated-hokses!: ended with result"
               result))
   true)
@@ -44,7 +44,7 @@
   [{:action daily-actions!
     :start (time->instant 6 0 0) :period (Period/ofDays 1)}
    {:action reinit-uninitiated-hoksen!
-    :start (time->instant 0 0 0) :period (Duration/ofHours 1)}])
+    :start (time->instant 0 0 0) :period (Duration/ofHours 3)}])
 
 (defn run-scheduler!
   "Run a given action periodically starting at start-time and repeating

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -12,25 +12,30 @@
   [opts]
   (log/info "Commencing palaute daily actions.")
   (try
-    (log/info "Handling palautteet that have reached their heratepvm.")
-    (vt/handle-palautteet-waiting-for-heratepvm!
-      ["aloittaneet" "valmistuneet" "osia_suorittaneet"
-       "tyopaikkajakson_suorittaneet"])
+    true  ;; nothing at the moment
     (catch Exception e
       (log/error e "Unhandled exception in daily-actions!.")))
   (log/info "Done palaute daily actions.")
   true)
 
-(defn reinit-uninitiated-hoksen!
-  "Look for HOKSes that are missing corresponding palaute records and
-  initiate all palautteet for those HOKSes."
+(defn hourly-actions!
+  "Run all palaute checks that are to be run every hour."
   [opts]
-  (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
-  (let [result (util/with-timeout
-                 (* 45 60 1000)
-                 #(palaute/reinit-palautteet-for-uninitiated-hokses! 300))]
-    (log/info "reinit-palautteet-for-uninitiated-hokses!: ended with result"
-              result))
+  (log/info "Commencing palaute hourly actions.")
+  (try
+    (log/info "Initialising palautteet for next batch of uninitialised HOKSes.")
+    (let [result (util/with-timeout
+                   (* 45 60 1000)
+                   #(palaute/reinit-palautteet-for-uninitiated-hokses! 300))]
+      (log/info "reinit-palautteet-for-uninitiated-hokses!: ended with result"
+                result))
+    (log/info "Handling palautteet that have reached their heratepvm.")
+    (vt/handle-palautteet-waiting-for-heratepvm!
+      ["aloittaneet" "valmistuneet" "osia_suorittaneet"
+       "tyopaikkajakson_suorittaneet"])
+    (catch Exception e
+      (log/error e "Unhandled exception in hourly-actions!.")))
+  (log/info "Done palaute hourly actions.")
   true)
 
 (defn time->instant
@@ -43,8 +48,8 @@
 (def schedules
   [{:action daily-actions!
     :start (time->instant 6 0 0) :period (Period/ofDays 1)}
-   {:action reinit-uninitiated-hoksen!
-    :start (time->instant 0 0 0) :period (Duration/ofHours 3)}])
+   {:action hourly-actions!
+    :start (time->instant 1 0 0) :period (Duration/ofHours 1)}])
 
 (defn run-scheduler!
   "Run a given action periodically starting at start-time and repeating


### PR DESCRIPTION
## Kuvaus muutoksista

Koulutuksenjärjestäjät haluavat että opiskelijat saavat palautelinkin nopeasti kun ensikertainen hyväksyminen on kirjattu.  Korjataan aluksi siihen, että kerran tunnissa käsitellään palautteet.  Myöhemmin voidaan harkita reaaliaikaisuutta.

https://jira.eduuni.fi/browse/EH-1846

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
