### PR TITLE
EH-1723: make Arvo calls based on Arvo-generated vastaajatunnus

### DIFF
--- a/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
+++ b/resources/db/hoksit/select_kyselylinkit_by_oppija_oid.sql
@@ -1,4 +1,5 @@
 SELECT kyselylinkki,
+       split_part(kyselylinkki, '/', -1) as arvo_tunniste,
        hoks_id,
        tyyppi,
        oppija_oid,
@@ -13,6 +14,7 @@ WHERE oppija_oid = ?
   AND alkupvm <= now()
 UNION
 SELECT p.kyselylinkki      AS kyselylinkki,
+       p.arvo_tunniste     AS arvo_tunniste,
        p.hoks_id           AS hoks_id,
        CASE
            WHEN p.kyselytyyppi = 'aloittaneet' THEN 'aloittaneet'
@@ -24,7 +26,7 @@ SELECT p.kyselylinkki      AS kyselylinkki,
        h.sahkoposti        AS sahkoposti,
        pv.created_at::date AS lahetyspvm,
        pv.tila::text       AS lahetystila,
-       null                AS vastattu,
+       p.tila = 'vastattu' AS vastattu,
        p.voimassa_loppupvm AS voimassa_loppupvm
 FROM palautteet p
          JOIN hoksit h ON h.id = p.hoks_id

--- a/resources/db/hoksit/select_kyselylinkit_by_vastaajatunnus.sql
+++ b/resources/db/hoksit/select_kyselylinkit_by_vastaajatunnus.sql
@@ -1,5 +1,6 @@
 SELECT
   k.*,
+  split_part(k.kyselylinkki, '/', -1) as arvo_tunniste,
   k.hoks_id AS hoks_id,
   o.oid AS oppijan_oid,
   o.nimi AS oppijan_nimi,
@@ -7,4 +8,4 @@ SELECT
 FROM kyselylinkit k
   LEFT OUTER JOIN oppijat AS o ON o.oid = k.oppija_oid
   LEFT OUTER JOIN hoksit AS h ON h.id = k.hoks_id
-WHERE k.kyselylinkki LIKE ?
+WHERE split_part(k.kyselylinkki, '/', -1) = ?

--- a/src/oph/ehoks/db/postgresql/common.clj
+++ b/src/oph/ehoks/db/postgresql/common.clj
@@ -155,7 +155,7 @@
   "Hakee kyselylinkit tietokannasta tunnuksen perusteella."
   [tunnus]
   (db-ops/query
-    [queries/select-kyselylinkit-by-fuzzy-linkki (str "%/" tunnus)]
+    [queries/select-kyselylinkit-by-vastaajatunnus tunnus]
     {:row-fn db-ops/from-sql}))
 
 (defn delete-kyselylinkki-by-tunnus

--- a/src/oph/ehoks/db/queries.clj
+++ b/src/oph/ehoks/db/queries.clj
@@ -122,8 +122,8 @@
       "hoksit/select_kyselylinkki.sql")
 (defq select-kyselylinkit-by-oppija-oid
       "hoksit/select_kyselylinkit_by_oppija_oid.sql")
-(defq select-kyselylinkit-by-fuzzy-linkki
-      "hoksit/select_kyselylinkit_by_fuzzy_linkki.sql")
+(defq select-kyselylinkit-by-vastaajatunnus
+      "hoksit/select_kyselylinkit_by_vastaajatunnus.sql")
 (defq select-hoksit-by-ensikert-hyvaks-and-saavutettu-tiedot
       "hoksit/select_hoksit_by_ensikert_hyvaks_and_saavutettu_tiedot.sql")
 (defq select-paattyneet-tyoelamajaksot-hato

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -1,6 +1,5 @@
 (ns oph.ehoks.external.arvo
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
@@ -22,14 +21,12 @@
         (c/with-api-headers)
         :body)))
 
-(defn get-kyselylinkki-status!
+(defn get-kyselytunnus-status!
   "Hakee kyselylinkin tilan Arvosta."
-  [kyselylinkki]
-  (try (->> (str/split kyselylinkki #"/")
-            last
-            (str "/vastauslinkki/v1/status/")
+  [vastaajatunnus]
+  (try (->> (str "/vastauslinkki/v1/status/" vastaajatunnus)
             (call! :get)
-            utils/to-dash-keys)
+            (utils/to-dash-keys))
        (catch ExceptionInfo e
          (when-not (= 404 (:status (ex-data e)))
            (throw e)))))

--- a/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
+++ b/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
@@ -32,8 +32,9 @@
   "Fetch the latest status (mainly, `:vastattu` and `voimassa-loppupvm`) of
   `kyselylinkki` from Arvo and update it accordingly."
   [kyselylinkki]
-  (let [linkki (:kyselylinkki kyselylinkki)]
-    (if-let [status (arvo/get-kyselylinkki-status! linkki)]
+  (let [vastaajatunnus (:arvo-tunniste kyselylinkki)
+        linkki (:kyselylinkki kyselylinkki)]
+    (if-let [status (arvo/get-kyselytunnus-status! vastaajatunnus)]
       (let [updates {:vastattu          (:vastattu status)
                      :voimassa-loppupvm
                      (LocalDate/parse

--- a/src/oph/ehoks/virkailija/handler.clj
+++ b/src/oph/ehoks/virkailija/handler.clj
@@ -594,7 +594,8 @@
                                 (kyselylinkki/get-by-oppija-oid! oppija-oid))
                               lahetysdata
                               (map
-                                #(dissoc %1 :kyselylinkki :vastattu)
+                                #(dissoc %1 :kyselylinkki :vastattu
+                                         :arvo-tunniste)
                                 (filter
                                   #(and
                                      (= (:hoks-id %1) hoks-id)

--- a/test/oph/ehoks/palaute/opiskelija/kyselylinkki_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija/kyselylinkki_test.clj
@@ -7,11 +7,12 @@
 
 (deftest test-update-status!
   (testing "returns updated kyselylinkki when status is found"
-    (with-redefs [arvo/get-kyselylinkki-status!
+    (with-redefs [arvo/get-kyselytunnus-status!
                   (fn [_] {:vastattu          true
                            :voimassa-loppupvm "2025-12-31T00:00:00"})
                   oph.ehoks.palaute.opiskelija.kyselylinkki/update! identity]
-      (let [input {:kyselylinkki "https://testidomain.testi/ABC123"}
+      (let [input {:kyselylinkki "https://testidomain.testi/ABC123"
+                   :arvo-tunniste "ABC123"}
             result (kyselylinkki/update-status! input)]
         (is (= result
                (assoc input
@@ -19,12 +20,13 @@
                       :voimassa-loppupvm (LocalDate/of 2025 12 31)))))))
 
   (testing "returns original kyselylinkki when linkki is not found from Arvo"
-    (with-redefs [arvo/get-kyselylinkki-status! (fn [_] nil)
+    (with-redefs [arvo/get-kyselytunnus-status! (fn [_] nil)
                   oph.ehoks.palaute.opiskelija.kyselylinkki/update! identity]
       (with-log
-        (let [input {:kyselylinkki "ABC123"}
+        (let [input {:kyselylinkki "https://testidomain.testi/ABC123"
+                     :arvo-tunniste "ABC123"}
               result (kyselylinkki/update-status! input)]
           (is (= input result))
           (is (logged? 'oph.ehoks.palaute.opiskelija.kyselylinkki
                        :error
-                       #"kyselylinkki `ABC123` was not found from Arvo")))))))
+                       #"kyselylinkki `[^ ]*ABC123` was not found")))))))

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -573,7 +573,7 @@
         (client/reset-functions!))
       (testing "get kyselylinkit returns linkki from palaute"
         (let [loppupvm (.plusMonths (LocalDateTime/now) 1)]
-          (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+          (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                         (fn [_]
                           {:vastattu false
                            :voimassa-loppupvm (str loppupvm "Z")})]

--- a/test/oph/ehoks/virkailija/handler_test.clj
+++ b/test/oph/ehoks/virkailija/handler_test.clj
@@ -1538,7 +1538,7 @@
            :sahkoposti        "testi@testi.fi"
            :lahetystila       "viestintapalvelussa"
            :voimassa-loppupvm (str (LocalDate/from loppupvm))}]
-      (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+      (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                     (fn [_]
                       {:vastattu false
                        :voimassa-loppupvm (str loppupvm "Z")})]
@@ -1610,7 +1610,7 @@
                 body (test-utils/parse-body (:body resp))]
             (t/is (= 200 (:status resp)))
             (t/is (= (first (:data body)) kyselylinkki-reply)))
-          (with-redefs [oph.ehoks.external.arvo/get-kyselylinkki-status!
+          (with-redefs [oph.ehoks.external.arvo/get-kyselytunnus-status!
                         (fn [_]
                           {:vastattu true
                            :voimassa-loppupvm (str new-loppupvm "Z")})]


### PR DESCRIPTION
## Kuvaus muutoksista

Ilmeisesti siihen on vaan historialliset syyt että sekä eHOKSin että Herätepalvelun koodissa opiskelijapalautteen vastaajatunnusten statusta kysellään niin että vastaajatunnus leikellään tuolta kyselylinkistä.  Viime perjantain Arvo-monthlyssa tuli ilmi että Arvon kehittäjillä saattais olla intressiä muutella kyselylinkin formaattia kuten lisäillä sinne jotain query-parametreja.

Tää PR tuli siitä innoituksesta, että kohta mun pitää myös patchata palaute-backendin koodissa opiskelijapalautteen vastaajatunnusten tietoja (EH-1723) ja mieluummin teen molemmat silleen että ne käyttää (oikeaoppisesti) tallennettua vastaajatunnusta eikä kyselylinkistä pääteltyä vastaajatunnusta.  Eli tiksu liittyy tähän vähän epäsuorasti.

https://jira.eduuni.fi/browse/EH-1723

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
