### PR TITLE
EH-2024: message sending logic

### DIFF
--- a/oph-configuration/dev.edn
+++ b/oph-configuration/dev.edn
@@ -2,5 +2,6 @@
  :send-herate-messages? false
  :enforce-opiskeluoikeus-match? false
  :prevent-finished-opiskeluoikeus-updates? false
- :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet]
+ :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet
+                                :send-initial-messages]
  :arvo-responsibilities [:create-kyselytunnus :create-jaksotunnus]}

--- a/oph-configuration/test-ci.edn
+++ b/oph-configuration/test-ci.edn
@@ -11,7 +11,8 @@
  :send-herate-messages? false
  :enforce-opiskeluoikeus-match? false
  :prevent-finished-opiskeluoikeus-updates? false
- :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet]
+ :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet
+                                :send-initial-messages]
  :arvo-responsibilities [:create-kyselytunnus :create-jaksotunnus]
  :koski-opiskeluoikeus-cache-ttl-millis 1
  :koski-oppija-cache-ttl-millis 1}

--- a/oph-configuration/test.edn
+++ b/oph-configuration/test.edn
@@ -7,7 +7,8 @@
  :send-herate-messages? false
  :enforce-opiskeluoikeus-match? false
  :prevent-finished-opiskeluoikeus-updates? false
- :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet]
+ :heratepalvelu-responsibities [:sync-amis-heratteet :sync-jakso-heratteet
+                                :send-initial-messages]
  :arvo-responsibilities [:create-kyselytunnus :create-jaksotunnus]
  :koski-opiskeluoikeus-cache-ttl-millis 1
  :koski-oppija-cache-ttl-millis 1}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>a7a335d4e4c3343b096b5ca1b68c84de1b015f7c</tag>
+    <tag>e883755fef70c73865897df9ccefba14bbd46f81</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -340,7 +340,12 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>6.5.7</version>
+        <version>11.20.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-database-postgresql</artifactId>
+        <version>11.20.3</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -518,6 +523,10 @@
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [com.taoensso/faraday]
                  [metosin/compojure-api]
                  [org.flywaydb/flyway-core]
+                 [org.flywaydb/flyway-database-postgresql]
                  [org.clojure/java.jdbc]
                  [org.postgresql/postgresql]
                  [com.layerware/hugsql]
@@ -81,7 +82,8 @@
 
                          ;; postgresql
                          [org.clojure/java.jdbc "0.7.12"]
-                         [org.flywaydb/flyway-core "6.5.7"]
+                         [org.flywaydb/flyway-core "11.20.3"]
+                         [org.flywaydb/flyway-database-postgresql "11.20.3"]
                          [org.postgresql/postgresql "42.7.7"]
                          [com.layerware/hugsql "0.5.3"]
 

--- a/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
+++ b/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
@@ -1,4 +1,5 @@
 SELECT kyselylinkki,
+       split_part(kyselylinkki, '/', -1) as arvo_tunniste,
        hoks_id,
        tyyppi,
        oppija_oid,
@@ -13,6 +14,7 @@ WHERE oppija_oid = ?
   AND alkupvm <= now()
 UNION
 SELECT p.kyselylinkki      AS kyselylinkki,
+       p.arvo_tunniste     AS arvo_tunniste,
        p.hoks_id           AS hoks_id,
        CASE
            WHEN p.kyselytyyppi = 'aloittaneet' THEN 'aloittaneet'
@@ -24,7 +26,7 @@ SELECT p.kyselylinkki      AS kyselylinkki,
        h.sahkoposti        AS sahkoposti,
        pv.created_at::date AS lahetyspvm,
        pv.tila::text       AS lahetystila,
-       null                AS vastattu,
+       p.tila = 'vastattu' AS vastattu,
        p.voimassa_loppupvm AS voimassa_loppupvm
 FROM palautteet p
          JOIN hoksit h ON h.id = p.hoks_id

--- a/resources/db/hoksit/select_kyselylinkit_by_vastaajatunnus.sql
+++ b/resources/db/hoksit/select_kyselylinkit_by_vastaajatunnus.sql
@@ -1,5 +1,6 @@
 SELECT
   k.*,
+  split_part(k.kyselylinkki, '/', -1) as arvo_tunniste,
   k.hoks_id AS hoks_id,
   o.oid AS oppijan_oid,
   o.nimi AS oppijan_nimi,
@@ -7,4 +8,4 @@ SELECT
 FROM kyselylinkit k
   LEFT OUTER JOIN oppijat AS o ON o.oid = k.oppija_oid
   LEFT OUTER JOIN hoksit AS h ON h.id = k.hoks_id
-WHERE k.kyselylinkki LIKE ?
+WHERE split_part(k.kyselylinkki, '/', -1) = ?

--- a/scripts/postgres-docker/Dockerfile
+++ b/scripts/postgres-docker/Dockerfile
@@ -1,6 +1,6 @@
 # Based on <https://hub.docker.com/_/postgres/>
 
-FROM docker.io/library/postgres:12.19
+FROM docker.io/library/postgres:15.12
 
 COPY ./configure-database.sh /docker-entrypoint-initdb.d/
 COPY ./configure-postgres.sh /docker-entrypoint-initdb.d/

--- a/scripts/postgres-docker/configure-database.sh
+++ b/scripts/postgres-docker/configure-database.sh
@@ -9,8 +9,10 @@ DB_APP_PASSWORD=ehoks
 
 echo "Creating database \"$DB_APP_DB\", creating role \"$DB_APP_USER\" with database owner privileges…"
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension pgcrypto;'
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension pg_trgm;'
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 \
+	-c 'create extension pgcrypto;'
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 \
+	-c 'create extension pg_trgm;'
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-END
 create role "${DB_APP_USER}" with password '${DB_APP_PASSWORD}' login;
@@ -19,3 +21,9 @@ create database "${DB_APP_DB_TEST}" encoding 'UTF-8';
 grant all privileges on database "${DB_APP_DB}" to "${DB_APP_USER}";
 grant all privileges on database "${DB_APP_DB_TEST}" to "${DB_APP_USER}";
 END
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_APP_DB" \
+ -c "grant all privileges on schema public to \"${DB_APP_USER}\";"
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_APP_DB_TEST" \
+ -c "grant all privileges on schema public to \"${DB_APP_USER}\";"

--- a/src/db/migration/V1_1773665567109__OHT_HOKS_mapping_view.sql
+++ b/src/db/migration/V1_1773665567109__OHT_HOKS_mapping_view.sql
@@ -1,0 +1,39 @@
+create view oht_hoks_mapping as
+ select	oht.id as hankkimistapa_id,
+	oht.yksiloiva_tunniste,
+	osa.hoks_id
+ from	hankittavat_ammat_tutkinnon_osat osa
+ join	hankittavan_ammat_tutkinnon_osan_osaamisen_hankkimistavat osaoh
+	on (osa.id = osaoh.hankittava_ammat_tutkinnon_osa_id)
+ join	osaamisen_hankkimistavat oht
+	on (osaoh.osaamisen_hankkimistapa_id = oht.id)
+ where	osa.deleted_at is null
+ and	osaoh.deleted_at is null
+ and	oht.deleted_at is null
+union
+ select	oht.id as hankkimistapa_id,
+	oht.yksiloiva_tunniste,
+	osa.hoks_id
+ from	hankittavat_paikalliset_tutkinnon_osat osa
+ join	hankittavan_paikallisen_tutkinnon_osan_osaamisen_hankkimistavat osaoh
+	on (osa.id = osaoh.hankittava_paikallinen_tutkinnon_osa_id)
+ join	osaamisen_hankkimistavat oht
+	on (osaoh.osaamisen_hankkimistapa_id = oht.id)
+ where	osa.deleted_at is null
+ and	osaoh.deleted_at is null
+ and	oht.deleted_at is null
+union
+ select	oht.id as hankkimistapa_id,
+	oht.yksiloiva_tunniste,
+	osa.hoks_id
+ from	hankittavat_yhteiset_tutkinnon_osat osa
+ join	yhteisen_tutkinnon_osan_osa_alueet alue
+	on (osa.id = alue.yhteinen_tutkinnon_osa_id)
+ join	yhteisen_tutkinnon_osan_osa_alueen_osaamisen_hankkimistavat alueoh
+	on (alue.id = alueoh.yhteisen_tutkinnon_osan_osa_alue_id)
+ join	osaamisen_hankkimistavat oht
+	on (alueoh.osaamisen_hankkimistapa_id = oht.id)
+ where	osa.deleted_at is null
+ and	alue.deleted_at is null
+ and	alueoh.deleted_at is null
+ and	oht.deleted_at is null;

--- a/src/db/migration/V1_1773670254847__lahetys_tapahtumatyyppi.sql
+++ b/src/db/migration/V1_1773670254847__lahetys_tapahtumatyyppi.sql
@@ -1,0 +1,3 @@
+
+ALTER TYPE tapahtumatyypit ADD VALUE IF NOT EXISTS 'lahetys';
+

--- a/src/oph/ehoks/db/dynamodb.clj
+++ b/src/oph/ehoks/db/dynamodb.clj
@@ -102,11 +102,20 @@
 
 (defn sync-amis-herate!
   "Put information for single opiskelijapalaute to herätepalvelu DDB."
-  [kyselyrecord]
-  (if-not (contains? (set (:heratepalvelu-responsibities config))
-                     :sync-amis-heratteet)
-    (log/info "sync-amis-herate!: configured to not write to DDB.")
-    (sync-item! :amis kyselyrecord)))
+  [kyselyrecord processing-phase]
+  (let [resp (set (:heratepalvelu-responsibities config))]
+    (cond
+      (not (contains? resp :sync-amis-heratteet))
+      (log/info "sync-amis-herate!: configured to not write to DDB.")
+
+      ;; this phase recognition might be better based directly on
+      ;; the tila of given palaute (which is part of the kyselyrecord)
+      (and (= processing-phase :after-arvo-call)
+           (contains? resp :send-initial-messages))
+      (log/info "sync-amis-herate!: not syncing amis heräte"
+                "before its messages have been sent.")
+
+      :else (sync-item! :amis kyselyrecord))))
 
 (defn get-jakso-by-hoks-id-and-yksiloiva-tunniste!
   "Get työelämäjakso from DDB."

--- a/src/oph/ehoks/db/migrations.clj
+++ b/src/oph/ehoks/db/migrations.clj
@@ -8,15 +8,15 @@
     (-> (Flyway/configure)
         (.dataSource
           (format
-            "jdbc:%s://%s:%d/%s?user=%s&password=%s"
+            "jdbc:%s://%s:%d/%s"
             (:db-type config)
             (:db-server config)
             (:db-port config)
-            (:db-name config)
-            (:db-username config)
-            (:db-password config))
-          nil
-          nil)
+            (:db-name config))
+          (:db-username config)
+          (:db-password config))
+        (.configuration {"flyway.postgresql.transactional.lock" false})
+        (.cleanDisabled false)
         (.load))))
 
 (defn migrate!

--- a/src/oph/ehoks/db/postgresql/common.clj
+++ b/src/oph/ehoks/db/postgresql/common.clj
@@ -155,7 +155,7 @@
   "Hakee kyselylinkit tietokannasta tunnuksen perusteella."
   [tunnus]
   (db-ops/query
-    [queries/select-kyselylinkit-by-fuzzy-linkki (str "%/" tunnus)]
+    [queries/select-kyselylinkit-by-vastaajatunnus tunnus]
     {:row-fn db-ops/from-sql}))
 
 (defn delete-kyselylinkki-by-tunnus

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -122,8 +122,8 @@
       "hoksit/select_kyselylinkki.sql")
 (defq select-kyselylinkit-by-oppija-oid
       "hoksit/select_kyselylinkit_by_oppija_oid.sql")
-(defq select-kyselylinkit-by-fuzzy-linkki
-      "hoksit/select_kyselylinkit_by_fuzzy_linkki.sql")
+(defq select-kyselylinkit-by-vastaajatunnus
+      "hoksit/select_kyselylinkit_by_vastaajatunnus.sql")
 (defq select-hoksit-by-ensikert-hyvaks-and-saavutettu-tiedot
       "hoksit/select_hoksit_by_ensikert_hyvaks_and_saavutettu_tiedot.sql")
 (defq select-paattyneet-tyoelamajaksot-hato

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -37,6 +37,20 @@ and	p.heratepvm <= now()
 and	p.deleted_at is null
 order by hoks_id asc
 
+-- :name get-unsent-palautteet! :? :*
+-- :doc Fetch palautteet with kyselylinkki but without sent messages.
+select * from palautteet p
+where kyselytyyppi in (:v*:kyselytyypit)
+  and kyselylinkki is not null
+  and tila in ('kysely_muodostettu', 'vastaajatunnus_muodostettu')
+  and not exists (
+	select 1 from palaute_viestit pv
+	where pv.palaute_id = p.id
+	  and viestityyppi = :viestityyppi
+	  and tila in ('odottaa_lahetysta', 'lahetetty'))
+  and deleted_at is null
+order by hoks_id asc
+
 -- :name update-arvo-tunniste! :? :*
 -- :doc Update arvo-tunniste for palaute with given id.
 update	palautteet

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -9,46 +9,6 @@ insert into palautteet (
 
 -- :name get-palautteet-waiting-for-vastaajatunnus! :? :*
 -- :doc List all unhandled palautteet whose herätepäivä has come
-with oht_hoks_mapping as not materialized (
- select	oht.id as hankkimistapa_id,
-	oht.yksiloiva_tunniste,
-	osa.hoks_id
- from	hankittavat_ammat_tutkinnon_osat osa
- join	hankittavan_ammat_tutkinnon_osan_osaamisen_hankkimistavat osaoh
-	on (osa.id = osaoh.hankittava_ammat_tutkinnon_osa_id)
- join	osaamisen_hankkimistavat oht
-	on (osaoh.osaamisen_hankkimistapa_id = oht.id)
- where	osa.deleted_at is null
- and	osaoh.deleted_at is null
- and	oht.deleted_at is null
-union
- select	oht.id as hankkimistapa_id,
-	oht.yksiloiva_tunniste,
-	osa.hoks_id
- from	hankittavat_paikalliset_tutkinnon_osat osa
- join	hankittavan_paikallisen_tutkinnon_osan_osaamisen_hankkimistavat osaoh
-	on (osa.id = osaoh.hankittava_paikallinen_tutkinnon_osa_id)
- join	osaamisen_hankkimistavat oht
-	on (osaoh.osaamisen_hankkimistapa_id = oht.id)
- where	osa.deleted_at is null
- and	osaoh.deleted_at is null
- and	oht.deleted_at is null
-union
- select	oht.id as hankkimistapa_id,
-	oht.yksiloiva_tunniste,
-	osa.hoks_id
- from	hankittavat_yhteiset_tutkinnon_osat osa
- join	yhteisen_tutkinnon_osan_osa_alueet alue
-	on (osa.id = alue.yhteinen_tutkinnon_osa_id)
- join	yhteisen_tutkinnon_osan_osa_alueen_osaamisen_hankkimistavat alueoh
-	on (alue.id = alueoh.yhteisen_tutkinnon_osan_osa_alue_id)
- join	osaamisen_hankkimistavat oht
-	on (alueoh.osaamisen_hankkimistapa_id = oht.id)
- where	osa.deleted_at is null
- and	alue.deleted_at is null
- and	alueoh.deleted_at is null
- and	oht.deleted_at is null
-)
 select	p.id,
 	p.hoks_id,
 	p.heratepvm,

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -7,6 +7,16 @@ insert into palautteet (
 --~ (sql/values-for-insert params)
 ) returning *
 
+-- :name get-palaute-with-hankkimistapa-id-by-id! :? :*
+select	p.*, ohm.hankkimistapa_id
+from	palautteet p
+left join oht_hoks_mapping ohm
+on	(p.hoks_id = ohm.hoks_id
+		and p.jakson_yksiloiva_tunniste = ohm.yksiloiva_tunniste)
+where	(:hoks-id ::int is null or p.hoks_id = :hoks-id ::int)
+and	(:palaute-id ::int is null or p.id = :palaute-id ::int)
+and	p.deleted_at is null
+
 -- :name get-palautteet-waiting-for-vastaajatunnus! :? :*
 -- :doc List all unhandled palautteet whose herätepäivä has come
 select	p.id,
@@ -23,8 +33,6 @@ on	(p.hoks_id = ohm.hoks_id
 		and p.jakson_yksiloiva_tunniste = ohm.yksiloiva_tunniste)
 where	p.tila = 'odottaa_kasittelya'
 and	p.kyselytyyppi in (:v*:kyselytyypit)
-and	(:hoks-id ::int is null or p.hoks_id = :hoks-id ::int)
-and	(:palaute-id ::int is null or p.id = :palaute-id ::int)
 and	p.heratepvm <= now()
 and	p.deleted_at is null
 order by hoks_id asc

--- a/src/oph/ehoks/db/sql/palauteviesti.sql
+++ b/src/oph/ehoks/db/sql/palauteviesti.sql
@@ -1,0 +1,29 @@
+-- :name insert!
+-- :doc Create a new palaute message record.
+
+INSERT INTO palaute_viestit (
+	palaute_id,
+	vastaanottaja,
+	viestityyppi,
+	tila,
+	ulkoinen_tunniste)
+VALUES (
+	:palaute-id,
+	:vastaanottaja,
+	:viestityyppi,
+	:tila,
+	:ulkoinen-tunniste)
+RETURNING id
+
+-- :name get-by-tila-and-viestityypit!
+-- :doc Fetch all messages (along with their respective palautteet) from
+-- given viestityypit in given tila
+
+SELECT p.tila AS palaute_tila, pv.*
+FROM palaute_viestit pv
+LEFT JOIN palautteet p ON (pv.palaute_id = p.id)
+WHERE pv.viestityyppi in (:v*:viestityypit)
+AND pv.tila = :tila
+AND pv.deleted_at IS NULL
+AND p.deleted_at IS NULL
+

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -1,6 +1,5 @@
 (ns oph.ehoks.external.arvo
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
@@ -22,14 +21,12 @@
         (c/with-api-headers)
         :body)))
 
-(defn get-kyselylinkki-status!
+(defn get-kyselytunnus-status!
   "Hakee kyselylinkin tilan Arvosta."
-  [kyselylinkki]
-  (try (->> (str/split kyselylinkki #"/")
-            last
-            (str "/vastauslinkki/v1/status/")
+  [vastaajatunnus]
+  (try (->> (str "/vastauslinkki/v1/status/" vastaajatunnus)
             (call! :get)
-            utils/to-dash-keys)
+            (utils/to-dash-keys))
        (catch ExceptionInfo e
          (when-not (= 404 (:status (ex-data e)))
            (throw e)))))

--- a/src/oph/ehoks/heratepalvelu.clj
+++ b/src/oph/ehoks/heratepalvelu.clj
@@ -59,7 +59,7 @@
 
 (defn sync-jakso!
   "Put information about single työelämäpalaute to herätepalvelu DDB."
-  [jaksorecord]
+  [jaksorecord _] ; processing phase
   (if-not (contains? (set (:heratepalvelu-responsibities config))
                      :sync-jakso-heratteet)
     (log/info "sync-jakso!: configured to not write to DDB.")

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -141,12 +141,16 @@
     (db-handler tx palaute)))
 
 (defn update-tila!
-  [{:keys [existing-palaute] :as ctx} tila reason lisatiedot]
-  (jdbc/with-db-transaction
-    [tx db/spec]
-    (update! tx {:id   (:id existing-palaute)
-                 :tila (utils/to-underscore-str tila)})
-    (tapahtuma/build-and-insert! ctx tila reason lisatiedot)))
+  "Update palaute (given in :existing-palaute in ctx) to state tila."
+  [{:keys [existing-palaute tx] :as ctx} tila reason lisatiedot]
+  (if (not tx)
+    (jdbc/with-db-transaction
+      [tx db/spec]
+      (update-tila! (assoc ctx :tx tx) tila reason lisatiedot))
+    (do
+      (update! tx {:id   (:id existing-palaute)
+                   :tila (utils/to-underscore-str tila)})
+      (tapahtuma/build-and-insert! ctx tila reason lisatiedot))))
 
 (defn feedback-collecting-prevented?
   "Jätetäänkö palaute keräämättä sen vuoksi, että opiskelijan opiskelu on

--- a/src/oph/ehoks/palaute/handler.clj
+++ b/src/oph/ehoks/palaute/handler.clj
@@ -35,11 +35,8 @@
             (c-api/POST "/:hoks-id/kyselylinkki" [hoks-id]
               :summary "Luo yhden HOKSin kyselylinkit, jos niitä ei ole luotu."
               (let [amis-palautteet
-                    (palaute/get-palautteet-waiting-for-vastaajatunnus!
-                      db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"
-                                              "osia_suorittaneet"]
-                               :hoks-id hoks-id
-                               :palaute-id nil})
+                    (palaute/get-palaute-with-hankkimistapa-id-by-id!
+                      db/spec {:hoks-id hoks-id :palaute-id nil})
                     vastaajatunnukset
                     (map vt/handle-palaute-waiting-for-heratepvm!
                          amis-palautteet)]
@@ -65,11 +62,8 @@
                               ticket :- s/Str]
               :path-params [palaute-id :- s/Int]
               (let [tep-palautteet
-                    (palaute/get-palautteet-waiting-for-vastaajatunnus!
-                      db/spec
-                      {:kyselytyypit ["tyopaikkajakson_suorittaneet"]
-                       :palaute-id palaute-id
-                       :hoks-id nil})
+                    (palaute/get-palaute-with-hankkimistapa-id-by-id!
+                      db/spec {:palaute-id palaute-id :hoks-id nil})
                     vastaajatunnukset
                     (map vt/handle-palaute-waiting-for-heratepvm!
                          tep-palautteet)]

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -1,7 +1,14 @@
 (ns oph.ehoks.palaute.lahetys
-  (:require [oph.ehoks.palaute.viestit :as v]
+  (:require [clojure.tools.logging :as log]
+            [clojure.string :as str]
+            [oph.ehoks.db :as db]
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
-            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]))
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.vastaajatunnus :as vt]
+            [oph.ehoks.palaute.viestit :as v]
+            [oph.ehoks.utils.date :as dateutil])
+  (:import (java.time LocalDate)))
 
 (defn send-palaute-initial-email!
   "Lähettää viestin, jossa kutsutaan vastaamaan Arvossa olevaan kyselyyn."
@@ -15,3 +22,76 @@
                                         :kyselylinkki kyselylinkki})
         email-subject (v/palaute-message-subject ctx)]
     (vvp/send-message! recipient email-subject email-body)))
+
+(defn vastausaika-loppunut?
+  "Onko kyselylinkin arvo-statuksessa vastausajan loppupvm saavutettu?"
+  [status]
+  (when-let [loppupvm (:voimassa_loppupvm status)]
+    (let [enddate (LocalDate/parse (first (str/split loppupvm #"T")))]
+      (dateutil/is-after (dateutil/now) enddate))))
+
+(defn vastattu?
+  "Onko kyselylinkin arvo-statuksessa kysely merkitty vastatuksi?"
+  [status]
+  (:vastattu status))
+
+;; this should be put into handlers if the logic is different for tep
+(defn check-palaute-for-sending
+  "Kertoo mihin tilaan palaute ja sen viesti menee tilanteen perusteella.
+  Palauttaa seuraavat tiedot:
+  viestin uusi tila (nil = ei tehdä viestiä),
+  palautteen uusi tila (nil = ei muutu),
+  kenttä jonka perusteella päätös tehty,
+  päätöksen syy -tagi."
+  [{:keys [hoks existing-palaute existing-ddb-herate arvo-status]}]
+  (cond
+    (and existing-ddb-herate (seq @existing-ddb-herate))
+    [nil :heratepalvelussa :heratepvm :heratepalvelun-vastuulla]
+
+    (empty? (:sahkoposti hoks))
+    [:lahetys-epaonnistunut nil :sahkoposti :ei-ole]
+
+    (empty? (:kyselylinkki existing-palaute))
+    [nil :odottaa-kasittelya :kyselylinkki :ei-ole]
+
+    (and arvo-status (empty? @arvo-status))
+    [nil nil :kyselylinkki :ei-loydy]
+
+    (and arvo-status (vastausaika-loppunut? @arvo-status))
+    [nil :vastausaika-loppunut :voimassa-loppupvm :arvo-paivitys]
+
+    (and arvo-status (vastattu? @arvo-status))
+    [nil :vastattu :heratepvm :arvo-paivitys]
+
+    :else
+    [:odottaa-lahetysta nil :voimassa-alkupvm :kysely-muodostettu]))
+
+(defn palaute-check-send-save-and-sync!
+  "Tekee kaikki palautekutsun lähetyksen vaiheet"
+  [{:keys [existing-palaute hoks tx] :as ctx} _] ; no handlers used yet
+  (let [[msg-state state field reason] (check-palaute-for-sending ctx)]
+    (log/info "Message state for palaute" (:id existing-palaute)
+              "of HOKS" (:id hoks) "is" (or msg-state :ei-laheteta)
+              "and state for palaute is" (or state "unchanged")
+              "because of" reason "in" field)
+    nil))  ; stub
+
+(defn handle-unsent-palaute!
+  "Lähettää viestin yhdelle palautteelle, jos aiheellista."
+  [palaute]
+  (log/info "Sending survey invitation for" (:kyselytyyppi palaute)
+            "palaute" (:id palaute))
+  (vt/call-with-context-and-error-handling
+    :lahetys palaute-check-send-save-and-sync! palaute))
+
+(defn handle-unsent-palautteet!
+  "Hakee ja lähettää viestit (kyselykutsut) kaikille palautteille
+  joilla on kyselylinkki mutta viestiä ei ole vielä lähetetty."
+  [kyselytyypit]
+  ;; tep-viestejä ei ole vielä toteutettu
+  (assert (not (contains? (set kyselytyypit) "tyopaikkajakson_suorittaneet")))
+  (log/info "Sending messages for kyselytyypit" kyselytyypit)
+  (doall (map handle-unsent-palaute!
+              (palaute/get-unsent-palautteet!
+                db/spec {:kyselytyypit kyselytyypit
+                         :viestityyppi "email"}))))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -1,14 +1,22 @@
 (ns oph.ehoks.palaute.lahetys
   (:require [clojure.tools.logging :as log]
             [clojure.string :as str]
+            [hugsql.core :as hugsql]
             [oph.ehoks.db :as db]
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.tapahtuma :as pt]
             [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.palaute.viestit :as v]
+            [oph.ehoks.utils :as utils]
             [oph.ehoks.utils.date :as dateutil])
-  (:import (java.time LocalDate)))
+  (:import (java.time LocalDate)
+           (clojure.lang ExceptionInfo)))
+
+(declare insert!)
+(declare get-by-tila-and-viestityypit!)
+(hugsql/def-db-fns "oph/ehoks/db/sql/palauteviesti.sql")
 
 (defn send-palaute-initial-email!
   "Lähettää viestin, jossa kutsutaan vastaamaan Arvossa olevaan kyselyyn."
@@ -26,7 +34,7 @@
 (defn vastausaika-loppunut?
   "Onko kyselylinkin arvo-statuksessa vastausajan loppupvm saavutettu?"
   [status]
-  (when-let [loppupvm (:voimassa_loppupvm status)]
+  (when-let [loppupvm (:voimassa-loppupvm status)]
     (let [enddate (LocalDate/parse (first (str/split loppupvm #"T")))]
       (dateutil/is-after (dateutil/now) enddate))))
 
@@ -64,17 +72,53 @@
     [nil :vastattu :heratepvm :arvo-paivitys]
 
     :else
-    [:odottaa-lahetysta nil :voimassa-alkupvm :kysely-muodostettu]))
+    [:odottaa-lahetysta nil :voimassa-alkupvm :viesti-lahetys]))
+
+(defn record-palauteviesti!
+  "Record in DB the palauteviesti that was (not) sent."
+  [{:keys [existing-palaute hoks tx]} msg-state msg-id]
+  (insert! tx {:palaute-id (:id existing-palaute)
+               :vastaanottaja (:sahkoposti hoks)
+               :viestityyppi "email"
+               :tila (utils/to-underscore-str msg-state)
+               :ulkoinen-tunniste msg-id}))
 
 (defn palaute-check-send-save-and-sync!
   "Tekee kaikki palautekutsun lähetyksen vaiheet"
-  [{:keys [existing-palaute hoks tx] :as ctx} _] ; no handlers used yet
-  (let [[msg-state state field reason] (check-palaute-for-sending ctx)]
+  [{:keys [existing-palaute hoks] :as ctx} _] ; no handlers used yet
+  (let [[msg-state state field reason] (check-palaute-for-sending ctx)
+        reporting-msg-state (or msg-state :ei-laheteta)
+        additional-info {field (str (get existing-palaute field))
+                         :msg-state reporting-msg-state}]
     (log/info "Message state for palaute" (:id existing-palaute)
-              "of HOKS" (:id hoks) "is" (or msg-state :ei-laheteta)
+              "of HOKS" (:id hoks) "is" reporting-msg-state
               "and state for palaute is" (or state "unchanged")
               "because of" reason "in" field)
-    nil))  ; stub
+    ;; do DB stuff first because it's easier to cancel (exceptions will
+    ;; roll back the transaction)
+    (palaute/update-tila!
+      ctx (or state (:tila existing-palaute)) reason additional-info)
+    (when msg-state
+      (try
+        (let [msg-id (when (= msg-state :odottaa-lahetysta)
+                       (send-palaute-initial-email! ctx))]
+          (record-palauteviesti! ctx msg-state msg-id)
+          msg-id)
+        (catch ExceptionInfo e
+          ;; Most typical reason is that sending failed for some reason
+          ;; (and no message has been queued).  This means that there is
+          ;; no harm in retrying.  However, we handle the 400 case as
+          ;; permanent failure because 400 results are pretty certain to
+          ;; persist even if we retry.
+          (if (= 400 (:status (ex-data e)))
+            (do (record-palauteviesti! ctx :lahetys-epaonnistunut nil)
+                (pt/build-and-insert!
+                  ctx ::viestin-lahetys-epaonnistui
+                  {:errormsg (ex-message e)
+                   :body     (:body (ex-data e))}))
+            (throw (ex-info "Viestin lähetyksessä tapahtui virhe"
+                            {:type ::viestin-lahetys-epaonnistui :ctx ctx}
+                            e))))))))
 
 (defn handle-unsent-palaute!
   "Lähettää viestin yhdelle palautteelle, jos aiheellista."

--- a/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
+++ b/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
@@ -32,8 +32,9 @@
   "Fetch the latest status (mainly, `:vastattu` and `voimassa-loppupvm`) of
   `kyselylinkki` from Arvo and update it accordingly."
   [kyselylinkki]
-  (let [linkki (:kyselylinkki kyselylinkki)]
-    (if-let [status (arvo/get-kyselylinkki-status! linkki)]
+  (let [vastaajatunnus (:arvo-tunniste kyselylinkki)
+        linkki (:kyselylinkki kyselylinkki)]
+    (if-let [status (arvo/get-kyselytunnus-status! vastaajatunnus)]
       (let [updates {:vastattu          (:vastattu status)
                      :voimassa-loppupvm
                      (LocalDate/parse

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -155,7 +155,7 @@
   "Makes sure that the nippu for the työelämäpalaute exists in
   herätepalvelu's data base.  Without this, herätepalvelu doesn't know
   what to niputtaa when it's time."
-  [{:keys [arvo-response] :as ctx}]
+  [{:keys [arvo-response] :as ctx} _] ;; processing phase
   (heratepalvelu/sync-tpo-nippu!
     (nippu/build-tpo-nippu-for-heratepalvelu ctx)
     (:tunnus arvo-response)))

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -210,8 +210,8 @@
    {:keys [heratepalvelu-builder heratepalvelu-caller extra-handlers]}]
   (log/info "Replicating palaute" (:id existing-palaute) "to herätepalvelu")
   (try
-    (heratepalvelu-caller (heratepalvelu-builder ctx))
-    (doseq [handler extra-handlers] (handler ctx))
+    (heratepalvelu-caller (heratepalvelu-builder ctx) :after-arvo-call)
+    (doseq [handler extra-handlers] (handler ctx :after-arvo-call))
     (catch Exception e
       (log/warn "Herätepalvelu sync error:" (ex-message e) (:body (ex-data e)))
       (throw (ex-info

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -252,7 +252,7 @@
     (jdbc/with-db-transaction
       [tx db/spec]
       (handler
-        (assoc (build-ctx! palaute) :tx tx)
+        (assoc (build-ctx! palaute) :tapahtumatyyppi tapahtumatyyppi :tx tx)
         (if (:jakson-yksiloiva-tunniste palaute) tep/handlers amis/handlers)))
     (catch ExceptionInfo e
       (jdbc/with-db-transaction

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -46,8 +46,8 @@
            (delay (palaute-ddb-record existing-palaute hoks koulutustoimija))
            :arvo-status
            ;; needs more logic when tep-palaute may also be queried
-           (delay (some-> (:kyselylinkki existing-palaute)
-                          (arvo/get-kyselylinkki-status!)))
+           (delay (some-> (:arvo-tunniste existing-palaute)
+                          (arvo/get-kyselytunnus-status!)))
            :niputuspvm            (tep/next-niputus-date (date/now))
            :vastaamisajan-alkupvm (tep/next-niputus-date
                                     (:heratepvm existing-palaute))

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -20,6 +20,18 @@
   (:import (clojure.lang ExceptionInfo)
            (java.util UUID)))
 
+(defn palaute-ddb-record
+  "Hakee DynamoDB:stä palautetta vastaavan tietueen."
+  [palaute hoks koulutustoimija]
+  (if (:jakson-yksiloiva-tunniste palaute)
+    (ddb/get-jakso-by-hoks-id-and-yksiloiva-tunniste!
+      (:id hoks) (:jakson-yksiloiva-tunniste palaute))
+    (ddb/get-item!
+      :amis {:toimija_oppija (str koulutustoimija "/" (:oppija-oid hoks))
+             :tyyppi_kausi
+             (str (amis/translate-kyselytyyppi (:kyselytyyppi palaute))
+                  "/" (palaute/rahoituskausi (:heratepvm palaute)))})))
+
 (defn- enrich-ctx!
   "Lisää muista palveluista saatavia tietoja kontekstiin myöhempää
   käsittelyä varten."
@@ -31,24 +43,18 @@
         koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)]
     (assoc ctx
            :existing-ddb-herate
-           (delay
-             (if (:jakson-yksiloiva-tunniste existing-palaute)
-               (ddb/get-jakso-by-hoks-id-and-yksiloiva-tunniste!
-                 (:id hoks) (:jakson-yksiloiva-tunniste existing-palaute))
-               (ddb/get-item!
-                 :amis
-                 {:toimija_oppija (str koulutustoimija "/" (:oppija-oid hoks))
-                  :tyyppi_kausi   (format "%s/%s"
-                                          (amis/translate-kyselytyyppi
-                                            (:kyselytyyppi existing-palaute))
-                                          (palaute/rahoituskausi
-                                            (:heratepvm existing-palaute)))})))
+           (delay (palaute-ddb-record existing-palaute hoks koulutustoimija))
+           :arvo-status
+           ;; needs more logic when tep-palaute may also be queried
+           (delay (some-> (:kyselylinkki existing-palaute)
+                          (arvo/get-kyselylinkki-status!)))
            :niputuspvm            (tep/next-niputus-date (date/now))
            :vastaamisajan-alkupvm (tep/next-niputus-date
                                     (:heratepvm existing-palaute))
            :opiskeluoikeus opiskeluoikeus
            :suoritus suoritus
-           :hk-toteuttaja (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
+           :hk-toteuttaja
+           (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
            :koulutustoimija koulutustoimija
            :toimipiste (palaute/toimipiste-oid! suoritus))))
 
@@ -111,8 +117,9 @@
 
 (def hoks-cache-amount
   "How many HOKSes we cache.  Palautteet from
-  palaute/get-palautteet-waiting-for-vastaajatunnus! are ordered by
-  hoks-id, so 1 should suffice."
+  palaute/get-palautteet-waiting-for-vastaajatunnus! and
+  palaute/get-unsent-palautteet! are ordered by hoks-id, so 1 should
+  suffice."
   2)
 
 (def hoks-cache-time

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -275,8 +275,7 @@
   (log/info "Creating vastaajatunnukset for kyselytyypit" kyselytyypit)
   (doall (map handle-palaute-waiting-for-heratepvm!
               (palaute/get-palautteet-waiting-for-vastaajatunnus!
-                db/spec {:kyselytyypit kyselytyypit
-                         :hoks-id nil :palaute-id nil}))))
+                db/spec {:kyselytyypit kyselytyypit}))))
 
 (defn handle-amis-palautteet-on-heratepvm!
   "Create kyselylinkki for palautteet whose herätepvm has come but

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -237,28 +237,35 @@
         (palaute/update-tila! ctx state reason lisatiedot))
       (tapahtuma/build-and-insert! ctx reason lisatiedot))))
 
-(defn handle-palaute-waiting-for-heratepvm!
-  "Check that palaute is part of kohderyhmä and create and save
-  vastaajatunnus if so."
-  [palaute]
+(defn call-with-context-and-error-handling
+  "Process one palaute with given handler, giving full context to the
+  handler and processing any errors"
+  [tapahtumatyyppi handler palaute]
   (try
     (jdbc/with-db-transaction
       [tx db/spec]
-      (log/info "Creating vastaajatunnus for" (:kyselytyyppi palaute)
-                "palaute" (:id palaute))
-      (palaute-check-call-arvo-save-and-sync!
+      (handler
         (assoc (build-ctx! palaute) :tx tx)
         (if (:jakson-yksiloiva-tunniste palaute) tep/handlers amis/handlers)))
     (catch ExceptionInfo e
       (jdbc/with-db-transaction
         [tx db/spec]
         (-> (:ctx (ex-data e))
-            (or {:existing-palaute palaute})
-            (assoc :tapahtumatyyppi :arvo-luonti :tx tx)
+            (or {:existing-palaute palaute})  ; poor person's context
+            (assoc :tapahtumatyyppi tapahtumatyyppi :tx tx)
             (handle-exception e)))
-      nil) ; no arvo-tunnus created
+      nil) ; handler failed, nothing created
     (catch Exception e
       (log/error e "Unknown error processing palaute" palaute))))
+
+(defn handle-palaute-waiting-for-heratepvm!
+  "Check that palaute is part of kohderyhmä and create and save
+  vastaajatunnus if so."
+  [palaute]
+  (log/info "Creating vastaajatunnus for" (:kyselytyyppi palaute)
+            "palaute" (:id palaute))
+  (call-with-context-and-error-handling
+    :arvo-luonti palaute-check-call-arvo-save-and-sync! palaute))
 
 (defn handle-palautteet-waiting-for-heratepvm!
   "Fetch all unhandled palautteet whose heratepvm has come, check that

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -594,7 +594,8 @@
                                 (kyselylinkki/get-by-oppija-oid! oppija-oid))
                               lahetysdata
                               (map
-                                #(dissoc %1 :kyselylinkki :vastattu)
+                                #(dissoc %1 :kyselylinkki :vastattu
+                                         :arvo-tunniste)
                                 (filter
                                   #(and
                                      (= (:hoks-id %1) hoks-id)

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -54,7 +54,7 @@
             amis-herate
             (opiskelija/build-amisherate-record-for-heratepalvelu ctx)]
         (is (= (:sahkoposti (:hoks ctx)) "irma.isomerkki@esimerkki.com"))
-        (ddb/sync-amis-herate! amis-herate)
+        (ddb/sync-amis-herate! amis-herate :after-all-processing)
         (let [ddb-key {:tyyppi_kausi
                        (str "aloittaneet/"
                             (palaute/rahoituskausi (LocalDate/now)))
@@ -68,7 +68,8 @@
                             :expr-attr-names {"#2" "viestintapalvelu-id"}
                             :expr-attr-vals {":1" "lahetetty"
                                              ":2" "2027-05-06"}})
-          (ddb/sync-amis-herate! (assoc amis-herate :sahkoposti "foo@bar.com"))
+          (ddb/sync-amis-herate! (assoc amis-herate :sahkoposti "foo@bar.com")
+                                 :after-all-processing)
           ; fields that are owned by herätepalvelu are not overwritten
           (let [new-ddb-item (ddb/get-item! :amis ddb-key)]
             (is (= (:sahkoposti new-ddb-item) "foo@bar.com"))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -1,8 +1,27 @@
 (ns oph.ehoks.palaute.lahetys-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [oph.ehoks.test-utils :as util]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as s]
-            [oph.ehoks.palaute.lahetys :as l]))
+            [oph.ehoks.db :as db]
+            [oph.ehoks.hoks.handler :as hoks-handler]
+            [oph.ehoks.hoks-test :as hoks-test]
+            [oph.ehoks.oppija.auth-handler-test :refer [mock-get-oppija-raw!]]
+            [oph.ehoks.external.http-client :refer [with-mock-responses]]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.external.koski-test :as koski-test]
+            [oph.ehoks.external.oppijanumerorekisteri :as onr]
+            [oph.ehoks.external.organisaatio :as organisaatio]
+            [oph.ehoks.external.organisaatio-test :as organisaatio-test]
+            [oph.ehoks.oppijaindex :as oppijaindex]
+            [oph.ehoks.opiskeluoikeus-test :as oo-test]
+            [oph.ehoks.test-utils :as util]
+            [oph.ehoks.utils.date :as date]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.lahetys :as l]
+            [oph.ehoks.palaute.vastaajatunnus :as vt])
+  (:import (java.time LocalDate)))
+
+(use-fixtures :once util/migrate-database)
+(use-fixtures :each util/empty-both-dbs-after-test)
 
 (def esim-ctx
   {:hoks {:id 1, :sahkoposti "testikayttaja@testi.fi"},
@@ -86,10 +105,138 @@
              (l/check-palaute-for-sending
                (assoc esim-ctx :arvo-status
                       (delay {:vastattu false
-                              :voimassa_loppupvm "2021-01-01T00:00:00Z"}))))))
+                              :voimassa-loppupvm "2021-01-01T00:00:00Z"}))))))
     (testing "don't send messages for already answered palautekysely"
       (is (= [nil :vastattu :heratepvm :arvo-paivitys]
              (l/check-palaute-for-sending
                (assoc esim-ctx :arvo-status
                       (delay {:vastattu true
-                              :voimassa_loppupvm "2051-01-01T00:00:00Z"}))))))))
+                              :voimassa-loppupvm "2051-01-01T00:00:00Z"}))))))))
+
+(deftest test-handle-unsent-palaute!
+  (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
+                koski/get-oppija-opiskeluoikeudet
+                koski-test/mock-get-oppija-opiskeluoikeudet
+                koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw
+                onr/get-oppija-raw!
+                mock-get-oppija-raw!
+                organisaatio/get-organisaatio!
+                organisaatio-test/mock-get-organisaatio!]
+    (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-1)
+    (let [hoks (hoks-handler/save-hoks-and-initiate-all-palautteet!
+                 {:hoks hoks-test/hoks-1
+                  :opiskeluoikeus oo-test/opiskeluoikeus-1})
+          sent-message (atom {})]
+      (testing "handle-unsent-palaute! sending messages"
+        (with-mock-responses
+          [(fn [_ __] {})
+           (fn [^String url _]
+             (when (s/ends-with? url "/api/vastauslinkki/v1")
+               {:status 200
+                :body {:tunnus "testivain"
+                       :kysely_linkki "https://arvovastaus.csc.fi/v/test"
+                       :voimassa_loppupvm "2024-10-10"}}))]
+          (->> {:kyselytyypit ["aloittaneet"]}
+               (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec)
+               (first)
+               (vt/handle-palaute-waiting-for-heratepvm!)))
+        (let [heratteet
+              (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
+                   (palaute/get-unsent-palautteet! db/spec))]
+          (is (= [["kysely_muodostettu" "aloittaneet"
+                   "https://arvovastaus.csc.fi/v/test"]]
+                 (map (juxt :tila :kyselytyyppi :kyselylinkki) heratteet)))
+
+          (testing "with unsuccessful sending"
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2026-04-14"
+                           :vastattu false}}))
+               (fn [^String url _]
+                 (when (s/ends-with? url "/lahetys/v1/viestit")
+                   (throw (ex-info
+                            "clj-http: status 400"
+                            {:status 400
+                             :body (str "{\"validointiVirheet\":["
+                                        "\"jokin on pakollinen\"]}")}))))]
+              (l/handle-unsent-palaute! (first heratteet)))
+            (is (= [["kysely_muodostettu" "aloittaneet"
+                     "https://arvovastaus.csc.fi/v/test"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
+            (is (= [["lahetys_epaonnistunut" "email" nil]]
+                   (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
+                        (l/get-by-tila-and-viestityypit! db/spec)
+                        (map (juxt :tila :viestityyppi :ulkoinen_tunniste))))))
+
+          (testing "with successful arvo-status and sending"
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2026-04-14"
+                           :vastattu false}}))
+               (fn [^String url options]
+                 (when (s/ends-with? url "/lahetys/v1/viestit")
+                   (reset! sent-message (:body options))
+                   {:status 200
+                    :body {:viestiTunniste "brymir"
+                           :lahetysTunniste "brymir"}}))]
+              (is (= "brymir" (l/handle-unsent-palaute! (first heratteet)))))
+            (is (s/includes?
+                  @sent-message
+                  "\"sahkopostiOsoite\":\"testi.testaaja@testidomain.testi\""))
+            (is (s/includes?
+                  @sent-message
+                  "https:\\/\\/arvovastaus.csc.fi\\/v\\/test?t=e<\\/a>"))
+            (is (= [] (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
+                           (palaute/get-unsent-palautteet! db/spec)
+                           (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
+            (is (= [["kysely_muodostettu" "aloittaneet"
+                     "https://arvovastaus.csc.fi/v/test"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
+            (is (= [["odottaa_lahetysta" "email" "brymir"]]
+                   (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                        (l/get-by-tila-and-viestityypit! db/spec)
+                        (map (juxt :tila :viestityyppi :ulkoinen_tunniste))))))
+
+          (testing "with expired kyselylinkki"
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2022-04-14"
+                           :vastattu false}}))
+               (fn [_ __] {})]
+              (is (nil? (l/handle-unsent-palaute! (first heratteet)))))
+            (is (= [["vastausaika_loppunut" "aloittaneet"
+                     "https://arvovastaus.csc.fi/v/test"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi :kyselylinkki))))))
+
+          (testing "with already vastattu kysely"
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2026-04-14"
+                           :vastattu true}}))
+               (fn [_ __] {})]
+              (is (nil? (l/handle-unsent-palaute! (first heratteet)))))
+            (is (= [["vastattu" "aloittaneet"
+                     "https://arvovastaus.csc.fi/v/test"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi :kyselylinkki))))))
+          nil)))))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -66,3 +66,30 @@
         (is (s/includes?
               (:body @req)
               "<p><a href=\\\"http:\\/\\/kysely?t=e\\\">"))))))
+
+(deftest test-check-palaute-for-sending
+  (testing "check-palaute-for-sending"
+    (testing "returns go for example context"
+      (is (= [:odottaa-lahetysta nil :voimassa-alkupvm :viesti-lahetys]
+             (l/check-palaute-for-sending esim-ctx))))
+    (testing "doesn't handle anything already in heratepalvelu"
+      (is (= [nil :heratepalvelussa :heratepvm :heratepalvelun-vastuulla]
+             (l/check-palaute-for-sending
+               (assoc esim-ctx :existing-ddb-herate
+                      (delay {:toimija_oppija "foo/bar"}))))))
+    (testing "no action if email is missing"
+      (is (= [:lahetys-epaonnistunut nil :sahkoposti :ei-ole]
+             (l/check-palaute-for-sending
+               (assoc-in esim-ctx [:hoks :sahkoposti] "")))))
+    (testing "don't send messages for overdue palautekysely"
+      (is (= [nil :vastausaika-loppunut :voimassa-loppupvm :arvo-paivitys]
+             (l/check-palaute-for-sending
+               (assoc esim-ctx :arvo-status
+                      (delay {:vastattu false
+                              :voimassa_loppupvm "2021-01-01T00:00:00Z"}))))))
+    (testing "don't send messages for already answered palautekysely"
+      (is (= [nil :vastattu :heratepvm :arvo-paivitys]
+             (l/check-palaute-for-sending
+               (assoc esim-ctx :arvo-status
+                      (delay {:vastattu true
+                              :voimassa_loppupvm "2051-01-01T00:00:00Z"}))))))))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -145,14 +145,15 @@
         (let [heratteet
               (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
                    (palaute/get-unsent-palautteet! db/spec))]
-          (is (= [["kysely_muodostettu" "aloittaneet"
+          (is (= [["kysely_muodostettu" "aloittaneet" "testivain"
                    "https://arvovastaus.csc.fi/v/test"]]
-                 (map (juxt :tila :kyselytyyppi :kyselylinkki) heratteet)))
+                 (map (juxt :tila :kyselytyyppi :arvo-tunniste :kyselylinkki)
+                      heratteet)))
 
           (testing "with unsuccessful sending"
             (with-mock-responses
               [(fn [url _]
-                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
                    {:status 200
                     :body {:tunnus "test"
                            :voimassa_loppupvm "2026-04-14"
@@ -178,7 +179,7 @@
           (testing "with successful arvo-status and sending"
             (with-mock-responses
               [(fn [url _]
-                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
                    {:status 200
                     :body {:tunnus "test"
                            :voimassa_loppupvm "2026-04-14"
@@ -212,7 +213,7 @@
           (testing "with expired kyselylinkki"
             (with-mock-responses
               [(fn [url _]
-                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
                    {:status 200
                     :body {:tunnus "test"
                            :voimassa_loppupvm "2022-04-14"
@@ -228,7 +229,7 @@
           (testing "with already vastattu kysely"
             (with-mock-responses
               [(fn [url _]
-                 (when (s/ends-with? url "/vastauslinkki/v1/status/test")
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
                    {:status 200
                     :body {:tunnus "test"
                            :voimassa_loppupvm "2026-04-14"

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as s]
             [oph.ehoks.db :as db]
+            [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.hoks.handler :as hoks-handler]
             [oph.ehoks.hoks-test :as hoks-test]
             [oph.ehoks.oppija.auth-handler-test :refer [mock-get-oppija-raw!]]
@@ -16,6 +17,7 @@
             [oph.ehoks.test-utils :as util]
             [oph.ehoks.utils.date :as date]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.opiskelija :as op]
             [oph.ehoks.palaute.lahetys :as l]
             [oph.ehoks.palaute.vastaajatunnus :as vt])
   (:import (java.time LocalDate)))
@@ -124,9 +126,8 @@
                 organisaatio/get-organisaatio!
                 organisaatio-test/mock-get-organisaatio!]
     (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-1)
-    (let [hoks (hoks-handler/save-hoks-and-initiate-all-palautteet!
-                 {:hoks hoks-test/hoks-1
-                  :opiskeluoikeus oo-test/opiskeluoikeus-1})
+    (let [ctx {:hoks hoks-test/hoks-1 :opiskeluoikeus oo-test/opiskeluoikeus-1}
+          hoks (hoks-handler/save-hoks-and-initiate-all-palautteet! ctx)
           sent-message (atom {})]
       (testing "handle-unsent-palaute! sending messages"
         (with-mock-responses
@@ -239,4 +240,18 @@
                    (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                         (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                         (map (juxt :tila :kyselytyyppi :kyselylinkki))))))
+
+          (testing "with a record already in Herätepalvelu"
+            (ddb/sync-amis-herate!
+              (op/build-amisherate-record-for-heratepalvelu
+                (assoc ctx
+                       :existing-palaute (first heratteet)
+                       :koulutustoimija "1.2.246.562.10.10000000009"
+                       :hk-toteuttaja (delay nil)))
+              :after-all-processing)
+            (is (nil? (l/handle-unsent-palaute! (first heratteet))))
+            (is (= [["heratepalvelussa" "aloittaneet"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi))))))
           nil)))))

--- a/test/oph/ehoks/palaute/opiskelija/kyselylinkki_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija/kyselylinkki_test.clj
@@ -7,11 +7,12 @@
 
 (deftest test-update-status!
   (testing "returns updated kyselylinkki when status is found"
-    (with-redefs [arvo/get-kyselylinkki-status!
+    (with-redefs [arvo/get-kyselytunnus-status!
                   (fn [_] {:vastattu          true
                            :voimassa-loppupvm "2025-12-31T00:00:00"})
                   oph.ehoks.palaute.opiskelija.kyselylinkki/update! identity]
-      (let [input {:kyselylinkki "https://testidomain.testi/ABC123"}
+      (let [input {:kyselylinkki "https://testidomain.testi/ABC123"
+                   :arvo-tunniste "ABC123"}
             result (kyselylinkki/update-status! input)]
         (is (= result
                (assoc input
@@ -19,12 +20,13 @@
                       :voimassa-loppupvm (LocalDate/of 2025 12 31)))))))
 
   (testing "returns original kyselylinkki when linkki is not found from Arvo"
-    (with-redefs [arvo/get-kyselylinkki-status! (fn [_] nil)
+    (with-redefs [arvo/get-kyselytunnus-status! (fn [_] nil)
                   oph.ehoks.palaute.opiskelija.kyselylinkki/update! identity]
       (with-log
-        (let [input {:kyselylinkki "ABC123"}
+        (let [input {:kyselylinkki "https://testidomain.testi/ABC123"
+                     :arvo-tunniste "ABC123"}
               result (kyselylinkki/update-status! input)]
           (is (= input result))
           (is (logged? 'oph.ehoks.palaute.opiskelija.kyselylinkki
                        :error
-                       #"kyselylinkki `ABC123` was not found from Arvo")))))))
+                       #"kyselylinkki `[^ ]*ABC123` was not found")))))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -282,8 +282,7 @@
                  {:hoks hoks-data :opiskeluoikeus oo-test/opiskeluoikeus-1})
           heratteet
           (palaute/get-palautteet-waiting-for-vastaajatunnus!
-            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]
-                     :hoks-id nil :palaute-id nil})]
+            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]})]
       (testing "HOKS with nonexistent opiskeluoikeus is marked as ei_laheteta"
         (with-redefs [koski/get-opiskeluoikeus-info-raw
                       mock-get-opiskeluoikeus-info-raw]
@@ -465,8 +464,7 @@
                   :opiskeluoikeus oo-test/opiskeluoikeus-1})
           heratteet
           (palaute/get-palautteet-waiting-for-vastaajatunnus!
-            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]
-                     :hoks-id nil :palaute-id nil})]
+            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]})]
       (testing "HOKS creation marks correct palautteet as actionable"
         (is (= [["odottaa_kasittelya" "aloittaneet"]
                 ["odottaa_kasittelya" "valmistuneet"]]
@@ -533,8 +531,7 @@
           vastauslinkki-counter (atom 0)
           heratteet
           (palaute/get-palautteet-waiting-for-vastaajatunnus!
-            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]
-                     :hoks-id nil :palaute-id nil})]
+            db/spec {:kyselytyypit ["aloittaneet" "valmistuneet"]})]
       (testing "successful Arvo call for amispalaute"
         (client/set-post!
           (fn [^String url options]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -421,7 +421,8 @@
                      :existing-palaute
                      {:kyselytyyppi "aloittaneet"
                       :heratepvm (:ensikertainen-hyvaksyminen
-                                   hoks-test/hoks-1)})))
+                                   hoks-test/hoks-1)}))
+            :after-all-processing)
           (ddb/sync-amis-herate!
             (op/build-amisherate-record-for-heratepalvelu
               (assoc ctx
@@ -430,7 +431,8 @@
                      :existing-palaute
                      {:kyselytyyppi "valmistuneet"
                       :heratepvm (:osaamisen-saavuttamisen-pvm
-                                   hoks-test/hoks-1)})))
+                                   hoks-test/hoks-1)}))
+            :after-all-processing)
           (are [kysely-type]
                (= :heratepalvelussa (op/initiate-if-needed! ctx kysely-type))
             :aloituskysely :paattokysely))
@@ -597,16 +599,13 @@
                     :vastattu          false
                     :sahkoposti        "testi.testaaja@testidomain.testi"
                     :voimassa-loppupvm (LocalDate/from loppupvm)}))))))
-      (testing "Palaute is synced to herätepalvelu after Arvo call"
+      (testing "Palaute is not synced to herätepalvelu after Arvo call"
         (let [ddb-key {:tyyppi_kausi "tutkinnon_suorittaneet/2023-2024"
                        :toimija_oppija
                        "1.2.246.562.10.346830761110/1.2.246.562.24.12312312319"}
               ddb-item (far/get-item
                          @ddb/faraday-opts @(ddb/tables :amis) ddb-key)]
-          (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
-          (is (= "https://arvovastaus.csc.fi/v/foo1" (:kyselylinkki ddb-item)))
-          (is (not (empty? (:request-id ddb-item))))
-          (is (= "351407" (str (:tutkintotunnus ddb-item))))))
+          (is (empty? ddb-item))))
       (testing "unsuccessful Arvo call for amispalaute"
         (client/set-post!
           (fn [^String url _]
@@ -674,9 +673,8 @@
                 organisaatio/get-organisaatio!
                 organisaatio-test/mock-get-organisaatio!]
     (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-4)
-    (let [hoks (hoks-handler/save-hoks-and-initiate-all-palautteet!
-                 {:hoks hoks-test/hoks-4
-                  :opiskeluoikeus oo-test/opiskeluoikeus-1})
+    (let [ctx {:hoks hoks-test/hoks-4 :opiskeluoikeus oo-test/opiskeluoikeus-1}
+          hoks (hoks-handler/save-hoks-and-initiate-all-palautteet! ctx)
           vastauslinkki-counter (atom 0)
           [aloituskysely paattokysely]
           (palaute/get-by-hoks-id-and-kyselytyypit!
@@ -706,9 +704,31 @@
           ; before vastaajatunnus creation.
           (palaute/update! db/spec aloituskysely)
           (palaute/update! db/spec paattokysely)
+          (ddb/sync-amis-herate!
+            (op/build-amisherate-record-for-heratepalvelu
+              (assoc ctx
+                     :existing-palaute aloituskysely
+                     :koulutustoimija "1.2.246.562.10.346830761110"
+                     :hk-toteuttaja (delay nil)))
+            :after-all-processing)
           (is (= 2 @vastauslinkki-counter))
           (vt/handle-amis-palautteet-on-heratepvm! {})
-          (is (= 2 @vastauslinkki-counter)) ; shouldn't be incremented
+          (is (= 3 @vastauslinkki-counter)) ; not incremented for aloitus
+          (is (= [["heratepalvelussa" "aloittaneet"]
+                  ["odottaa_kasittelya" "valmistuneet"]]
+                 (->> {:hoks-id (:id hoks)
+                       :kyselytyypit ["aloittaneet" "valmistuneet"]}
+                      (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                      (map (juxt :tila :kyselytyyppi)))))
+          (ddb/sync-amis-herate!
+            (op/build-amisherate-record-for-heratepalvelu
+              (assoc ctx
+                     :existing-palaute paattokysely
+                     :koulutustoimija "1.2.246.562.10.346830761110"
+                     :hk-toteuttaja (delay nil)))
+            :after-all-processing)
+          (vt/handle-amis-palautteet-on-heratepvm! {})
+          (is (= 3 @vastauslinkki-counter)) ; not incremented for either
           (is (= [["heratepalvelussa" "aloittaneet"]
                   ["heratepalvelussa" "valmistuneet"]]
                  (->> {:hoks-id (:id hoks)

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -573,7 +573,7 @@
         (client/reset-functions!))
       (testing "get kyselylinkit returns linkki from palaute"
         (let [loppupvm (.plusMonths (LocalDateTime/now) 1)]
-          (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+          (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                         (fn [_]
                           {:vastattu false
                            :voimassa-loppupvm (str loppupvm "Z")})]

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -451,7 +451,8 @@
                    :jakso          test-jakso
                    :opiskeluoikeus oo-test/opiskeluoikeus-1}]
           (heratepalvelu/sync-jakso!
-            (tep/build-jaksoherate-record-for-heratepalvelu ctx))
+            (tep/build-jaksoherate-record-for-heratepalvelu ctx)
+            :after-arvo-call)
           (tep/initiate-if-needed! {:hoks           hoks-test/hoks-1
                                     :opiskeluoikeus oo-test/opiskeluoikeus-1}
                                    test-jakso)

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -641,8 +641,7 @@
 
   (let [initial-palautteet (hoks-utils/palautteet)
         palautteet
-        (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]
-              :hoks-id nil :palaute-id nil}
+        (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]}
              (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec))
         tep-palaute (find-first
                       #(= (:jakson-yksiloiva-tunniste %) "4") palautteet)

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -1538,7 +1538,7 @@
            :sahkoposti        "testi@testi.fi"
            :lahetystila       "viestintapalvelussa"
            :voimassa-loppupvm (str (LocalDate/from loppupvm))}]
-      (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+      (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                     (fn [_]
                       {:vastattu false
                        :voimassa-loppupvm (str loppupvm "Z")})]
@@ -1610,7 +1610,7 @@
                 body (test-utils/parse-body (:body resp))]
             (t/is (= 200 (:status resp)))
             (t/is (= (first (:data body)) kyselylinkki-reply)))
-          (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+          (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                         (fn [_]
                           {:vastattu true
                            :voimassa-loppupvm (str new-loppupvm "Z")})]


### PR DESCRIPTION
## Kuvaus muutoksista

Tässä PR:ssä toteutetaan käytännössä `handle-unsent-palautteet!` ja sen testit.  Mukaan lukien tarkistukset, mitä pitää lähettää ja mitä ei, sekä kirjanpito, mitä lähettämisessä tapahtui.

Tääkään ei vielä sellaisenaan toteuta täyttä viestitilojen käsittelyä, koska palautteista tietää vasta onko niiden lähetys epäonnistunut kun on tieto sekä meilin että tekstarin lopputuloksesta.

https://jira.eduuni.fi/browse/EH-2024

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
