### PR TITLE
EH-1906: valinnainen tutkinnon-osan-perusteen-diaarinro -kenttä (a)hatoille

### DIFF
--- a/resources/db/hoksit/select_all_ahatos_for_hoks.sql
+++ b/resources/db/hoksit/select_all_ahatos_for_hoks.sql
@@ -3,6 +3,7 @@ SELECT
   osa.hoks_id AS osa__hoks_id,
   osa.tutkinnon_osa_koodi_uri AS osa__tutkinnon_osa_koodi_uri,
   osa.tutkinnon_osa_koodi_versio AS osa__tutkinnon_osa_koodi_versio,
+  osa.tutkinnon_osan_perusteen_diaarinro AS osa__tutkinnon_osan_perusteen_diaarinro,
   osa.valittu_todentamisen_prosessi_koodi_uri
     AS osa__valittu_todentamisen_prosessi_koodi_uri,
   osa.valittu_todentamisen_prosessi_koodi_versio

--- a/resources/db/hoksit/select_all_hatos_for_hoks.sql
+++ b/resources/db/hoksit/select_all_hatos_for_hoks.sql
@@ -3,6 +3,7 @@ SELECT
   osa.hoks_id AS osa__hoks_id,
   osa.tutkinnon_osa_koodi_uri AS osa__tutkinnon_osa_koodi_uri,
   osa.tutkinnon_osa_koodi_versio AS osa__tutkinnon_osa_koodi_versio,
+  osa.tutkinnon_osan_perusteen_diaarinro AS osa__tutkinnon_osan_perusteen_diaarinro,
   osa.vaatimuksista_tai_tavoitteista_poikkeaminen
     AS osa__vaatimuksista_tai_tavoitteista_poikkeaminen,
   osa.koulutuksen_jarjestaja_oid AS osa__koulutuksen_jarjestaja_oid,

--- a/src/db/migration/V1_1759497119374__tutkinnon_osan_perustetieto.sql
+++ b/src/db/migration/V1_1759497119374__tutkinnon_osan_perustetieto.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE hankittavat_ammat_tutkinnon_osat
+ADD COLUMN tutkinnon_osan_perusteen_diaarinro TEXT;
+
+ALTER TABLE aiemmin_hankitut_ammat_tutkinnon_osat
+ADD COLUMN tutkinnon_osan_perusteen_diaarinro TEXT;
+

--- a/src/oph/ehoks/hoks/aiemmin_hankitut.clj
+++ b/src/oph/ehoks/hoks/aiemmin_hankitut.clj
@@ -58,6 +58,7 @@
   {:osa__id                         :id
    :osa__tutkinnon_osa_koodi_uri    :tutkinnon_osa_koodi_uri
    :osa__tutkinnon_osa_koodi_versio :tutkinnon_osa_koodi_versio
+   :osa__tutkinnon_osan_perusteen_diaarinro :tutkinnon_osan_perusteen_diaarinro
    :osa__koulutuksen_jarjestaja_oid :koulutuksen_jarjestaja_oid
    :osa__olennainen_seikka          :olennainen_seikka
    :osa__module_id                  :module_id

--- a/src/oph/ehoks/hoks/hankittavat.clj
+++ b/src/oph/ehoks/hoks/hankittavat.clj
@@ -103,6 +103,7 @@
   {:osa__id                         :id
    :osa__tutkinnon_osa_koodi_uri    :tutkinnon_osa_koodi_uri
    :osa__tutkinnon_osa_koodi_versio :tutkinnon_osa_koodi_versio
+   :osa__tutkinnon_osan_perusteen_diaarinro :tutkinnon_osan_perusteen_diaarinro
    :osa__koulutuksen_jarjestaja_oid :koulutuksen_jarjestaja_oid
    :osa__olennainen_seikka          :olennainen_seikka
    :osa__module_id                  :module_id

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -753,6 +753,12 @@
     :types {:any s/Int}
     :description (str "Tutkinnon osan Koodisto-koodi-URIn versio "
                       "ePerusteet-palvelussa (tutkinnonosat)")}
+   :tutkinnon-osan-perusteen-diaarinro
+   {:methods {:any :optional}
+    :types {:any s/Str}
+    :description (str "Perusteen diaarinumero ePerusteet-palvelussa, josta "
+                      "tutkinnonosa on poimittu, muotoa OPH-xxxx-vvvv eli "
+                      "esimerkiksi OPH-3418-2025")}
    :vaatimuksista-tai-tavoitteista-poikkeaminen
    {:methods {:any :optional}
     :types {:any s/Str}

--- a/test/oph/ehoks/hoks/hoks_save_test.clj
+++ b/test/oph/ehoks/hoks/hoks_save_test.clj
@@ -31,6 +31,7 @@
     :valittu-todentamisen-prosessi-koodi-uri
     "osaamisentodentamisenprosessi_3"
     :tutkinnon-osa-koodi-uri "tutkinnonosat_100022"
+    :tutkinnon-osan-perusteen-diaarinro "OPH-1234-2025"
     :tarkentavat-tiedot-osaamisen-arvioija
     {:lahetetty-arvioitavaksi (java.time.LocalDate/of 2019 3 18)
      :aiemmin-hankitun-osaamisen-arvioijat
@@ -101,6 +102,7 @@
 (def hao-data
   [{:tutkinnon-osa-koodi-uri "tutkinnonosat_102499"
     :tutkinnon-osa-koodi-versio 4
+    :tutkinnon-osan-perusteen-diaarinro "OPH-4321-2025"
     :vaatimuksista-tai-tavoitteista-poikkeaminen
     "Ei poikkeamia."
     :osaamisen-osoittaminen


### PR DESCRIPTION
## Kuvaus muutoksista

Muutos HOKSin rakenteeseen: lisätään tutkinnonosiin tieto siitä, mistä perusteesta ne on poimittu tutkintoon.  Tässä vaiheessa valinnaisena kaikille ammatillisen suoritustyypeille; mahdollisesti myöhemmin pakollinen tieto jos suorituksen tyyppi on ammatillisentutkinnonosiauseammastatutkinnosta.

Tässä vaiheessa vain ammatillisille tutkinnon osille, koska yhteiset tutkinnon osat ovat ilmeisesti aidosti tutkintoriippumattomia.  Mut on avoin kysymys, pitäiskö niillä silti olla perustetieto.

https://jira.eduuni.fi/browse/EH-1906

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
