### PR TITLE
Upgrade flyway and dev env postgres, fix breakage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>a7a335d4e4c3343b096b5ca1b68c84de1b015f7c</tag>
+    <tag>e883755fef70c73865897df9ccefba14bbd46f81</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -340,7 +340,12 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>6.5.7</version>
+        <version>11.20.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-database-postgresql</artifactId>
+        <version>11.20.3</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -518,6 +523,10 @@
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [com.taoensso/faraday]
                  [metosin/compojure-api]
                  [org.flywaydb/flyway-core]
+                 [org.flywaydb/flyway-database-postgresql]
                  [org.clojure/java.jdbc]
                  [org.postgresql/postgresql]
                  [com.layerware/hugsql]
@@ -81,7 +82,8 @@
 
                          ;; postgresql
                          [org.clojure/java.jdbc "0.7.12"]
-                         [org.flywaydb/flyway-core "6.5.7"]
+                         [org.flywaydb/flyway-core "11.20.3"]
+                         [org.flywaydb/flyway-database-postgresql "11.20.3"]
                          [org.postgresql/postgresql "42.7.7"]
                          [com.layerware/hugsql "0.5.3"]
 

--- a/scripts/postgres-docker/Dockerfile
+++ b/scripts/postgres-docker/Dockerfile
@@ -1,6 +1,6 @@
 # Based on <https://hub.docker.com/_/postgres/>
 
-FROM docker.io/library/postgres:12.19
+FROM docker.io/library/postgres:15.12
 
 COPY ./configure-database.sh /docker-entrypoint-initdb.d/
 COPY ./configure-postgres.sh /docker-entrypoint-initdb.d/

--- a/scripts/postgres-docker/configure-database.sh
+++ b/scripts/postgres-docker/configure-database.sh
@@ -9,8 +9,10 @@ DB_APP_PASSWORD=ehoks
 
 echo "Creating database \"$DB_APP_DB\", creating role \"$DB_APP_USER\" with database owner privileges…"
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension pgcrypto;'
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 -c 'create extension pg_trgm;'
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 \
+	-c 'create extension pgcrypto;'
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname template1 \
+	-c 'create extension pg_trgm;'
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-END
 create role "${DB_APP_USER}" with password '${DB_APP_PASSWORD}' login;
@@ -19,3 +21,9 @@ create database "${DB_APP_DB_TEST}" encoding 'UTF-8';
 grant all privileges on database "${DB_APP_DB}" to "${DB_APP_USER}";
 grant all privileges on database "${DB_APP_DB_TEST}" to "${DB_APP_USER}";
 END
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_APP_DB" \
+ -c "grant all privileges on schema public to \"${DB_APP_USER}\";"
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_APP_DB_TEST" \
+ -c "grant all privileges on schema public to \"${DB_APP_USER}\";"

--- a/src/oph/ehoks/db/migrations.clj
+++ b/src/oph/ehoks/db/migrations.clj
@@ -8,15 +8,15 @@
     (-> (Flyway/configure)
         (.dataSource
           (format
-            "jdbc:%s://%s:%d/%s?user=%s&password=%s"
+            "jdbc:%s://%s:%d/%s"
             (:db-type config)
             (:db-server config)
             (:db-port config)
-            (:db-name config)
-            (:db-username config)
-            (:db-password config))
-          nil
-          nil)
+            (:db-name config))
+          (:db-username config)
+          (:db-password config))
+        (.configuration {"flyway.postgresql.transactional.lock" false})
+        (.cleanDisabled false)
         (.load))))
 
 (defn migrate!


### PR DESCRIPTION
## Kuvaus muutoksista

Halusin käyttää PG:ssä `split_part`-funktiosta versiota, jossa on tuettu osien nappaaminen merkkijonon oikeasta päästä.  Tähän tarvitaan vähintään PG 14.

Mutta oikeasti kyse on siitäkin, että meillä ympäristöissä tietokanta on jo kauan ollut ihan muuta kuin deviympäristön 12.19.  On parempi tuoda  nää linjaan keskenään jottei tuu vastaan asioita jotka toimii deviympäristössä mutta testissä / tuotannossa ei.

Tää on aikamoinen kaninkolo koska PG:n päivitys vaatii flywayn päivityksen ja uudempi flyway taas rikkoutuu erilaisilla random tavoilla.

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
