### PR TITLE
EH-1723: message state tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>8485cd0c8aec26e0b7acabc7613732e410964cb3</tag>
+    <tag>0818435264d758be25a6a8ba597fff817385099c</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/resources/dev/src/oph/ehoks/mocked_routes/mock_arvo_routes.clj
+++ b/resources/dev/src/oph/ehoks/mocked_routes/mock_arvo_routes.clj
@@ -1,5 +1,6 @@
 (ns oph.ehoks.mocked-routes.mock-arvo-routes
-  (:require [compojure.core :refer [GET POST defroutes]]
+  (:require [compojure.core :refer [GET POST PATCH defroutes]]
+            [ring.util.http-response :as response]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.mocked-routes.mock-gen :as mock-gen])
   (:import (java.time Instant)))
@@ -9,6 +10,10 @@
     (mock-gen/json-response
       {:vastattu false
        :voimassa_loppupvm (.plusSeconds (Instant/now) 7200)}))
+
+  (PATCH "/api/vastauslinkki/v1/:linkId" request
+    (-> (response/ok (slurp (:body request)))
+        (response/content-type "application/json")))
 
   (POST "/api/vastauslinkki/v1" request
     (let [tunnus (subs (str (java.util.UUID/randomUUID)) 30)]

--- a/resources/prod/src/oph/ehoks/external/http_client.clj
+++ b/resources/prod/src/oph/ehoks/external/http_client.clj
@@ -3,7 +3,6 @@
   (:require [clj-http.client :as client]))
 
 (def delete client/delete)
-
 (def get client/get)
-
 (def post client/post)
+(def patch client/patch)

--- a/resources/test/src/oph/ehoks/external/http_client.clj
+++ b/resources/test/src/oph/ehoks/external/http_client.clj
@@ -35,11 +35,15 @@
 
 (defn set-patch! [f] (swap! client-functions assoc :patch f))
 
-(defmacro with-mock-responses [[get-response post-response] & body]
+(defmacro with-mock-responses
+  "set handlers of GET, POST (and PATCH) requests temporarily to given
+  functions for the duration of body"
+  [[get-response post-response patch-response] & body]
   `(do
      (let [fns# (get-client-functions)]
        (set-get! ~get-response)
        (set-post! ~post-response)
+       (when ~patch-response (set-patch! ~patch-response))
        (let [result# (do ~@body)]
          (restore-functions! fns#)
          result#))))

--- a/resources/test/src/oph/ehoks/external/http_client.clj
+++ b/resources/test/src/oph/ehoks/external/http_client.clj
@@ -2,38 +2,38 @@
   (:refer-clojure :exclude [get])
   (:require [clj-http.client :as client]))
 
+(def original-client-functions
+  {:delete client/delete
+   :get client/get
+   :post client/post
+   :patch client/patch})
+
 (def ^:private client-functions
-  (atom {:delete client/delete
-         :get client/get
-         :post client/post}))
+  (atom original-client-functions))
 
 (defn get-client-functions [] @client-functions)
-
-(defn reset-functions! []
-  (reset! client-functions {:delete client/delete
-                            :get client/get
-                            :post client/post}))
-
-(defn restore-functions! [fns]
-  (reset! client-functions fns))
+(defn restore-functions! [fns] (reset! client-functions fns))
+(defn reset-functions! [] (restore-functions! original-client-functions))
 
 (defn delete [url options]
   (or ((:delete @client-functions) url options) (client/delete url options)))
 
-(defn set-delete! [f]
-  (swap! client-functions assoc :delete f))
+(defn set-delete! [f] (swap! client-functions assoc :delete f))
 
 (defn get [url options]
   (or ((:get @client-functions) url options) (client/get url options)))
 
-(defn set-get! [f]
-  (swap! client-functions assoc :get f))
+(defn set-get! [f] (swap! client-functions assoc :get f))
 
 (defn post [url options]
   (or ((:post @client-functions) url options) (client/post url options)))
 
-(defn set-post! [f]
-  (swap! client-functions assoc :post f))
+(defn set-post! [f] (swap! client-functions assoc :post f))
+
+(defn patch [url options]
+  (or ((:patch @client-functions) url options) (client/patch url options)))
+
+(defn set-patch! [f] (swap! client-functions assoc :patch f))
 
 (defmacro with-mock-responses [[get-response post-response] & body]
   `(do

--- a/resources/test/src/oph/ehoks/external/http_client.clj
+++ b/resources/test/src/oph/ehoks/external/http_client.clj
@@ -35,15 +35,21 @@
 
 (defn set-patch! [f] (swap! client-functions assoc :patch f))
 
+(defn with-mock-responses*
+  "set handlers of GET, POST (and PATCH) requests temporarily to given
+  functions for the duration of callback"
+  [get-response post-response patch-response callback]
+  (let [old-handlers (get-client-functions)]
+    (set-get! get-response)
+    (set-post! post-response)
+    (when patch-response (set-patch! patch-response))
+    (let [result (callback)]
+      (restore-functions! old-handlers)
+      result)))
+
 (defmacro with-mock-responses
   "set handlers of GET, POST (and PATCH) requests temporarily to given
   functions for the duration of body"
   [[get-response post-response patch-response] & body]
-  `(do
-     (let [fns# (get-client-functions)]
-       (set-get! ~get-response)
-       (set-post! ~post-response)
-       (when ~patch-response (set-patch! ~patch-response))
-       (let [result# (do ~@body)]
-         (restore-functions! fns#)
-         result#))))
+  `(with-mock-responses* ~get-response ~post-response ~patch-response
+     (fn [] ~@body)))

--- a/src/oph/ehoks/db/sql/palauteviesti.sql
+++ b/src/oph/ehoks/db/sql/palauteviesti.sql
@@ -19,11 +19,13 @@ RETURNING id
 -- :doc Fetch all messages (along with their respective palautteet) from
 -- given viestityypit in given tila
 
-SELECT p.tila AS palaute_tila, pv.*
+SELECT	p.*,
+	p.tila AS palaute_tila,
+	pv.*,
+	pv.tila AS viesti_tila
 FROM palaute_viestit pv
 LEFT JOIN palautteet p ON (pv.palaute_id = p.id)
 WHERE pv.viestityyppi in (:v*:viestityypit)
 AND pv.tila = :tila
 AND pv.deleted_at IS NULL
 AND p.deleted_at IS NULL
-

--- a/src/oph/ehoks/db/sql/palauteviesti.sql
+++ b/src/oph/ehoks/db/sql/palauteviesti.sql
@@ -21,11 +21,24 @@ RETURNING id
 
 SELECT	p.*,
 	p.tila AS palaute_tila,
-	pv.*,
-	pv.tila AS viesti_tila
+	pv.id AS viesti_id,
+	pv.ulkoinen_tunniste,
+	pv.viestityyppi,
+	pv.tila AS viesti_tila,
+	pv.vastaanottaja
 FROM palaute_viestit pv
 LEFT JOIN palautteet p ON (pv.palaute_id = p.id)
 WHERE pv.viestityyppi in (:v*:viestityypit)
 AND pv.tila = :tila
 AND pv.deleted_at IS NULL
 AND p.deleted_at IS NULL
+
+-- :name update-tila!
+-- :doc update tila for palaute message.
+
+UPDATE	palaute_viestit
+SET	tila = :tila,
+	updated_at = now()
+WHERE	id = :id
+RETURNING id
+

--- a/src/oph/ehoks/db/sql/palauteviesti.sql
+++ b/src/oph/ehoks/db/sql/palauteviesti.sql
@@ -1,4 +1,4 @@
--- :name insert!
+-- :name insert! :? :1
 -- :doc Create a new palaute message record.
 
 INSERT INTO palaute_viestit (
@@ -15,7 +15,7 @@ VALUES (
 	:ulkoinen-tunniste)
 RETURNING id
 
--- :name get-by-tila-and-viestityypit!
+-- :name get-by-tila-and-viestityypit! :? :*
 -- :doc Fetch all messages (along with their respective palautteet) from
 -- given viestityypit in given tila
 
@@ -33,7 +33,7 @@ AND pv.tila = :tila
 AND pv.deleted_at IS NULL
 AND p.deleted_at IS NULL
 
--- :name update-tila!
+-- :name update-tila! :? :1
 -- :doc update tila for palaute message.
 
 UPDATE	palaute_viestit

--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -40,6 +40,20 @@
     (call! :post "/vastauslinkki/v1"
            {:form-params kyselylinkki-params :content-type :json})))
 
+(defn update-kyselytunnus!
+  "Päivittää Arvoon kyselylinkin muuttuneet tiedot."
+  [vastaajatunnus tila new-alkupvm new-loppupvm]
+  (try
+    (utils/to-dash-keys
+      (call! :patch (str "/vastauslinkki/v1/" vastaajatunnus)
+             {:content-type :json
+              :form-params {:metatiedot {:tila tila}
+                            :voimassa_alkupvm new-alkupvm
+                            :voimassa_loppupvm new-loppupvm}}))
+    (catch ExceptionInfo e
+      (when-not (= 404 (:status (ex-data e)))
+        (throw e)))))
+
 (defn delete-kyselytunnus
   "Poistaa kyselytunnuksen Arvosta."
   [tunnus]

--- a/src/oph/ehoks/external/connection.clj
+++ b/src/oph/ehoks/external/connection.clj
@@ -3,7 +3,8 @@
             [oph.ehoks.external.http-client :as client]))
 
 (def get-client-fn
-  (some-fn {:delete client/delete :get client/get :post client/post}
+  (some-fn {:delete client/delete :get client/get
+            :post client/post :patch client/patch}
            #(throw (ex-info "Unsupported method" {:method %}))))
 
 (defn with-api-headers

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -159,19 +159,16 @@
   (let [heratepvm (:heratepvm existing-palaute)
         new-alkupvm (greatest heratepvm (dateutil/now))
         new-loppupvm (palaute/vastaamisajan-loppupvm heratepvm new-alkupvm)
-        voimassaolo {:voimassa_alkupvm (str new-alkupvm)
-                     :voimassa_loppupvm (str new-loppupvm)}]
+        voimassaolo {:voimassa-alkupvm (str new-alkupvm)
+                     :voimassa-loppupvm (str new-loppupvm)}]
     (log/info "Palaute" (:id existing-palaute) "has now been sent"
               "so updating vastausaika to"
               (str new-alkupvm " -- " new-loppupvm))
-    (palaute/update!
-      tx (assoc voimassaolo :id (:id existing-palaute)))
-    (palaute/update-tila!
-      ctx :lahetetty :viesti-status
-      (assoc voimassaolo :viesti-status viesti-status))
+    (palaute/update! tx (assoc voimassaolo :id (:id existing-palaute)))
+    (palaute/update-tila! ctx :lahetetty :viesti-status
+                          (assoc voimassaolo :viesti-status viesti-status))
     (arvo/update-kyselytunnus!
-      (:arvo_tunniste existing-palaute)
-      "lahetetty" new-alkupvm new-loppupvm)))
+      (:arvo-tunniste existing-palaute) "lahetetty" new-alkupvm new-loppupvm)))
 
 (def vvp-state->viesti-tila
   {["SKANNAUS"] :odottaa-lahetysta,
@@ -189,13 +186,13 @@
   "Päivittää lähetysstatuksen yhdelle viestille ja päivittää palautteen
   tiedot vastaavasti."
   [{:keys [existing-viesti tx] :as ctx}]
-  (log/info "Updating delivery status for message" (:viesti_id existing-viesti)
-            "(external id" (:ulkoinen_tunniste existing-viesti) ")")
-  (let [status (vvp/message-state! (:ulkoinen_tunniste existing-viesti))
+  (log/info "Updating delivery status for message" (:viesti-id existing-viesti)
+            "(external id" (:ulkoinen-tunniste existing-viesti) ")")
+  (let [status (vvp/message-state! (:ulkoinen-tunniste existing-viesti))
         viesti-tila (vvp-state->viesti-tila status)]
-    (log/info "Delivery status for message" (:viesti_id existing-viesti)
+    (log/info "Delivery status for message" (:viesti-id existing-viesti)
               "is" status "which means" viesti-tila)
-    (update-tila! tx {:id (:viesti_id existing-viesti)
+    (update-tila! tx {:id (:viesti-id existing-viesti)
                       :tila (utils/to-underscore-str viesti-tila)})
     (if (= :lahetetty viesti-tila)
       (record-sending-to-db-and-arvo! (assoc ctx :viesti-status status))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -1,9 +1,12 @@
 (ns oph.ehoks.palaute.lahetys
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
             [clojure.string :as str]
             [hugsql.core :as hugsql]
+            [medley.core :refer [greatest]]
             [oph.ehoks.db :as db]
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
+            [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.handling :as handling]
@@ -16,6 +19,7 @@
 
 (declare insert!)
 (declare get-by-tila-and-viestityypit!)
+(declare update-tila!)
 (hugsql/def-db-fns "oph/ehoks/db/sql/palauteviesti.sql")
 
 (defn send-palaute-initial-email!
@@ -147,3 +151,73 @@
               (palaute/get-unsent-palautteet!
                 db/spec {:kyselytyypit kyselytyypit
                          :viestityyppi "email"}))))
+
+(defn record-sending-to-db-and-arvo!
+  "Päivittää Arvoon ja tietokantaan palautteen tilan sekä vastaamisajan
+  alku- ja loppupäivän sillä hetkellä kun viestin saadaan tietää lähteneen"
+  [{:keys [existing-palaute viesti-status tx] :as ctx}]
+  (let [heratepvm (:heratepvm existing-palaute)
+        new-alkupvm (greatest heratepvm (dateutil/now))
+        new-loppupvm (palaute/vastaamisajan-loppupvm heratepvm new-alkupvm)
+        voimassaolo {:voimassa_alkupvm (str new-alkupvm)
+                     :voimassa_loppupvm (str new-loppupvm)}]
+    (log/info "Palaute" (:id existing-palaute) "has now been sent"
+              "so updating vastausaika to"
+              (str new-alkupvm " -- " new-loppupvm))
+    (palaute/update!
+      tx (assoc voimassaolo :id (:id existing-palaute)))
+    (palaute/update-tila!
+      ctx :lahetetty :viesti-status
+      (assoc voimassaolo :viesti-status viesti-status))
+    (arvo/update-kyselytunnus!
+      (:arvo_tunniste existing-palaute)
+      "lahetetty" new-alkupvm new-loppupvm)))
+
+(def vvp-state->viesti-tila
+  {["SKANNAUS"] :odottaa-lahetysta,
+   ["ODOTTAA"] :odottaa-lahetysta,
+   ["LAHETYKSESSA"] :odottaa-lahetysta,
+   ["VIRHE"] :lahetys-epaonnistunut,
+   ["LAHETETTY"] :lahetetty,
+   ["DELIVERY"] :lahetetty,
+   ["BOUNCE"] :lahetys-epaonnistunut,
+   ["COMPLAINT"] :lahetetty,
+   ["REJECT"] :lahetys-epaonnistunut,
+   ["DELIVERYDELAY"] :odottaa-lahetysta})
+
+(defn update-delivery-status!
+  "Päivittää lähetysstatuksen yhdelle viestille ja päivittää palautteen
+  tiedot vastaavasti."
+  [{:keys [existing-viesti tx] :as ctx}]
+  (log/info "Updating delivery status for message" (:viesti_id existing-viesti)
+            "(external id" (:ulkoinen_tunniste existing-viesti) ")")
+  (let [status (vvp/message-state! (:ulkoinen_tunniste existing-viesti))
+        viesti-tila (vvp-state->viesti-tila status)]
+    (log/info "Delivery status for message" (:viesti_id existing-viesti)
+              "is" status "which means" viesti-tila)
+    (update-tila! tx {:id (:viesti_id existing-viesti)
+                      :tila (utils/to-underscore-str viesti-tila)})
+    (if (= :lahetetty viesti-tila)
+      (record-sending-to-db-and-arvo! (assoc ctx :viesti-status status))
+      (pt/build-and-insert! ctx :viesti-status {:viesti-status status}))))
+
+(defn handle-palaute-waiting-for-sending-status!
+  "Tekee asiat, mitä tarvitsee tehdä yhdelle viestille jonka lähetysstatusta
+  ei vielä tiedetä."
+  [palaute-viesti]
+  (jdbc/with-db-transaction
+    [tx db/spec]
+    (update-delivery-status! {:existing-palaute palaute-viesti
+                              :existing-viesti palaute-viesti
+                              :tapahtumatyyppi :lahetys
+                              :tx tx})))
+
+(defn handle-palautteet-waiting-for-sending-status!
+  "Päivittää lähetysstatuksen viesteille, joille sitä ei ole vielä tiedetä."
+  []
+  (log/info "Checking delivery status for new messages")
+  (doall (map handle-palaute-waiting-for-sending-status!
+              (get-by-tila-and-viestityypit!
+                db/spec {:tila "odottaa_lahetysta"
+                         :viestityypit ["email" "email_muistutus_1"
+                                        "email_muistutus_2"]}))))

--- a/src/oph/ehoks/palaute/scheduler.clj
+++ b/src/oph/ehoks/palaute/scheduler.clj
@@ -56,7 +56,17 @@
       (log/info "handle-unsent-palautteet!: ended with result"
                 result))
     (catch Exception e
-      (log/error e "Unhandled exception in handle-unsent-palautteet!"))))
+      (log/error e "Unhandled exception in handle-unsent-palautteet!")))
+  (try
+    (log/info "Handling viestit whose sending status is unknown.")
+    (let [result (lahetys/handle-palautteet-waiting-for-sending-status!)]
+      (log/info "handle-palautteet-waiting-for-sending-status!: ended with"
+                "result" result))
+    (catch Exception e
+      (log/error e "Unhandled exception in"
+                 "handle-palautteet-waiting-for-sending-status!")))
+  (log/info "Done palaute hourly actions.")
+  true)
 
 (defn time->instant
   "Converts a specific time of day into an instant on today"

--- a/src/oph/ehoks/palaute/viestit.clj
+++ b/src/oph/ehoks/palaute/viestit.clj
@@ -162,14 +162,13 @@
 
 (defn amispalaute-body
   "Luo AMIS-kyselyviestin tekstin. Data-objektiin kuuluvat seuraavat kentät:
-    :kyselytyyppi   - aloittaneet, tutkinnon_suorittaneet tai
-                      tutkinnon_osia_suorittaneet
+    :kyselytyyppi   - aloittaneet, valmistuneet tai osia_suorittaneet
     :muistutus?     - onko kyseessä muistutusviesti jo lähetetystä linkistä
     :kyselylinkki   - kyselylinkki, joka lähetetään opiskelijalle"
   [{:keys [kyselytyyppi kyselylinkki muistutus?]}]
-  (let [templates {"aloittaneet" amispalaute-body-alkukysely
-                   "tutkinnon_suorittaneet" amispalaute-body-loppukysely
-                   "tutkinnon_osia_suorittaneet" amispalaute-body-loppukysely}
+  (let [templates {"aloittaneet"    amispalaute-body-alkukysely
+                   "valmistuneet"   amispalaute-body-loppukysely
+                   "osia_suorittaneet" amispalaute-body-loppukysely}
         template (templates kyselytyyppi)]
     (list (when muistutus? (amismuistutus-body kyselylinkki))
           (template kyselylinkki))))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -256,3 +256,229 @@
                         (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                         (map (juxt :tila :kyselytyyppi))))))
           nil)))))
+
+(deftest test-update-delivery-status!
+  (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
+                koski/get-oppija-opiskeluoikeudet
+                koski-test/mock-get-oppija-opiskeluoikeudet
+                koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw
+                onr/get-oppija-raw!
+                mock-get-oppija-raw!
+                organisaatio/get-organisaatio!
+                organisaatio-test/mock-get-organisaatio!]
+    (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-1)
+    (let [ctx {:hoks (assoc
+                       hoks-test/hoks-1
+                       :osaamisen-saavuttamisen-pvm (LocalDate/of 2023 4 17))
+               :opiskeluoikeus oo-test/opiskeluoikeus-1}
+          hoks (hoks-handler/save-hoks-and-initiate-all-palautteet! ctx)]
+
+      (testing "update-delivery-status! with LAHETETTY status"
+        (with-mock-responses
+          [(fn [_ __] {})
+           (fn [url _]
+             (when (s/ends-with? url "/api/vastauslinkki/v1")
+               {:status 200
+                :body {:tunnus "testivain"
+                       :kysely_linkki "https://arvovastaus.csc.fi/v/test"
+                       :voimassa_loppupvm "2024-10-10"}}))]
+          (->> {:kyselytyypit ["aloittaneet"]}
+               (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec)
+               (first)
+               (vt/create-vastaajatunnus!)))
+
+        (let [heratteet
+              (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
+                   (palaute/get-unsent-palautteet! db/spec))]
+          (with-mock-responses
+            [(fn [url _]
+               (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                 {:status 200
+                  :body {:tunnus "test"
+                         :voimassa_loppupvm "2026-04-14"
+                         :vastattu false}}))
+             (fn [^String url _]
+               (when (s/ends-with? url "/lahetys/v1/viestit")
+                 {:status 200
+                  :body {:viestiTunniste "test-message-id"
+                         :lahetysTunniste "test-message-id"}}))]
+            (is (= "test-message-id"
+                   (l/handle-unsent-palaute! (first heratteet)))))
+
+          (let [viestit (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                             (l/get-by-tila-and-viestityypit! db/spec))
+                viesti (first viestit)]
+            (testing "message was created with odottaa_lahetysta status"
+              (is (= 1 (count viestit)))
+              (is (= "test-message-id" (:ulkoinen_tunniste viesti))))
+
+            (testing "updates status to lahetetty when VVP reports LAHETETTY"
+              (with-mock-responses
+                [(fn [url _]
+                   (cond
+                     (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                     {:status 200
+                      :body {:tunnus "test"
+                             :voimassa_loppupvm "2026-04-14"
+                             :vastattu false}}
+                     (s/ends-with?
+                       url "/lahetykset/test-message-id/vastaanottajat")
+                     {:status 200
+                      :body {:vastaanottajat [{:tila "LAHETETTY"}]}}))
+                 (fn [_ _])
+                 (fn [url options]
+                   (when (s/ends-with? url "/vastauslinkki/v1/testivain")
+                     {:status 200
+                      :body (:body options)}))]
+                (l/handle-palaute-waiting-for-sending-status! viesti))
+
+              (is (= [] (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                             (l/get-by-tila-and-viestityypit! db/spec))))
+              (is (= [["lahetetty" "test-message-id"]]
+                     (->> {:viestityypit ["email"] :tila "lahetetty"}
+                          (l/get-by-tila-and-viestityypit! db/spec)
+                          (map (juxt :viesti_tila :ulkoinen_tunniste)))))
+              (is (= [["lahetetty" "aloittaneet"]]
+                     (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                          (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                          (map (juxt :tila :kyselytyyppi)))))))))
+
+      (testing "update-delivery-status! with VIRHE status"
+        (with-mock-responses
+          [(fn [_ __] {})
+           (fn [url _]
+             (when (s/ends-with? url "/api/vastauslinkki/v1")
+               {:status 200
+                :body {:tunnus "testivain2"
+                       :kysely_linkki "https://arvovastaus.csc.fi/v/test2"
+                       :voimassa_loppupvm "2024-10-10"}}))]
+          (let [palautteet (palaute/get-palautteet-waiting-for-vastaajatunnus!
+                             db/spec {:kyselytyypit ["valmistuneet"]})]
+            (is (= 1 (count palautteet)))
+            (is (= "testivain2"
+                   (vt/create-vastaajatunnus! (first palautteet))))))
+
+        (let [heratteet
+              (->> {:kyselytyypit ["valmistuneet"] :viestityyppi "email"}
+                   (palaute/get-unsent-palautteet! db/spec))]
+          (is (= 1 (count heratteet)))
+          (with-mock-responses
+            [(fn [url _]
+               (when (s/ends-with? url "/vastauslinkki/v1/status/testivain2")
+                 {:status 200
+                  :body {:tunnus "test2"
+                         :voimassa_loppupvm "2026-04-14"
+                         :vastattu false}}))
+             (fn [^String url _]
+               (when (s/ends-with? url "/lahetys/v1/viestit")
+                 {:status 200
+                  :body {:viestiTunniste "test-message-id-2"
+                         :lahetysTunniste "test-message-id-2"}}))]
+            (is (= "test-message-id-2"
+                   (l/handle-unsent-palaute! (first heratteet))))))
+
+        (let [viestit (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                           (l/get-by-tila-and-viestityypit! db/spec))
+              viesti (first viestit)]
+
+          (testing "päättökyselyn viesti was created"
+            (is (= 1 (count viestit)))
+            (is (= "test-message-id-2" (:ulkoinen_tunniste viesti))))
+
+          (testing (str "updates status to lahetys-epaonnistunut "
+                        "when VVP reports VIRHE")
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with?
+                         url "/lahetykset/test-message-id-2/vastaanottajat")
+                   {:status 200
+                    :body {:vastaanottajat [{:tila "VIRHE"}]}}))
+               (fn [_ __] {})]
+              (l/handle-palaute-waiting-for-sending-status! viesti))
+
+            (is (= [["kysely_muodostettu" "valmistuneet"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["valmistuneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi)))))
+            (is (= [["lahetys_epaonnistunut" "test-message-id-2"]]
+                   (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
+                        (l/get-by-tila-and-viestityypit! db/spec)
+                        (map (juxt :viesti_tila :ulkoinen_tunniste)))))))))))
+
+(deftest test-handle-palautteet-waiting-for-sending-status!
+  (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
+                koski/get-oppija-opiskeluoikeudet
+                koski-test/mock-get-oppija-opiskeluoikeudet
+                koski/get-opiskeluoikeus-info-raw
+                koski-test/mock-get-opiskeluoikeus-raw
+                onr/get-oppija-raw!
+                mock-get-oppija-raw!
+                organisaatio/get-organisaatio!
+                organisaatio-test/mock-get-organisaatio!]
+    (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-1)
+    (let [ctx {:hoks hoks-test/hoks-1 :opiskeluoikeus oo-test/opiskeluoikeus-1}]
+      (hoks-handler/save-hoks-and-initiate-all-palautteet! ctx)
+
+      (with-mock-responses
+        [(fn [_ __] {})
+         (fn [url _]
+           (when (s/ends-with? url "/api/vastauslinkki/v1")
+             {:status 200
+              :body {:tunnus "testivain"
+                     :kysely_linkki "https://arvovastaus.csc.fi/v/test"
+                     :voimassa_loppupvm "2024-10-10"}}))]
+        (->> {:kyselytyypit ["aloittaneet"]}
+             (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec)
+             (first)
+             (vt/create-vastaajatunnus!)))
+
+      (let [heratteet
+            (->> {:kyselytyypit ["aloittaneet"] :viestityyppi "email"}
+                 (palaute/get-unsent-palautteet! db/spec))]
+        (with-mock-responses
+          [(fn [url _]
+             (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+               {:status 200
+                :body {:tunnus "test"
+                       :voimassa_loppupvm "2026-04-14"
+                       :vastattu false}}))
+           (fn [^String url _]
+             (when (s/ends-with? url "/lahetys/v1/viestit")
+               {:status 200
+                :body {:viestiTunniste "test-message-id"
+                       :lahetysTunniste "test-message-id"}}))]
+          (l/handle-unsent-palaute! (first heratteet)))
+
+        (testing "processes all messages waiting for sending status"
+          (let [viestit-before
+                (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                     (l/get-by-tila-and-viestityypit! db/spec))]
+            (is (= 1 (count viestit-before)))
+
+            (with-mock-responses
+              [(fn [url _]
+                 (cond
+                   (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2026-04-14"
+                           :vastattu false}}
+                   (s/ends-with?
+                     url "/lahetykset/test-message-id/vastaanottajat")
+                   {:status 200
+                    :body {:vastaanottajat [{:tila "LAHETETTY"}]}}))
+               (fn [_ _])
+               (fn [url options]
+                 (when (s/ends-with? url "/vastauslinkki/v1/testivain")
+                   {:status 200
+                    :body (:body options)}))]
+              (l/handle-palautteet-waiting-for-sending-status!))
+
+            (let [viestit-after
+                  (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                       (l/get-by-tila-and-viestityypit! db/spec))]
+              (is (= 0 (count viestit-after)))
+              (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
+                            (l/get-by-tila-and-viestityypit! db/spec)
+                            count))))))))))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -171,10 +171,10 @@
                    (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                         (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                         (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
-            (is (= [["lahetys_epaonnistunut" "email" nil]]
+            (is (= [["lahetys_epaonnistunut" nil]]
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :tila :viestityyppi :ulkoinen_tunniste))))))
+                        (map (juxt :viesti_tila :ulkoinen_tunniste))))))
 
           (testing "with successful arvo-status and sending"
             (with-mock-responses
@@ -205,10 +205,10 @@
                    (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                         (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                         (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
-            (is (= [["odottaa_lahetysta" "email" "brymir"]]
+            (is (= [["odottaa_lahetysta" "brymir"]]
                    (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :tila :viestityyppi :ulkoinen_tunniste))))))
+                        (map (juxt :viesti_tila :ulkoinen_tunniste))))))
 
           (testing "with expired kyselylinkki"
             (with-mock-responses

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -174,7 +174,7 @@
             (is (= [["lahetys_epaonnistunut" nil]]
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :viesti_tila :ulkoinen_tunniste))))))
+                        (map (juxt :viesti-tila :ulkoinen-tunniste))))))
 
           (testing "with successful arvo-status and sending"
             (with-mock-responses
@@ -208,7 +208,7 @@
             (is (= [["odottaa_lahetysta" "brymir"]]
                    (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :viesti_tila :ulkoinen_tunniste))))))
+                        (map (juxt :viesti-tila :ulkoinen-tunniste))))))
 
           (testing "with expired kyselylinkki"
             (with-mock-responses
@@ -311,7 +311,7 @@
                 viesti (first viestit)]
             (testing "message was created with odottaa_lahetysta status"
               (is (= 1 (count viestit)))
-              (is (= "test-message-id" (:ulkoinen_tunniste viesti))))
+              (is (= "test-message-id" (:ulkoinen-tunniste viesti))))
 
             (testing "updates status to lahetetty when VVP reports LAHETETTY"
               (with-mock-responses
@@ -338,7 +338,7 @@
               (is (= [["lahetetty" "test-message-id"]]
                      (->> {:viestityypit ["email"] :tila "lahetetty"}
                           (l/get-by-tila-and-viestityypit! db/spec)
-                          (map (juxt :viesti_tila :ulkoinen_tunniste)))))
+                          (map (juxt :viesti-tila :ulkoinen-tunniste)))))
               (is (= [["lahetetty" "aloittaneet"]]
                      (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                           (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
@@ -384,7 +384,7 @@
 
           (testing "päättökyselyn viesti was created"
             (is (= 1 (count viestit)))
-            (is (= "test-message-id-2" (:ulkoinen_tunniste viesti))))
+            (is (= "test-message-id-2" (:ulkoinen-tunniste viesti))))
 
           (testing (str "updates status to lahetys-epaonnistunut "
                         "when VVP reports VIRHE")
@@ -404,7 +404,7 @@
             (is (= [["lahetys_epaonnistunut" "test-message-id-2"]]
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :viesti_tila :ulkoinen_tunniste)))))))))))
+                        (map (juxt :viesti-tila :ulkoinen-tunniste)))))))))))
 
 (deftest test-handle-palautteet-waiting-for-sending-status!
   (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
@@ -451,34 +451,33 @@
           (l/handle-unsent-palaute! (first heratteet)))
 
         (testing "processes all messages waiting for sending status"
-          (let [viestit-before
-                (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
-                     (l/get-by-tila-and-viestityypit! db/spec))]
-            (is (= 1 (count viestit-before)))
+          (is (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                   (l/get-by-tila-and-viestityypit! db/spec)
+                   (count)
+                   (= 1)))
 
-            (with-mock-responses
-              [(fn [url _]
-                 (cond
-                   (s/ends-with? url "/vastauslinkki/v1/status/testivain")
-                   {:status 200
-                    :body {:tunnus "test"
-                           :voimassa_loppupvm "2026-04-14"
-                           :vastattu false}}
-                   (s/ends-with?
-                     url "/lahetykset/test-message-id/vastaanottajat")
-                   {:status 200
-                    :body {:vastaanottajat [{:tila "LAHETETTY"}]}}))
-               (fn [_ _])
-               (fn [url options]
-                 (when (s/ends-with? url "/vastauslinkki/v1/testivain")
-                   {:status 200
-                    :body (:body options)}))]
-              (l/handle-palautteet-waiting-for-sending-status!))
+          (with-mock-responses
+            [(fn [url _]
+               (cond
+                 (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                 {:status 200
+                  :body {:tunnus "test"
+                         :voimassa_loppupvm "2026-04-14"
+                         :vastattu false}}
+                 (s/ends-with?
+                   url "/lahetykset/test-message-id/vastaanottajat")
+                 {:status 200
+                  :body {:vastaanottajat [{:tila "LAHETETTY"}]}}))
+             (fn [_ _])
+             (fn [url options]
+               (when (s/ends-with? url "/vastauslinkki/v1/testivain")
+                 {:status 200
+                  :body (:body options)}))]
+            (l/handle-palautteet-waiting-for-sending-status!))
 
-            (let [viestit-after
-                  (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
-                       (l/get-by-tila-and-viestityypit! db/spec))]
-              (is (= 0 (count viestit-after)))
-              (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
-                            (l/get-by-tila-and-viestityypit! db/spec)
-                            count))))))))))
+          (is (= 0 (->> {:viestityypit ["email"] :tila "odottaa_lahetysta"}
+                        (l/get-by-tila-and-viestityypit! db/spec)
+                        (count))))
+          (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
+                        (l/get-by-tila-and-viestityypit! db/spec)
+                        (count)))))))))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -481,3 +481,92 @@
           (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
                         (l/get-by-tila-and-viestityypit! db/spec)
                         (count)))))))))
+
+(deftest test-vastausaika-updated-on-confirmed-delivery!
+  (testing (str "voimassa_alkupvm and voimassa_loppupvm are updated to reflect "
+                "the actual sending date, not the original heratepvm")
+    (let [initial-date (LocalDate/of 2023 4 18)
+          sending-date (LocalDate/of 2023 4 21)]
+      (with-redefs [date/now (constantly initial-date)
+                    koski/get-oppija-opiskeluoikeudet
+                    koski-test/mock-get-oppija-opiskeluoikeudet
+                    koski/get-opiskeluoikeus-info-raw
+                    koski-test/mock-get-opiskeluoikeus-raw
+                    onr/get-oppija-raw!
+                    mock-get-oppija-raw!
+                    organisaatio/get-organisaatio!
+                    organisaatio-test/mock-get-organisaatio!]
+        (oppijaindex/add-hoks-dependents-in-index! hoks-test/hoks-1)
+        (hoks-handler/save-hoks-and-initiate-all-palautteet!
+          {:hoks hoks-test/hoks-1 :opiskeluoikeus oo-test/opiskeluoikeus-1})
+
+        (with-mock-responses
+          [(fn [_ __] {})
+           (fn [url _]
+             (when (s/ends-with? url "/api/vastauslinkki/v1")
+               {:status 200
+                :body {:tunnus "testivain"
+                       :kysely_linkki "https://arvovastaus.csc.fi/v/test"
+                       :voimassa_loppupvm "2024-10-10"}}))]
+          (->> {:kyselytyypit ["aloittaneet"]}
+               (palaute/get-palautteet-waiting-for-vastaajatunnus! db/spec)
+               (first)
+               (vt/create-vastaajatunnus!)
+               (= "testivain")
+               (is)))
+
+        (let [palautteet (palaute/get-unsent-palautteet!
+                           db/spec {:kyselytyypit ["aloittaneet"]
+                                    :viestityyppi "email"})
+              palaute (first palautteet)]
+          (is (= 1 (count palautteet)))
+          (is (= "2023-04-18" (str (:voimassa-alkupvm palaute))))
+
+          (with-mock-responses
+            [(fn [url _]
+               (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                 {:status 200
+                  :body {:tunnus "test"
+                         :voimassa_loppupvm "2026-04-14"
+                         :vastattu false}}))
+             (fn [url _]
+               (when (s/ends-with? url "/lahetys/v1/viestit")
+                 {:status 200
+                  :body {:viestiTunniste "test-message-id"
+                         :lahetysTunniste "test-message-id"}}))]
+            (is (= "test-message-id" (l/handle-unsent-palaute! palaute)))))
+
+        (let [viesti (first (l/get-by-tila-and-viestityypit!
+                              db/spec {:viestityypit ["email"]
+                                       :tila "odottaa_lahetysta"}))]
+          (is (= "odottaa_lahetysta" (:viesti-tila viesti)))
+          (is (= "test-message-id" (:ulkoinen-tunniste viesti)))
+          (let [arvo-patch-options (atom nil)]
+            (with-redefs [date/now (constantly sending-date)]
+              (with-mock-responses
+                [(fn [url _]
+                   (when (s/ends-with?
+                           url "/lahetykset/test-message-id/vastaanottajat")
+                     {:status 200
+                      :body {:vastaanottajat [{:tila "LAHETETTY"}]}}))
+                 (fn [_ _])
+                 (fn [url options]
+                   (when (s/ends-with? url "/vastauslinkki/v1/testivain")
+                     (reset! arvo-patch-options options)
+                     {:status 200 :body (:body options)}))]
+                (l/handle-palaute-waiting-for-sending-status! viesti)))
+            (is (= (str sending-date)
+                   (str (get-in @arvo-patch-options
+                                [:form-params :voimassa_alkupvm]))))
+            (is (= (str (.plusDays sending-date 29))
+                   (str (get-in @arvo-patch-options
+                                [:form-params :voimassa_loppupvm])))))
+
+          (let [palautteet (palaute/get-by-hoks-id-and-kyselytyypit!
+                             db/spec {:hoks-id (:hoks-id viesti)
+                                      :kyselytyypit ["aloittaneet"]})
+                palaute (first palautteet)]
+            (is (= 1 (count palautteet)))
+            (is (= (str sending-date) (str (:voimassa-alkupvm palaute))))
+            (is (= (str (.plusDays sending-date 29))
+                   (str (:voimassa-loppupvm palaute))))))))))

--- a/test/oph/ehoks/palaute/viestit_test.clj
+++ b/test/oph/ehoks/palaute/viestit_test.clj
@@ -120,7 +120,7 @@
   (testing "amispalaute-html formats correctly loppukysely"
     (let [actual (v/amispalaute-html
                    {:suorituskieli "fi"
-                    :kyselytyyppi "tutkinnon_suorittaneet"
+                    :kyselytyyppi "valmistuneet"
                     :kyselylinkki "https://kysely.linkki/123"})]
       (is (= actual mock-amispalaute-html-loppukysely)
           (format-diff (d/diff actual mock-amispalaute-html-loppukysely))))))
@@ -190,7 +190,7 @@
   (testing "amismuistutus-html formats correctly"
     (let [actual (v/amispalaute-html
                    {:suorituskieli "fi"
-                    :kyselytyyppi "tutkinnon_osia_suorittaneet"
+                    :kyselytyyppi "osia_suorittaneet"
                     :muistutus? true
                     :kyselylinkki "https://kysely.linkki/123"})]
       (is (= actual mock-amismuistutus-html)


### PR DESCRIPTION
## Kuvaus muutoksista

Koodi, jolla seurataan viestien lähetystiloja (viestintäpalvelussa) ja pidetään kirjaa, kun viesti on lähetetty tai epäonnistunut.

Teen _vielä_ erillisen PR:n siitä, että tilaksi päivitetään `lahetys_epaonnistunut` mikäli sekä meili että SMS epäonnistuu.

https://jira.eduuni.fi/browse/EH-1723

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
