### PR TITLE
EH-2025: when to send messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>e8aebc2a88a3a7d30d7a912b28420a35b1e7cd58</tag>
+    <tag>8485cd0c8aec26e0b7acabc7613732e410964cb3</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -584,6 +584,10 @@
     <dependency>
       <groupId>environ</groupId>
       <artifactId>environ</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>hiccup</groupId>
+      <artifactId>hiccup</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
                  [org.clojure/data.xml]
                  [org.clojure/data.json]
                  [environ]
+                 [hiccup]
                  [software.amazon.awssdk/sqs]
                  [com.rpl/specter]
                  [org.clojure/core.memoize]]

--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_auth_routes.clj
@@ -5,6 +5,8 @@
             [clj-http.client :as client]))
 
 (def cas-oppija-ticket "ST-6778-aBcDeFgHiJkLmN123456-cas.1234567890ac")
+(def cas-virkailija-ticket "ST-6777-aBcDeFgHiJkLmN123456-cas.1234567890ac")
+(def cas-palvelu-ticket "ST-5777-aBcDeFgHiJkLmN123456-cas.1234567890ac")
 
 (def mock-routes
   (routes
@@ -54,17 +56,20 @@
                "Ticket &#39;%s&#39; not recognized"
                "</cas:authenticationFailure>\n"
                "</cas:serviceResponse>\n"))
-           (let [username (if (= (get-in request [:query-params "ticket"])
-                                 "ST-6777-aBcDeFgHiJkLmN123456-cas.1234567890ac")
-                            "ehoksvirkailija"
-                            "ehoks")]
+           (let [[username ktyyppi]
+                 (if (= (get-in request [:query-params "ticket"])
+                        cas-virkailija-ticket)
+                   ["ehoksvirkailija" "VIRKAILIJA"]
+                   ["ehoks" "PALVELU"])]
              (response/ok
                (format
-                 (str "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>"
+                 (str "<cas:serviceResponse "
+                      "xmlns:cas='http://www.yale.edu/tp/cas'>"
                       "<cas:authenticationSuccess><cas:user>%s</cas:user>"
                       "<cas:attributes>"
-                      "<cas:oidHenkilo>1.2.246.562.24.11474338835</cas:oidHenkilo>"
-                      "<cas:kayttajaTyyppi>VIRKAILIJA</cas:kayttajaTyyppi>"
+                      "<cas:oidHenkilo>1.2.246.562.24.11474338835"
+                      "</cas:oidHenkilo>"
+                      "<cas:kayttajaTyyppi>%s</cas:kayttajaTyyppi>"
                       "<cas:idpEntityId>usernamePassword</cas:idpEntityId>"
                       "<cas:roles>"
                       "ROLE_APP_EHOKS_OPHPAAKAYTTAJA_1.2.246.562.10.12944436166"
@@ -90,19 +95,18 @@
                       "<cas:authenticationDate>2019-02-20T10:14:24.046+02:00"
                       "</cas:authenticationDate></cas:attributes>"
                       "</cas:authenticationSuccess></cas:serviceResponse>")
-                 username)))))
+                 username ktyyppi)))))
 
     (GET "/cas/login" request
-         (response/see-other
-           (format
-             "%s?ticket=ST-6777-aBcDeFgHiJkLmN123456-cas.1234567890ac"
-             (get-in request [:query-params "service"]))))
+      (response/see-other
+        (format "%s?ticket=%s"
+                (get-in request [:query-params "service"])
+                cas-virkailija-ticket)))
 
     (GET "/cas-oppija/login" request
       (response/see-other
-        (format
-          "%s?ticket=%s"
-          (get-in request [:query-params "service"]) cas-oppija-ticket)))
+        (format "%s?ticket=%s"
+                (get-in request [:query-params "service"]) cas-oppija-ticket)))
 
     (GET "/cas-oppija/logout" request
       (response/see-other (get-in request [:query-params "service"])))

--- a/src/oph/ehoks/db/sql/palaute.sql
+++ b/src/oph/ehoks/db/sql/palaute.sql
@@ -7,7 +7,15 @@ insert into palautteet (
 --~ (sql/values-for-insert params)
 ) returning *
 
+-- :name get-by-id! :? :*
+-- :doc Get palaute by palaute id.
+select	p.*
+from	palautteet p
+where	p.id = :palaute-id
+and	p.deleted_at is null
+
 -- :name get-palaute-with-hankkimistapa-id-by-id! :? :*
+-- :doc Get palaute and corresponding OHT id by palaute id or HOKS id
 select	p.*, ohm.hankkimistapa_id
 from	palautteet p
 left join oht_hoks_mapping ohm

--- a/src/oph/ehoks/palaute/handler.clj
+++ b/src/oph/ehoks/palaute/handler.clj
@@ -38,8 +38,7 @@
                     (palaute/get-palaute-with-hankkimistapa-id-by-id!
                       db/spec {:hoks-id hoks-id :palaute-id nil})
                     vastaajatunnukset
-                    (map vt/handle-palaute-waiting-for-heratepvm!
-                         amis-palautteet)]
+                    (map vt/create-vastaajatunnus! amis-palautteet)]
                 (assoc (restful/ok {:vastaajatunnukset vastaajatunnukset})
                        ::audit/target {:vastaajatunnukset vastaajatunnukset
                                        :hoks-id hoks-id})))
@@ -65,8 +64,7 @@
                     (palaute/get-palaute-with-hankkimistapa-id-by-id!
                       db/spec {:palaute-id palaute-id :hoks-id nil})
                     vastaajatunnukset
-                    (map vt/handle-palaute-waiting-for-heratepvm!
-                         tep-palautteet)]
+                    (map vt/create-vastaajatunnus! tep-palautteet)]
                 (assoc (restful/ok {:vastaajatunnukset vastaajatunnukset})
                        ::audit/target {:vastaajatunnukset vastaajatunnukset
                                        :hoks-id nil

--- a/src/oph/ehoks/palaute/handler.clj
+++ b/src/oph/ehoks/palaute/handler.clj
@@ -10,6 +10,7 @@
             [oph.ehoks.logging.audit :as audit]
             [oph.ehoks.middleware :refer [wrap-user-details]]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.lahetys :as lahetys]
             [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.restful :as restful]
             [ring.util.http-response :as response]
@@ -32,25 +33,47 @@
           (c-api/context "/opiskelijapalaute" []
             :tags ["opiskelijapalaute"]
 
-            (c-api/POST "/:hoks-id/kyselylinkki" [hoks-id]
-              :summary "Luo yhden HOKSin kyselylinkit, jos niitä ei ole luotu."
-              (let [amis-palautteet
-                    (palaute/get-palaute-with-hankkimistapa-id-by-id!
-                      db/spec {:hoks-id hoks-id :palaute-id nil})
-                    vastaajatunnukset
-                    (map vt/create-vastaajatunnus! amis-palautteet)]
-                (assoc (restful/ok {:vastaajatunnukset vastaajatunnukset})
-                       ::audit/target {:vastaajatunnukset vastaajatunnukset
-                                       :hoks-id hoks-id})))
+            (c-api/context ":hoks-id" [hoks-id]
+
+              (c-api/POST "/kyselylinkki" []
+                :summary "Luo yhden HOKSin kyselylinkit, jos ne kuuluvat
+                         kohderyhmään."
+                (let [amis-palautteet
+                      (palaute/get-palaute-with-hankkimistapa-id-by-id!
+                        db/spec {:hoks-id hoks-id :palaute-id nil})
+                      vastaajatunnukset
+                      (map vt/create-vastaajatunnus! amis-palautteet)]
+                  (assoc (restful/ok {:vastaajatunnukset vastaajatunnukset})
+                         ::audit/target {:vastaajatunnukset vastaajatunnukset
+                                         :hoks-id hoks-id})))
+
+              (c-api/POST "/kutsuviesti" []
+                :summary "Lähettää yhden HOKSin palautekutsut, jos mahdollista."
+                (let [amis-palautteet
+                      (palaute/get-palaute-with-hankkimistapa-id-by-id!
+                        db/spec {:hoks-id hoks-id :palaute-id nil})
+                      lahetys-ids
+                      (map lahetys/send-invitation! amis-palautteet)]
+                  (assoc (restful/ok {:lahetykset lahetys-ids})
+                         ::audit/target {:lahetykset lahetys-ids
+                                         :hoks-id hoks-id}))))
 
             (c-api/POST "/kyselylinkit" []
               :summary "Luo kyselylinkit niille palautteille, jotka
                        odottavat käsittelyä."
-              (let [palautteet
-                    (vt/handle-amis-palautteet-on-heratepvm! {})]
-                (-> {:kyselylinkit palautteet}
+              (let [tulos (vt/handle-amis-palautteet-on-heratepvm! {})]
+                (-> {:kyselylinkit tulos}
                     (restful/ok)
-                    (assoc ::audit/target {:palautteet palautteet})))))
+                    (assoc ::audit/target {:kyselylinkit tulos}))))
+
+            (c-api/POST "/kutsuviestit" []
+              :summary "Lähettää palautekutsut niille palautteille, jotka
+                       odottavat lähetystä."
+              (let [tulos (lahetys/handle-unsent-palautteet!
+                            ["aloittaneet" "valmistuneet" "osia_suorittaneet"])]
+                (-> {:lahetykset tulos}
+                    (restful/ok)
+                    (assoc ::audit/target {:lahetykset tulos})))))
 
           (c-api/context "/tyoelamapalaute" []
             :tags ["tyoelamapalaute"]

--- a/src/oph/ehoks/palaute/handling.clj
+++ b/src/oph/ehoks/palaute/handling.clj
@@ -1,0 +1,164 @@
+(ns oph.ehoks.palaute.handling
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
+            [medley.core :refer [find-first]]
+            [oph.ehoks.db :as db]
+            [oph.ehoks.db.dynamodb :as ddb]
+            [oph.ehoks.external.arvo :as arvo]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.heratepalvelu :as heratepalvelu]
+            [oph.ehoks.hoks :as hoks]
+            [oph.ehoks.hoks.osaamisen-hankkimistapa :as oht]
+            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
+            [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.opiskelija :as amis]
+            [oph.ehoks.palaute.tyoelama :as tep]
+            [oph.ehoks.palaute.tapahtuma :as tapahtuma]
+            [oph.ehoks.utils :as utils]
+            [oph.ehoks.utils.date :as date])
+  (:import (clojure.lang ExceptionInfo)
+           (java.util UUID)))
+
+(defn palaute-ddb-record
+  "Hakee DynamoDB:stä palautetta vastaavan tietueen."
+  [palaute hoks koulutustoimija]
+  (if (:jakson-yksiloiva-tunniste palaute)
+    (ddb/get-jakso-by-hoks-id-and-yksiloiva-tunniste!
+      (:id hoks) (:jakson-yksiloiva-tunniste palaute))
+    (ddb/get-item!
+      :amis {:toimija_oppija (str koulutustoimija "/" (:oppija-oid hoks))
+             :tyyppi_kausi
+             (str (amis/translate-kyselytyyppi (:kyselytyyppi palaute))
+                  "/" (palaute/rahoituskausi (:heratepvm palaute)))})))
+
+(defn- enrich-ctx!
+  "Lisää muista palveluista saatavia tietoja kontekstiin myöhempää
+  käsittelyä varten."
+  [{:keys [hoks existing-palaute] :as ctx}]
+  (let [opiskeluoikeus (koski/get-existing-opiskeluoikeus!
+                         (:opiskeluoikeus-oid hoks))
+        suoritus (find-first suoritus/ammatillinen?
+                             (:suoritukset opiskeluoikeus))
+        koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)]
+    (assoc ctx
+           :existing-ddb-herate
+           (delay (palaute-ddb-record existing-palaute hoks koulutustoimija))
+           :arvo-status
+           ;; needs more logic when tep-palaute may also be queried
+           (delay (some-> (:arvo-tunniste existing-palaute)
+                          (arvo/get-kyselytunnus-status!)))
+           :niputuspvm            (tep/next-niputus-date (date/now))
+           :vastaamisajan-alkupvm (tep/next-niputus-date
+                                    (:heratepvm existing-palaute))
+           :opiskeluoikeus opiskeluoikeus
+           :suoritus suoritus
+           :hk-toteuttaja
+           (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
+           :koulutustoimija koulutustoimija
+           :toimipiste (palaute/toimipiste-oid! suoritus))))
+
+(defn- handle-exception
+  "Handles an ExceptionInfo `ex` based on `:type` in `ex-data`. If `ex` doesn't
+  match any of the cases below, re-throws `ex`."
+  [{:keys [existing-palaute hoks] :as ctx} ex]
+  (let [ex-params (ex-data ex)
+        ex-type (:type ex-params)
+        tunnus  (:arvo-tunnus ex-params)
+        tunnus-cleanup-handler
+        (if (:jakson-yksiloiva-tunniste existing-palaute)
+          arvo/delete-jaksotunnus arvo/delete-kyselytunnus)]
+    (log/info ex "Handling exception in tunnus handling")
+    (when (and tunnus (not (.startsWith ^String tunnus "<dummy-")))
+      (try
+        (log/infof "Trying to delete vastaajatunnus `%s` from Arvo" tunnus)
+        (tunnus-cleanup-handler tunnus)
+        (catch Exception e
+          (log/error e "While trying to clean up tunnus from Arvo"))))
+    (case ex-type
+      (::koski/opiskeluoikeus-not-found
+        ::hoks/invalid-data
+        :oph.ehoks.palaute.vastaajatunnus/arvossa-ei-kyselya)
+      (do (log/warnf "%s. Setting `tila` to `ei_laheteta` for palaute `%d`."
+                     (ex-message ex) (:id existing-palaute))
+          (palaute/update-tila!
+            ctx "ei_laheteta" ex-type
+            {:opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
+             :heratepvm (str (:heratepvm existing-palaute))}))
+
+      (:oph.ehoks.palaute.vastaajatunnus/arvo-kutsu-epaonnistui
+        :oph.ehoks.palaute.vastaajatunnus/tunnus-tallennus-epaonnistui)
+      (let [cause (ex-cause ex)]
+        (log/error "Error" ex-type "because of" (ex-message cause)
+                   "with error body" (:body (ex-data cause))
+                   "for palaute" (:id existing-palaute))
+        (tapahtuma/build-and-insert!
+          ctx ex-type {:errormsg (ex-message cause)
+                       :body     (:body (ex-data cause))}))
+
+      :oph.ehoks.palaute.vastaajatunnus/heratepalvelu-sync-epaonnistui
+      (let [ddb-ex (ex-cause ex)]
+        (log/errorf (str "%s. Trying to delete jakso corresponding to "
+                         "palaute `%d` from Herätepalvelu")
+                    (ex-message ddb-ex) (:id existing-palaute))
+        (tapahtuma/build-and-insert!
+          ctx ex-type {:errormsg (ex-message ddb-ex)
+                       :body     (ex-data ddb-ex)})
+        (try
+          (heratepalvelu/delete-jakso-herate! existing-palaute)
+          (catch Exception e
+            (log/error e "While cleaning up jakso from Herätepalvelu"))))
+
+      (let [cause-ex (ex-cause ex)]
+        (log/error "Unknown exception while processing palaute "
+                   (:id existing-palaute))
+        (tapahtuma/build-and-insert! ctx :tuntematon-virhe
+                                     {:errormsg (ex-message ex)
+                                      :causemsg (ex-message cause-ex)})))))
+
+(def hoks-cache-amount
+  "How many HOKSes we cache.  Palautteet from
+  palaute/get-palautteet-waiting-for-vastaajatunnus! and
+  palaute/get-unsent-palautteet! are ordered by hoks-id, so 1 should
+  suffice."
+  2)
+
+(def hoks-cache-time
+  "Handling a palaute should not take longer than 15 seconds"
+  15000)
+
+(def get-hoks-by-id!
+  (utils/with-fifo-ttl-cache
+    hoks/get-by-id hoks-cache-time hoks-cache-amount {}))
+
+(defn build-ctx!
+  "Creates a full information context (i.e. background information)
+  for a given palaute."
+  [palaute]
+  (let [hoks (get-hoks-by-id! (:hoks-id palaute))
+        jakso (some->>
+                (:jakson-yksiloiva-tunniste palaute)
+                (oht/osaamisen-hankkimistapa-by-yksiloiva-tunniste hoks))]
+    (enrich-ctx! {:hoks hoks :jakso jakso :existing-palaute palaute
+                  :tapahtumatyyppi :arvo-luonti
+                  :request-id (str (UUID/randomUUID))})))
+
+(defn call-with-context-and-error-handling
+  "Process one palaute with given handler, giving full context to the
+  handler and processing any errors"
+  [tapahtumatyyppi handler palaute]
+  (try
+    (jdbc/with-db-transaction
+      [tx db/spec]
+      (handler
+        (assoc (build-ctx! palaute) :tapahtumatyyppi tapahtumatyyppi :tx tx)
+        (if (:jakson-yksiloiva-tunniste palaute) tep/handlers amis/handlers)))
+    (catch ExceptionInfo e
+      (jdbc/with-db-transaction
+        [tx db/spec]
+        (-> (:ctx (ex-data e))
+            (or {:existing-palaute palaute})  ; poor person's context
+            (assoc :tapahtumatyyppi tapahtumatyyppi :tx tx)
+            (handle-exception e)))
+      nil) ; handler failed, nothing created
+    (catch Exception e
+      (log/error e "Unknown error processing palaute" palaute))))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -115,18 +115,26 @@
                 (pt/build-and-insert!
                   ctx ::viestin-lahetys-epaonnistui
                   {:errormsg (ex-message e)
-                   :body     (:body (ex-data e))}))
+                   :body     (:body (ex-data e))})
+                nil)  ; no msg-id created
             (throw (ex-info "Viestin lähetyksessä tapahtui virhe"
                             {:type ::viestin-lahetys-epaonnistui :ctx ctx}
                             e))))))))
 
-(defn handle-unsent-palaute!
+(defn send-invitation!
   "Lähettää viestin yhdelle palautteelle, jos aiheellista."
   [palaute]
   (log/info "Sending survey invitation for" (:kyselytyyppi palaute)
             "palaute" (:id palaute))
   (handling/call-with-context-and-error-handling
     :lahetys palaute-check-send-save-and-sync! palaute))
+
+(defn handle-unsent-palaute!
+  "Tekee kaiken mitä pitää tehdä palautteelle josta ei ole vielä lähetetty
+  viestiä."
+  [palaute]
+  ;; TODO: also process viestinvalityspalvelu reports
+  (send-invitation! palaute))
 
 (defn handle-unsent-palautteet!
   "Hakee ja lähettää viestit (kyselykutsut) kaikille palautteille

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -6,8 +6,8 @@
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.handling :as handling]
             [oph.ehoks.palaute.tapahtuma :as pt]
-            [oph.ehoks.palaute.vastaajatunnus :as vt]
             [oph.ehoks.palaute.viestit :as v]
             [oph.ehoks.utils :as utils]
             [oph.ehoks.utils.date :as dateutil])
@@ -125,7 +125,7 @@
   [palaute]
   (log/info "Sending survey invitation for" (:kyselytyyppi palaute)
             "palaute" (:id palaute))
-  (vt/call-with-context-and-error-handling
+  (handling/call-with-context-and-error-handling
     :lahetys palaute-check-send-save-and-sync! palaute))
 
 (defn handle-unsent-palautteet!

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -124,7 +124,7 @@
 (defn send-invitation!
   "Lähettää viestin yhdelle palautteelle, jos aiheellista."
   [palaute]
-  (log/info "Sending survey invitation for" (:kyselytyyppi palaute)
+  (log/info "Processing email survey invitation for" (:kyselytyyppi palaute)
             "palaute" (:id palaute))
   (handling/call-with-context-and-error-handling
     :lahetys palaute-check-send-save-and-sync! palaute))
@@ -142,7 +142,7 @@
   [kyselytyypit]
   ;; tep-viestejä ei ole vielä toteutettu
   (assert (not (contains? (set kyselytyypit) "tyopaikkajakson_suorittaneet")))
-  (log/info "Sending messages for kyselytyypit" kyselytyypit)
+  (log/info "Processing messages for kyselytyypit" kyselytyypit)
   (doall (map handle-unsent-palaute!
               (palaute/get-unsent-palautteet!
                 db/spec {:kyselytyypit kyselytyypit

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -3,6 +3,7 @@
             [clojure.tools.logging :as log]
             [oph.ehoks.utils :as util]
             [oph.ehoks.palaute.initiation :as palaute]
+            [oph.ehoks.palaute.lahetys :as lahetys]
             [oph.ehoks.palaute.vastaajatunnus :as vt])
   (:import (java.lang AutoCloseable)
            (java.time Instant LocalTime ZonedDateTime ZoneId Period Duration)))
@@ -34,6 +35,29 @@
   (log/info "Done palaute hourly actions.")
   true)
 
+(defn as-often-as-possible-actions!
+  "Run all actions that should be taken as often as possible."
+  [_]
+  (try
+    (log/info (str "Handling palautteet that have reached "
+                   "their heratepvm."))
+    (let [result (vt/handle-palautteet-waiting-for-heratepvm!
+                   ["aloittaneet" "valmistuneet" "osia_suorittaneet"
+                    "tyopaikkajakson_suorittaneet"])]
+      (log/info "handle-palautteet-waiting-for-heratepvm!: ended with result"
+                result))
+    (catch Exception e
+      (log/error e (str "Unhandled exception in "
+                        "handle-palautteet-waiting-for-heratepvm!"))))
+  (try
+    (log/info "Handling palautteet that we should send messages for.")
+    (let [result (lahetys/handle-unsent-palautteet!
+                   ["aloittaneet" "valmistuneet" "osia_suorittaneet"])]
+      (log/info "handle-unsent-palautteet!: ended with result"
+                result))
+    (catch Exception e
+      (log/error e "Unhandled exception in handle-unsent-palautteet!"))))
+
 (defn time->instant
   "Converts a specific time of day into an instant on today"
   [hour minute sec]
@@ -49,16 +73,7 @@
     :action hourly-actions!}
 
    {:start (time->instant 1 0 0) :period (Duration/ofMinutes 5)
-    :action (fn [_]
-              (try
-                (log/info (str "Handling palautteet that have reached "
-                               "their heratepvm."))
-                (vt/handle-palautteet-waiting-for-heratepvm!
-                  ["aloittaneet" "valmistuneet" "osia_suorittaneet"
-                   "tyopaikkajakson_suorittaneet"])
-                (catch Exception e
-                  (log/error e (str "Unhandled exception in scheduled "
-                                    "handling of palautteet")))))}])
+    :action as-often-as-possible-actions!}])
 
 (defn run-scheduler!
   "Run a given action periodically starting at start-time and repeating

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -5,6 +5,7 @@
             [oph.ehoks.db :as db]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.handling :as handling]
+            [oph.ehoks.palaute.lahetys :as lahetys]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.utils :as utils])
   (:import (clojure.lang ExceptionInfo)))
@@ -111,7 +112,7 @@
         (palaute/update-tila! ctx state reason lisatiedot))
       (tapahtuma/build-and-insert! ctx reason lisatiedot))))
 
-(defn handle-palaute-waiting-for-heratepvm!
+(defn create-vastaajatunnus!
   "Check that palaute is part of kohderyhmä and create and save
   vastaajatunnus if so."
   [palaute]
@@ -119,6 +120,21 @@
             "palaute" (:id palaute))
   (handling/call-with-context-and-error-handling
     :arvo-luonti palaute-check-call-arvo-save-and-sync! palaute))
+
+(defn handle-palaute-waiting-for-heratepvm!
+  "Do all actions that need to be done to palaute when its heratepvm comes."
+  [palaute]
+  (let [vastaajatunnus (create-vastaajatunnus! palaute)
+        ;; this needs to have hankkimistapa_id too when työelämäpalaute
+        ;; support is added
+        updated-palaute (palaute/get-by-id! db/spec {:id (:id palaute)})]
+    ;; if creation succeeded, also send messages immediately (with fresh caches)
+    (if (contains? #{"kysely_muodostettu" "vastaajatunnus_muodostettu"}
+                   (:tila updated-palaute))
+      (lahetys/handle-unsent-palaute! updated-palaute)
+      (log/info "Palaute" (:id updated-palaute) "is in state"
+                (:tila updated-palaute) "so not proceeding to sending"))
+    vastaajatunnus))
 
 (defn handle-palautteet-waiting-for-heratepvm!
   "Fetch all unhandled palautteet whose heratepvm has come, check that

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -129,11 +129,17 @@
         ;; support is added
         updated-palaute (palaute/get-by-id! db/spec {:id (:id palaute)})]
     ;; if creation succeeded, also send messages immediately (with fresh caches)
-    (if (contains? #{"kysely_muodostettu" "vastaajatunnus_muodostettu"}
-                   (:tila updated-palaute))
-      (lahetys/handle-unsent-palaute! updated-palaute)
+    (cond
+      (not (contains? #{"kysely_muodostettu" "vastaajatunnus_muodostettu"}
+                      (:tila updated-palaute)))
       (log/info "Palaute" (:id updated-palaute) "is in state"
-                (:tila updated-palaute) "so not proceeding to sending"))
+                (:tila updated-palaute) "so not proceeding to sending")
+
+      (= "tyopaikkajakson_suorittaneet" (:kyselytyyppi updated-palaute))
+      (log/info "Palaute" (:id updated-palaute) "is tyoelämäpalaute"
+                "so not proceeding to sending")
+
+      :else (lahetys/handle-unsent-palaute! updated-palaute))
     vastaajatunnus))
 
 (defn handle-palautteet-waiting-for-heratepvm!

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -1,146 +1,13 @@
 (ns oph.ehoks.palaute.vastaajatunnus
-  (:require [clojure.java.jdbc :as jdbc]
-            [clojure.set]
+  (:require [clojure.set]
             [clojure.tools.logging :as log]
-            [medley.core :refer [find-first map-vals]]
+            [medley.core :refer [map-vals]]
             [oph.ehoks.db :as db]
-            [oph.ehoks.db.dynamodb :as ddb]
-            [oph.ehoks.external.arvo :as arvo]
-            [oph.ehoks.external.koski :as koski]
-            [oph.ehoks.heratepalvelu :as heratepalvelu]
-            [oph.ehoks.hoks :as hoks]
-            [oph.ehoks.hoks.osaamisen-hankkimistapa :as oht]
-            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
-            [oph.ehoks.palaute.opiskelija :as amis]
+            [oph.ehoks.palaute.handling :as handling]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
-            [oph.ehoks.palaute.tyoelama :as tep]
-            [oph.ehoks.utils :as utils]
-            [oph.ehoks.utils.date :as date])
-  (:import (clojure.lang ExceptionInfo)
-           (java.util UUID)))
-
-(defn palaute-ddb-record
-  "Hakee DynamoDB:stä palautetta vastaavan tietueen."
-  [palaute hoks koulutustoimija]
-  (if (:jakson-yksiloiva-tunniste palaute)
-    (ddb/get-jakso-by-hoks-id-and-yksiloiva-tunniste!
-      (:id hoks) (:jakson-yksiloiva-tunniste palaute))
-    (ddb/get-item!
-      :amis {:toimija_oppija (str koulutustoimija "/" (:oppija-oid hoks))
-             :tyyppi_kausi
-             (str (amis/translate-kyselytyyppi (:kyselytyyppi palaute))
-                  "/" (palaute/rahoituskausi (:heratepvm palaute)))})))
-
-(defn- enrich-ctx!
-  "Lisää muista palveluista saatavia tietoja kontekstiin myöhempää
-  käsittelyä varten."
-  [{:keys [hoks existing-palaute] :as ctx}]
-  (let [opiskeluoikeus (koski/get-existing-opiskeluoikeus!
-                         (:opiskeluoikeus-oid hoks))
-        suoritus (find-first suoritus/ammatillinen?
-                             (:suoritukset opiskeluoikeus))
-        koulutustoimija (palaute/koulutustoimija-oid! opiskeluoikeus)]
-    (assoc ctx
-           :existing-ddb-herate
-           (delay (palaute-ddb-record existing-palaute hoks koulutustoimija))
-           :arvo-status
-           ;; needs more logic when tep-palaute may also be queried
-           (delay (some-> (:arvo-tunniste existing-palaute)
-                          (arvo/get-kyselytunnus-status!)))
-           :niputuspvm            (tep/next-niputus-date (date/now))
-           :vastaamisajan-alkupvm (tep/next-niputus-date
-                                    (:heratepvm existing-palaute))
-           :opiskeluoikeus opiskeluoikeus
-           :suoritus suoritus
-           :hk-toteuttaja
-           (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
-           :koulutustoimija koulutustoimija
-           :toimipiste (palaute/toimipiste-oid! suoritus))))
-
-(defn- handle-exception
-  "Handles an ExceptionInfo `ex` based on `:type` in `ex-data`. If `ex` doesn't
-  match any of the cases below, re-throws `ex`."
-  [{:keys [existing-palaute hoks] :as ctx} ex]
-  (let [ex-params (ex-data ex)
-        ex-type (:type ex-params)
-        tunnus  (:arvo-tunnus ex-params)
-        tunnus-cleanup-handler
-        (if (:jakson-yksiloiva-tunniste existing-palaute)
-          arvo/delete-jaksotunnus arvo/delete-kyselytunnus)]
-    (log/info ex "Handling exception in tunnus handling")
-    (when (and tunnus (not (.startsWith ^String tunnus "<dummy-")))
-      (try
-        (log/infof "Trying to delete vastaajatunnus `%s` from Arvo" tunnus)
-        (tunnus-cleanup-handler tunnus)
-        (catch Exception e
-          (log/error e "While trying to clean up tunnus from Arvo"))))
-    (case ex-type
-      (::koski/opiskeluoikeus-not-found
-        ::hoks/invalid-data
-        ::arvossa-ei-kyselya)
-      (do (log/warnf "%s. Setting `tila` to `ei_laheteta` for palaute `%d`."
-                     (ex-message ex) (:id existing-palaute))
-          (palaute/update-tila!
-            ctx "ei_laheteta" ex-type
-            {:opiskeluoikeus-oid (:opiskeluoikeus-oid hoks)
-             :heratepvm (str (:heratepvm existing-palaute))}))
-
-      (::arvo-kutsu-epaonnistui ::tunnus-tallennus-epaonnistui)
-      (let [cause (ex-cause ex)]
-        (log/error "Error" ex-type "because of" (ex-message cause)
-                   "with error body" (:body (ex-data cause))
-                   "for palaute" (:id existing-palaute))
-        (tapahtuma/build-and-insert!
-          ctx ex-type {:errormsg (ex-message cause)
-                       :body     (:body (ex-data cause))}))
-
-      ::heratepalvelu-sync-epaonnistui
-      (let [ddb-ex (ex-cause ex)]
-        (log/errorf (str "%s. Trying to delete jakso corresponding to "
-                         "palaute `%d` from Herätepalvelu")
-                    (ex-message ddb-ex) (:id existing-palaute))
-        (tapahtuma/build-and-insert!
-          ctx ex-type {:errormsg (ex-message ddb-ex)
-                       :body     (ex-data ddb-ex)})
-        (try
-          (heratepalvelu/delete-jakso-herate! existing-palaute)
-          (catch Exception e
-            (log/error e "While cleaning up jakso from Herätepalvelu"))))
-
-      (let [cause-ex (ex-cause ex)]
-        (log/error "Unknown exception while processing palaute "
-                   (:id existing-palaute))
-        (tapahtuma/build-and-insert! ctx :tuntematon-virhe
-                                     {:errormsg (ex-message ex)
-                                      :causemsg (ex-message cause-ex)})))))
-
-(def hoks-cache-amount
-  "How many HOKSes we cache.  Palautteet from
-  palaute/get-palautteet-waiting-for-vastaajatunnus! and
-  palaute/get-unsent-palautteet! are ordered by hoks-id, so 1 should
-  suffice."
-  2)
-
-(def hoks-cache-time
-  "Handling a palaute should not take longer than 15 seconds"
-  15000)
-
-(def get-hoks-by-id!
-  (utils/with-fifo-ttl-cache
-    hoks/get-by-id hoks-cache-time hoks-cache-amount {}))
-
-(defn build-ctx!
-  "Creates a full information context (i.e. background information)
-  for a given palaute."
-  [palaute]
-  (let [hoks (get-hoks-by-id! (:hoks-id palaute))
-        jakso (some->>
-                (:jakson-yksiloiva-tunniste palaute)
-                (oht/osaamisen-hankkimistapa-by-yksiloiva-tunniste hoks))]
-    (enrich-ctx! {:hoks hoks :jakso jakso :existing-palaute palaute
-                  :tapahtumatyyppi :arvo-luonti
-                  :request-id (str (UUID/randomUUID))})))
+            [oph.ehoks.utils :as utils])
+  (:import (clojure.lang ExceptionInfo)))
 
 (defn make-kysely-type
   "Map DB-level kyselytyyppi back into what is expected by
@@ -244,34 +111,13 @@
         (palaute/update-tila! ctx state reason lisatiedot))
       (tapahtuma/build-and-insert! ctx reason lisatiedot))))
 
-(defn call-with-context-and-error-handling
-  "Process one palaute with given handler, giving full context to the
-  handler and processing any errors"
-  [tapahtumatyyppi handler palaute]
-  (try
-    (jdbc/with-db-transaction
-      [tx db/spec]
-      (handler
-        (assoc (build-ctx! palaute) :tapahtumatyyppi tapahtumatyyppi :tx tx)
-        (if (:jakson-yksiloiva-tunniste palaute) tep/handlers amis/handlers)))
-    (catch ExceptionInfo e
-      (jdbc/with-db-transaction
-        [tx db/spec]
-        (-> (:ctx (ex-data e))
-            (or {:existing-palaute palaute})  ; poor person's context
-            (assoc :tapahtumatyyppi tapahtumatyyppi :tx tx)
-            (handle-exception e)))
-      nil) ; handler failed, nothing created
-    (catch Exception e
-      (log/error e "Unknown error processing palaute" palaute))))
-
 (defn handle-palaute-waiting-for-heratepvm!
   "Check that palaute is part of kohderyhmä and create and save
   vastaajatunnus if so."
   [palaute]
   (log/info "Creating vastaajatunnus for" (:kyselytyyppi palaute)
             "palaute" (:id palaute))
-  (call-with-context-and-error-handling
+  (handling/call-with-context-and-error-handling
     :arvo-luonti palaute-check-call-arvo-save-and-sync! palaute))
 
 (defn handle-palautteet-waiting-for-heratepvm!

--- a/test/oph/ehoks/db/dynamodb_test.clj
+++ b/test/oph/ehoks/db/dynamodb_test.clj
@@ -9,7 +9,7 @@
             [oph.ehoks.oppijaindex :as oi]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.opiskelija :as opiskelija]
-            [oph.ehoks.palaute.vastaajatunnus :as vt]
+            [oph.ehoks.palaute.handling :as handling]
             [oph.ehoks.test-utils :as test-utils]
             [taoensso.faraday :as far])
   (:import (java.time LocalDate)))
@@ -50,7 +50,7 @@
             herate (first (palaute/get-by-hoks-id-and-kyselytyypit!
                             db/spec {:hoks-id (:id saved-hoks)
                                      :kyselytyypit ["aloittaneet"]}))
-            ctx (vt/build-ctx! herate)
+            ctx (handling/build-ctx! herate)
             amis-herate
             (opiskelija/build-amisherate-record-for-heratepalvelu ctx)]
         (is (= (:sahkoposti (:hoks ctx)) "irma.isomerkki@esimerkki.com"))

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -118,7 +118,6 @@
   (db-helpers/query
     [(str "select * from palautteet "
           "where arvo_tunniste is not null and "
-          "tila = 'vastaajatunnus_muodostettu' and "
           "kyselytyyppi = 'tyopaikkajakson_suorittaneet'")]))
 
 (defn mock-get-opiskeluoikeus! [oid]

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -141,7 +141,7 @@
           (->> {:kyselytyypit ["aloittaneet"]}
                (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec)
                (first)
-               (vt/handle-palaute-waiting-for-heratepvm!)))
+               (vt/create-vastaajatunnus!)))
         (let [heratteet
               (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
                    (palaute/get-unsent-palautteet! db/spec))]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -287,7 +287,7 @@
       (testing "HOKS with nonexistent opiskeluoikeus is marked as ei_laheteta"
         (with-redefs [koski/get-opiskeluoikeus-info-raw
                       mock-get-opiskeluoikeus-info-raw]
-          (vt/handle-palaute-waiting-for-heratepvm! (first heratteet)))
+          (vt/create-vastaajatunnus! (first heratteet)))
         (is (= [["ei_laheteta" "aloittaneet"]
                 ["odottaa_kasittelya" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
@@ -300,7 +300,7 @@
         (with-redefs [date/now (constantly (LocalDate/of 2024 4 18))
                       koski/get-opiskeluoikeus-info-raw
                       mock-get-opiskeluoikeus-info-raw]
-          (vt/handle-palaute-waiting-for-heratepvm! (second heratteet)))
+          (vt/create-vastaajatunnus! (second heratteet)))
         (is (= [["ei_laheteta" "aloittaneet"]
                 ["ei_laheteta" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
@@ -548,7 +548,7 @@
                       :voimassa_loppupvm "2024-10-10"}})))
         (is (->> heratteet
                  (find-first (comp (partial = "valmistuneet") :kyselytyyppi))
-                 (vt/handle-palaute-waiting-for-heratepvm!)
+                 (vt/create-vastaajatunnus!)
                  (some?)))
         (is (= [["odottaa_kasittelya" "aloittaneet"]
                 ["kysely_muodostettu" "valmistuneet"]]
@@ -615,7 +615,7 @@
                 (ex-info "bad request" {:status 400 :body arvo-error-body})))))
         (->> heratteet
              (find-first (comp (partial = "aloittaneet") :kyselytyyppi))
-             (vt/handle-palaute-waiting-for-heratepvm!))
+             (vt/create-vastaajatunnus!))
         (is (= [["odottaa_kasittelya" "aloittaneet"]
                 ["kysely_muodostettu" "valmistuneet"]]
                (->> {:hoks-id (:id hoks)
@@ -644,7 +644,7 @@
                          {:status 404 :body "{\"error\": \"ei-kyselya\"}"})))))
         (->> heratteet
              (find-first (comp (partial = "aloittaneet") :kyselytyyppi))
-             (vt/handle-palaute-waiting-for-heratepvm!))
+             (vt/create-vastaajatunnus!))
         (is (= [["odottaa_kasittelya" "odottaa_kasittelya"
                  {:request-id 0
                   :ensikertainen-hyvaksyminen "2023-04-16"}]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -21,6 +21,7 @@
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.oppijaindex-test :as oppijaindex-test]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.handling :as handling]
             [oph.ehoks.palaute.opiskelija :as op]
             [oph.ehoks.palaute.opiskelija.kyselylinkki :as kyselylinkki]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
@@ -269,7 +270,7 @@
                 koski/get-opiskeluoikeus-info-raw
                 (fn [oo] (assoc oo-test/opiskeluoikeus-1 :oid oo))
                 ;; don't use cache for hokses this time
-                vt/get-hoks-by-id! hoks/get-by-id
+                handling/get-hoks-by-id! hoks/get-by-id
                 onr/get-oppija-raw!
                 mock-get-oppija-raw!
                 organisaatio/get-organisaatio!
@@ -446,7 +447,7 @@
 (defn create-arvo-kyselylinkki!
   [palaute]
   (-> palaute
-      (vt/build-ctx!)
+      (handling/build-ctx!)
       (op/build-kyselylinkki-request-body)
       (arvo/create-kyselytunnus!)))
 

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -19,6 +19,7 @@
             [oph.ehoks.hoks.hoks-test-utils :as hoks-utils]
             [oph.ehoks.opiskeluoikeus-test :as oo-test]
             [oph.ehoks.palaute :as palaute]
+            [oph.ehoks.palaute.handling :as handling]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
             [oph.ehoks.palaute.tyoelama :as tep]
             [oph.ehoks.palaute.vastaajatunnus :as vt]
@@ -658,7 +659,7 @@
           (is (= @arvo-tunnukset [])))]
     (with-redefs [organisaatio/get-organisaatio!
                   hoks-utils/mock-get-organisaatio!
-                  vt/get-hoks-by-id!
+                  handling/get-hoks-by-id!
                   hoks/get-by-id
                   koski/get-opiskeluoikeus-info-raw
                   hoks-utils/mock-get-opiskeluoikeus!

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -676,7 +676,7 @@
         (testing "Arvo call for vastaajatunnus creation fails."
           (with-redefs [arvo/create-jaksotunnus!
                         (fn [_] (throw (ex-info "Arvo error" {})))]
-            (is (nil? (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
+            (is (nil? (vt/create-vastaajatunnus! tep-palaute))))
           (is (contains?
                 (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]
                       :hoks-id (:hoks-id tep-palaute)}
@@ -687,7 +687,7 @@
         (testing "jakso sync to Herätepalvelu fails."
           (with-redefs [heratepalvelu/sync-jakso!*
                         (fn [_] (throw (ex-info "Jakso sync error" {})))]
-            (is (nil? (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
+            (is (nil? (vt/create-vastaajatunnus! tep-palaute))))
           (is (contains?
                 (->> {:kyselytyypit ["tyopaikkajakson_suorittaneet"]
                       :hoks-id (:hoks-id tep-palaute)}
@@ -699,7 +699,7 @@
           (with-redefs
            [heratepalvelu/sync-tpo-nippu!*
             (fn [_] (throw (ex-info "TPO-nippu sync failed" {})))]
-            (is (nil? (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
+            (is (nil? (vt/create-vastaajatunnus! tep-palaute))))
           (check-current-state-is-same-as-initial-state)))
       (let [counter-value-before-fn-call @create-jaksotunnus-counter]
         (testing (str "When getting other than \"404 Not found\" error from "
@@ -711,14 +711,14 @@
                              "Koski error"
                              {:status 500
                               :type ::koski/opiskeluoikeus-fetching-error})))]
-            (is (nil? (vt/handle-palaute-waiting-for-heratepvm! tep-palaute))))
+            (is (nil? (vt/create-vastaajatunnus! tep-palaute))))
           (is (= counter-value-before-fn-call @create-jaksotunnus-counter))
           (check-current-state-is-same-as-initial-state))
         (testing (str "When opiskeluoikeus for palaute is not found from from "
                       "Koski, `tila` for it should be marked as `ei_laheteta`. "
                       "No call to Arvo should be made.")
           (with-redefs [koski/get-opiskeluoikeus! (fn [_] nil)]
-            (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)
+            (vt/create-vastaajatunnus! tep-palaute)
             (is (= counter-value-before-fn-call @create-jaksotunnus-counter))
             (is (= (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)}))
                    "ei_laheteta"))))
@@ -728,9 +728,9 @@
           ; before vastaajatunnus creation.
           (palaute/update! db/spec {:id 5 :jakson-yksiloiva-tunniste 4})
           (is (= 2 @create-jaksotunnus-counter))
-          (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)
+          (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
-          (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)
+          (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
           (is (= "heratepalvelussa"
                  (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)})))))
@@ -742,14 +742,14 @@
           (db-helpers/query ["UPDATE palautteet
                              SET tila='odottaa_kasittelya'
                              WHERE jakson_yksiloiva_tunniste='4' RETURNING *"])
-          (vt/handle-palaute-waiting-for-heratepvm! tep-palaute)
+          (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
           (is (= (:tila (palaute/get-by-id! db/spec {:id (:id tep-palaute)}))
                  "ei_laheteta")))
         (testing (str "Palaute should be marked as \"ei_laheteta\" when there "
                       "are one or more open keskeytymisajanjakso. No call to "
                       "Arvo should be made.")
-          (vt/handle-palaute-waiting-for-heratepvm! kesk-palaute)
+          (vt/create-vastaajatunnus! kesk-palaute)
           (is (= 3 @create-jaksotunnus-counter))
           (is (= (:tila (palaute/get-by-id! db/spec {:id (:id kesk-palaute)}))
                  "ei_laheteta")))))))


### PR DESCRIPTION
## Kuvaus muutoksista

Säännöt, missä tilanteessa viestejä lähetetään.  Ajatus on se, että aina kyselylinkin muodostamisen jälkeen ja lisäksi vielä varmuuden vuoksi kerran viidessä minuutissa niille herätteille, jotka tarvii lähettää.

Tässä ei oo vielä sitä rajoitusta, että viestejä lähetetään vain virka-aikaan.  Se toteutetaan tiketissä EH-2033.

Tääkin PR on ehkä helpompi katsoa commit kerrallaan, koska se sisältää muutaman refaktoroinnin.

https://jira.eduuni.fi/browse/EH-2025

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
