### PR TITLE
EH-2031: sync amispalaute to heratepalvelu after sending

### DIFF
--- a/src/oph/ehoks/db.clj
+++ b/src/oph/ehoks/db.clj
@@ -29,8 +29,7 @@
   (as-> result r
     (remove-vals nil? r)
     (map-vals pgarray->vec r)
-    (utils/to-dash-keys r)
-    (dissoc r :created-at :updated-at :deleted-at)))
+    (utils/to-dash-keys r)))
 
 (defn result-one-snake->kebab
   [this result options]

--- a/src/oph/ehoks/db/sql.clj
+++ b/src/oph/ehoks/db/sql.clj
@@ -24,7 +24,9 @@
   \"set key1 = 1,key2 = 'val2'\" when `params` is {:key1 1 :key2 \"val2\"})`."
   [params options]
   (str "set updated_at = now(), "
-       (str/join "," (for [[field _] params]
+       (str/join "," (for [[field _] params
+                            :when (not (#{:updated-at :created-at :deleted-at}
+                                        field))]
                        (-> (utils/to-underscore-str field)
                            (identifier-param-quote options)
                            (str " = :v:" (name field)))))))

--- a/src/oph/ehoks/db/sql.clj
+++ b/src/oph/ehoks/db/sql.clj
@@ -25,7 +25,7 @@
   [params options]
   (str "set updated_at = now(), "
        (str/join "," (for [[field _] params
-                            :when (not (#{:updated-at :created-at :deleted-at}
+                           :when (not (#{:updated-at :created-at :deleted-at}
                                         field))]
                        (-> (utils/to-underscore-str field)
                            (identifier-param-quote options)

--- a/src/oph/ehoks/db/sql/palauteviesti.sql
+++ b/src/oph/ehoks/db/sql/palauteviesti.sql
@@ -15,6 +15,15 @@ VALUES (
 	:ulkoinen-tunniste)
 RETURNING id
 
+-- :name get-by-palaute-and-viestityypit! :? :*
+-- :doc Fetch all messages for the given palaute-id
+
+SELECT *
+FROM palaute_viestit
+WHERE viestityyppi in (:v*:viestityypit)
+AND palaute_id = :palaute-id
+AND deleted_at IS NULL
+
 -- :name get-by-tila-and-viestityypit! :? :*
 -- :doc Fetch all messages (along with their respective palautteet) from
 -- given viestityypit in given tila

--- a/src/oph/ehoks/palaute/handling.clj
+++ b/src/oph/ehoks/palaute/handling.clj
@@ -52,8 +52,7 @@
                                     (:heratepvm existing-palaute))
            :opiskeluoikeus opiskeluoikeus
            :suoritus suoritus
-           :hk-toteuttaja
-           (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
+           :hk-toteuttaja (delay (palaute/hankintakoulutuksen-toteuttaja! hoks))
            :koulutustoimija koulutustoimija
            :toimipiste (palaute/toimipiste-oid! suoritus))))
 

--- a/src/oph/ehoks/palaute/handling.clj
+++ b/src/oph/ehoks/palaute/handling.clj
@@ -43,8 +43,8 @@
     (assoc ctx
            :existing-ddb-herate
            (delay (palaute-ddb-record existing-palaute hoks koulutustoimija))
-           :arvo-status
            ;; needs more logic when tep-palaute may also be queried
+           :arvo-status
            (delay (some-> (:arvo-tunniste existing-palaute)
                           (arvo/get-kyselytunnus-status!)))
            :niputuspvm            (tep/next-niputus-date (date/now))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -230,7 +230,11 @@
                       {:type ::viestistatuksen-haku-epaonnistui :ctx ctx})))
     (if (= :lahetetty viesti-tila)
       (record-sending-to-db-hp-and-arvo! (assoc ctx :viesti-status status))
-      (pt/build-and-insert! ctx :viesti-status {:viesti-status status}))))
+      (pt/build-and-insert! ctx :viesti-status {:viesti-status status}))
+    ;; temporary fix until we also send SMS's: sync even failed
+    ;; palautteet to herätepalvelu for trying to send SMS
+    (when (= :lahetys-epaonnistunut viesti-tila)
+      (sync-to-heratepalvelu! ctx))))
 
 (defn handle-palaute-waiting-for-sending-status!
   "Tekee asiat, mitä tarvitsee tehdä yhdelle viestille jonka lähetysstatusta

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -5,11 +5,13 @@
             [hugsql.core :as hugsql]
             [medley.core :refer [greatest]]
             [oph.ehoks.db :as db]
+            [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
             [oph.ehoks.external.arvo :as arvo]
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.handling :as handling]
+            [oph.ehoks.palaute.opiskelija :as opiskelija]
             [oph.ehoks.palaute.tapahtuma :as pt]
             [oph.ehoks.palaute.viestit :as v]
             [oph.ehoks.utils :as utils]
@@ -155,7 +157,18 @@
                 db/spec {:kyselytyypit kyselytyypit
                          :viestityyppi "email"}))))
 
-(defn record-sending-to-db-and-arvo!
+(defn sync-to-heratepalvelu!
+  "Enrich context with enough information to sync palaute into
+  herätepalvelu and then do the sync.  Currently only works for
+  AMIS-kysely kyselytyypit."
+  [{:keys [existing-palaute] :as ctx}]
+  (-> existing-palaute
+      (handling/build-ctx!)
+      (merge ctx)  ; because original context has e.g. tx and existing-viesti
+      (opiskelija/build-amisherate-record-for-heratepalvelu)
+      (ddb/sync-amis-herate! :after-viestinvalityspalvelu-status)))
+
+(defn record-sending-to-db-hp-and-arvo!
   "Päivittää Arvoon ja tietokantaan palautteen tilan sekä vastaamisajan
   alku- ja loppupäivän sillä hetkellä kun viestin saadaan tietää lähteneen"
   [{:keys [existing-palaute viesti-status tx] :as ctx}]
@@ -171,7 +184,8 @@
     (palaute/update-tila! ctx :lahetetty :viesti-status
                           (assoc voimassaolo :viesti-status viesti-status))
     (arvo/update-kyselytunnus!
-      (:arvo-tunniste existing-palaute) "lahetetty" new-alkupvm new-loppupvm)))
+      (:arvo-tunniste existing-palaute) "lahetetty" new-alkupvm new-loppupvm)
+    (sync-to-heratepalvelu! ctx)))
 
 (def vvp-state->viesti-tila
   {["SKANNAUS"] :odottaa-lahetysta,
@@ -201,7 +215,7 @@
       (throw (ex-info "Unknown delivery status"
                       {:type ::viestistatuksen-haku-epaonnistui :ctx ctx})))
     (if (= :lahetetty viesti-tila)
-      (record-sending-to-db-and-arvo! (assoc ctx :viesti-status status))
+      (record-sending-to-db-hp-and-arvo! (assoc ctx :viesti-status status))
       (pt/build-and-insert! ctx :viesti-status {:viesti-status status}))))
 
 (defn handle-palaute-waiting-for-sending-status!

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -195,8 +195,11 @@
         viesti-tila (vvp-state->viesti-tila status)]
     (log/info "Delivery status for message" (:viesti-id existing-viesti)
               "is" status "which means" viesti-tila)
-    (update-tila! tx {:id (:viesti-id existing-viesti)
-                      :tila (utils/to-underscore-str viesti-tila)})
+    (if viesti-tila
+      (update-tila! tx {:id (:viesti-id existing-viesti)
+                        :tila (utils/to-underscore-str viesti-tila)})
+      (throw (ex-info "Unknown delivery status"
+                      {:type ::viestistatuksen-haku-epaonnistui :ctx ctx})))
     (if (= :lahetetty viesti-tila)
       (record-sending-to-db-and-arvo! (assoc ctx :viesti-status status))
       (pt/build-and-insert! ctx :viesti-status {:viesti-status status}))))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -90,7 +90,7 @@
                :tila (utils/to-underscore-str msg-state)
                :ulkoinen-tunniste msg-id}))
 
-(defn palaute-check-send-save-and-sync!
+(defn palaute-check-send-and-save!
   "Tekee kaikki palautekutsun lähetyksen vaiheet"
   [{:keys [existing-palaute hoks] :as ctx} _] ; no handlers used yet
   (let [[msg-state state field reason] (check-palaute-for-sending ctx)
@@ -134,7 +134,7 @@
   (log/info "Processing email survey invitation for" (:kyselytyyppi palaute)
             "palaute" (:id palaute))
   (handling/call-with-context-and-error-handling
-    :lahetys palaute-check-send-save-and-sync! palaute))
+    :lahetys palaute-check-send-and-save! palaute))
 
 (defn handle-unsent-palaute!
   "Tekee kaiken mitä pitää tehdä palautteelle josta ei ole vielä lähetetty

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -88,7 +88,7 @@
   "Record in DB the palauteviesti that was (not) sent."
   [{:keys [existing-palaute hoks tx]} msg-state msg-id]
   (insert! tx {:palaute-id (:id existing-palaute)
-               :vastaanottaja (:sahkoposti hoks)
+               :vastaanottaja (str (:sahkoposti hoks))
                :viestityyppi "email"
                :tila (utils/to-underscore-str msg-state)
                :ulkoinen-tunniste msg-id}))

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [clojure.string :as str]
             [hugsql.core :as hugsql]
-            [medley.core :refer [greatest]]
+            [medley.core :refer [greatest find-first]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.external.viestinvalityspalvelu :as vvp]
@@ -21,6 +21,7 @@
 
 (declare insert!)
 (declare get-by-tila-and-viestityypit!)
+(declare get-by-palaute-and-viestityypit!)
 (declare update-tila!)
 (hugsql/def-db-fns "oph/ehoks/db/sql/palauteviesti.sql")
 
@@ -157,6 +158,18 @@
                 db/spec {:kyselytyypit kyselytyypit
                          :viestityyppi "email"}))))
 
+(defn enrich-with-viestit!
+  "Add the :palaute-email and :palaute-sms fields to ctx to allow syncing
+  correct lahetyspvm, lahetystila, sms-lahetystila and viestintapalvelu-id
+  for amis-heräte."
+  [{:keys [existing-palaute tx] :as ctx}]
+  (let [viestit (get-by-palaute-and-viestityypit!
+                  tx {:palaute-id (:id existing-palaute)
+                      :viestityypit ["email" "sms"]})
+        email (find-first #(= "email" (:viestityyppi %)) viestit)
+        sms (find-first #(= "sms" (:viestityyppi %)) viestit)]
+    (assoc ctx :palaute-email email :palaute-sms sms)))
+
 (defn sync-to-heratepalvelu!
   "Enrich context with enough information to sync palaute into
   herätepalvelu and then do the sync.  Currently only works for
@@ -165,6 +178,7 @@
   (-> existing-palaute
       (handling/build-ctx!)
       (merge ctx)  ; because original context has e.g. tx and existing-viesti
+      (enrich-with-viestit!)
       (opiskelija/build-amisherate-record-for-heratepalvelu)
       (ddb/sync-amis-herate! :after-viestinvalityspalvelu-status)))
 

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -93,6 +93,30 @@
                :tila (utils/to-underscore-str msg-state)
                :ulkoinen-tunniste msg-id}))
 
+(defn enrich-with-viestit!
+  "Add the :palaute-email and :palaute-sms fields to ctx to allow syncing
+  correct lahetyspvm, lahetystila, sms-lahetystila and viestintapalvelu-id
+  for amis-heräte."
+  [{:keys [existing-palaute tx] :as ctx}]
+  (let [viestit (get-by-palaute-and-viestityypit!
+                  tx {:palaute-id (:id existing-palaute)
+                      :viestityypit ["email" "sms"]})
+        email (find-first #(= "email" (:viestityyppi %)) viestit)
+        sms (find-first #(= "sms" (:viestityyppi %)) viestit)]
+    (assoc ctx :palaute-email email :palaute-sms sms)))
+
+(defn sync-to-heratepalvelu!
+  "Enrich context with enough information to sync palaute into
+  herätepalvelu and then do the sync.  Currently only works for
+  AMIS-kysely kyselytyypit."
+  [{:keys [existing-palaute] :as ctx}]
+  (-> existing-palaute
+      (handling/build-ctx!)
+      (merge ctx)  ; because original context has e.g. tx and existing-viesti
+      (enrich-with-viestit!)
+      (opiskelija/build-amisherate-record-for-heratepalvelu)
+      (ddb/sync-amis-herate! :after-viestinvalityspalvelu-status)))
+
 (defn palaute-check-send-and-save!
   "Tekee kaikki palautekutsun lähetyksen vaiheet"
   [{:keys [existing-palaute hoks] :as ctx} _] ; no handlers used yet
@@ -113,6 +137,9 @@
         (let [msg-id (when (= msg-state :odottaa-lahetysta)
                        (send-palaute-initial-email! ctx))]
           (record-palauteviesti! ctx msg-state msg-id)
+          ;; temporary hack to sync failed messages to Heratepalvelu
+          (when (= msg-state :lahetys-epaonnistunut)
+            (sync-to-heratepalvelu! ctx))
           msg-id)
         (catch ExceptionInfo e
           ;; Most typical reason is that sending failed for some reason
@@ -122,10 +149,11 @@
           ;; persist even if we retry.
           (if (= 400 (:status (ex-data e)))
             (do (record-palauteviesti! ctx :lahetys-epaonnistunut nil)
-                (pt/build-and-insert!
-                  ctx ::viestin-lahetys-epaonnistui
-                  {:errormsg (ex-message e)
-                   :body     (:body (ex-data e))})
+                (pt/build-and-insert! ctx ::viestin-lahetys-epaonnistui
+                                      {:errormsg (ex-message e)
+                                       :body     (:body (ex-data e))})
+                ;; temporary hack to sync failed messages to Heratepalvelu
+                (sync-to-heratepalvelu! ctx)
                 nil)  ; no msg-id created
             (throw (ex-info "Viestin lähetyksessä tapahtui virhe"
                             {:type ::viestin-lahetys-epaonnistui :ctx ctx}
@@ -157,30 +185,6 @@
               (palaute/get-unsent-palautteet!
                 db/spec {:kyselytyypit kyselytyypit
                          :viestityyppi "email"}))))
-
-(defn enrich-with-viestit!
-  "Add the :palaute-email and :palaute-sms fields to ctx to allow syncing
-  correct lahetyspvm, lahetystila, sms-lahetystila and viestintapalvelu-id
-  for amis-heräte."
-  [{:keys [existing-palaute tx] :as ctx}]
-  (let [viestit (get-by-palaute-and-viestityypit!
-                  tx {:palaute-id (:id existing-palaute)
-                      :viestityypit ["email" "sms"]})
-        email (find-first #(= "email" (:viestityyppi %)) viestit)
-        sms (find-first #(= "sms" (:viestityyppi %)) viestit)]
-    (assoc ctx :palaute-email email :palaute-sms sms)))
-
-(defn sync-to-heratepalvelu!
-  "Enrich context with enough information to sync palaute into
-  herätepalvelu and then do the sync.  Currently only works for
-  AMIS-kysely kyselytyypit."
-  [{:keys [existing-palaute] :as ctx}]
-  (-> existing-palaute
-      (handling/build-ctx!)
-      (merge ctx)  ; because original context has e.g. tx and existing-viesti
-      (enrich-with-viestit!)
-      (opiskelija/build-amisherate-record-for-heratepalvelu)
-      (ddb/sync-amis-herate! :after-viestinvalityspalvelu-status)))
 
 (defn record-sending-to-db-hp-and-arvo!
   "Päivittää Arvoon ja tietokantaan palautteen tilan sekä vastaamisajan

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -289,13 +289,13 @@
        :heratepvm heratepvm
        :alkupvm alkupvm
        :voimassa-loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
-       :toimipiste_oid toimipiste
+       :toimipiste-oid toimipiste
        :lahetystila ; FIXME when it can have other states
        (if (not-empty (:sahkoposti hoks))
          "ei_lahetetty"
          "ei_laheteta")
        :puhelinnumero (:puhelinnumero hoks)
-       :hankintakoulutuksen_toteuttaja @hk-toteuttaja
+       :hankintakoulutuksen-toteuttaja @hk-toteuttaja
        :ehoks-id (:id hoks)
        :herate-source (or (translate-source (:herate-source existing-palaute))
                           "sqs_viesti_ehoksista")
@@ -315,6 +315,7 @@
                                  (not-empty (:puhelinnumero hoks)))
                           "ei_lahetetty"
                           "ei_laheteta")
+       :suorituskieli (suoritus/kieli suoritus)
        :tallennuspvm (date/now)
        :toimija_oppija (str koulutustoimija "/" oppija-oid)
        :tyyppi_kausi (str kyselytyyppi "/" rahoituskausi)

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -275,10 +275,29 @@
      :heratepvm (:heratepvm existing-palaute)
      :request_id request-id}))
 
+(defn combine-tila
+  "Calculate lahetystila (if :email) or sms-lahetystila (if :sms) based
+  on palaute and palaute-viesti states"
+  [msg-type kyselytyyppi palaute-tila viesti-tila no-contact-info?]
+  (cond
+    (contains? #{"vastausaika_loppunut" "vastattu" "ei_laheteta"} palaute-tila)
+    palaute-tila
+
+    (contains? #{"lahetetty" "lahetys_epaonnistunut"} viesti-tila)
+    viesti-tila
+
+    (and (= msg-type :sms) (= "aloittaneet" kyselytyyppi))
+    "ei_laheteta"
+
+    no-contact-info? "ei_laheteta"
+
+    :else "ei_lahetetty"))
+
 (defn build-amisherate-record-for-heratepalvelu
   "Turns the information context into AMISherate in heratepalvelu format."
   [{:keys [existing-palaute hoks koulutustoimija suoritus opiskeluoikeus
-           toimipiste hk-toteuttaja arvo-response request-id]}]
+           toimipiste palaute-email palaute-sms
+           hk-toteuttaja arvo-response request-id]}]
   (let [heratepvm (:heratepvm existing-palaute)
         oppija-oid (:oppija-oid hoks)
         rahoituskausi (palaute/rahoituskausi heratepvm)
@@ -290,10 +309,12 @@
        :alkupvm alkupvm
        :voimassa-loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
        :toimipiste-oid toimipiste
-       :lahetystila ; FIXME when it can have other states
-       (if (not-empty (:sahkoposti hoks))
-         "ei_lahetetty"
-         "ei_laheteta")
+       :lahetystila (combine-tila :email (:kyselytyyppi existing-palaute)
+                                  (:tila existing-palaute)
+                                  (:tila palaute-email)
+                                  (empty? (:sahkoposti hoks)))
+       :lahetyspvm (some-> palaute-email :updated-at date/timestamp->localdate str)
+       :viestintapalvelu-id (:ulkoinen-tunniste palaute-email)
        :puhelinnumero (:puhelinnumero hoks)
        :hankintakoulutuksen-toteuttaja @hk-toteuttaja
        :ehoks-id (:id hoks)
@@ -309,12 +330,10 @@
        :oppilaitos (:oid (:oppilaitos opiskeluoikeus))
        :osaamisala (str/join "," (suoritus/get-osaamisalat suoritus heratepvm))
        :rahoituskausi rahoituskausi
-       :sms-lahetystila (if (and (or (= kyselytyyppi "tutkinnon_suorittaneet")
-                                     (= kyselytyyppi
-                                        "tutkinnon_osia_suorittaneet"))
-                                 (not-empty (:puhelinnumero hoks)))
-                          "ei_lahetetty"
-                          "ei_laheteta")
+       :sms-lahetystila (combine-tila :sms (:kyselytyyppi existing-palaute)
+                                      (:tila existing-palaute)
+                                      (:tila palaute-sms)
+                                      (empty? (:puhelinnumero hoks)))
        :suorituskieli (suoritus/kieli suoritus)
        :tallennuspvm (date/now)
        :toimija_oppija (str koulutustoimija "/" oppija-oid)

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -313,7 +313,8 @@
                                   (:tila existing-palaute)
                                   (:tila palaute-email)
                                   (empty? (:sahkoposti hoks)))
-       :lahetyspvm (some-> palaute-email :updated-at date/timestamp->localdate str)
+       :lahetyspvm (some-> palaute-email :updated-at
+                           date/timestamp->localdate str)
        :viestintapalvelu-id (:ulkoinen-tunniste palaute-email)
        :puhelinnumero (:puhelinnumero hoks)
        :hankintakoulutuksen-toteuttaja @hk-toteuttaja

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -317,6 +317,9 @@
                      (some-> palaute-email :updated-at
                              date/timestamp->localdate str))
        :viestintapalvelu-id (:ulkoinen-tunniste palaute-email)
+       ;; this needs to be fixed if we ever sync herätteet after
+       ;; sending reminders
+       :muistutukset 0
        :puhelinnumero (:puhelinnumero hoks)
        :hankintakoulutuksen-toteuttaja @hk-toteuttaja
        :ehoks-id (:id hoks)

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -313,9 +313,8 @@
                                   (:tila existing-palaute)
                                   (:tila palaute-email)
                                   (empty? (:sahkoposti hoks)))
-       :lahetyspvm (when (= "lahetetty" (:tila palaute-email))
-                     (some-> palaute-email :updated-at
-                             date/timestamp->localdate str))
+       :lahetyspvm (some-> palaute-email :updated-at
+                           date/timestamp->localdate str)
        :viestintapalvelu-id (:ulkoinen-tunniste palaute-email)
        ;; this needs to be fixed if we ever sync herätteet after
        ;; sending reminders

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -313,8 +313,9 @@
                                   (:tila existing-palaute)
                                   (:tila palaute-email)
                                   (empty? (:sahkoposti hoks)))
-       :lahetyspvm (some-> palaute-email :updated-at
-                           date/timestamp->localdate str)
+       :lahetyspvm (when (= "lahetetty" (:tila palaute-email))
+                     (some-> palaute-email :updated-at
+                             date/timestamp->localdate str))
        :viestintapalvelu-id (:ulkoinen-tunniste palaute-email)
        :puhelinnumero (:puhelinnumero hoks)
        :hankintakoulutuksen-toteuttaja @hk-toteuttaja

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -1,7 +1,8 @@
 (ns oph.ehoks.utils.date
   "Date related utility functions. Some of the functions are simple wrappers of
   `java.time/LocalDate` that can be mocked in the tests."
-  (:import [java.time
+  (:import [java.sql Timestamp]
+           [java.time
             LocalDate
             ZonedDateTime
             Instant
@@ -13,11 +14,18 @@
 (defn now ^LocalDate [] (LocalDate/now))
 (defn now-with-time ^Instant [] (Instant/now))
 
+(def ehoks-zone (ZoneId/of "Europe/Helsinki"))
+
+(defn timestamp->localdate
+  "Converts a java.sql.Timestamp to java.time.LocalDate"
+  [^Timestamp ts]
+  (some-> ts (.toInstant) (.atZone ehoks-zone) (.toLocalDate)))
+
 (defn time->instant
   "Converts a specific time of day into an instant on today"
   [hour minute sec]
   (-> (LocalTime/of hour minute sec)
-      (.adjustInto (ZonedDateTime/now (ZoneId/of "Europe/Helsinki")))
+      (.adjustInto (ZonedDateTime/now ehoks-zone))
       (Instant/from)))
 
 (defn finnish-business-hours?

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -356,7 +356,15 @@
               (is (= [["lahetetty" "aloittaneet"]]
                      (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                           (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
-                          (map (juxt :tila :kyselytyyppi)))))))))
+                          (map (juxt :tila :kyselytyyppi)))))
+              (let [ddb-item (ddb/get-item! :amis
+                               {:toimija_oppija
+                                "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                                :tyyppi_kausi "aloittaneet/2022-2023"})]
+                (is (some? ddb-item))
+                (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
+                (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
+                (is (= "ei_lahetetty" (:lahetystila ddb-item))))))))
 
       (testing "update-delivery-status! with VIRHE status"
         (with-mock-responses
@@ -418,7 +426,11 @@
             (is (= [["lahetys_epaonnistunut" "test-message-id-2"]]
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :viesti-tila :ulkoinen-tunniste)))))))))))
+                        (map (juxt :viesti-tila :ulkoinen-tunniste)))))
+            (is (nil? (ddb/get-item! :amis
+                        {:toimija_oppija
+                         "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                         :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})))))))))
 
 (deftest test-handle-palautteet-waiting-for-sending-status!
   (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
@@ -495,7 +507,15 @@
                         (count))))
           (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
                         (l/get-by-tila-and-viestityypit! db/spec)
-                        (count)))))))))
+                        (count))))
+          (let [ddb-item (ddb/get-item! :amis
+                           {:toimija_oppija
+                            "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                            :tyyppi_kausi "aloittaneet/2022-2023"})]
+            (is (some? ddb-item))
+            (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
+            (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
+            (is (= "ei_lahetetty" (:lahetystila ddb-item)))))))))
 
 (deftest test-vastausaika-updated-on-confirmed-delivery!
   (testing (str "voimassa_alkupvm and voimassa_loppupvm are updated to reflect "

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -368,6 +368,7 @@
                 (is (= "https://arvovastaus.csc.fi/v/test"
                        (:kyselylinkki ddb-item)))
                 (is (= "lahetetty" (:lahetystila ddb-item)))
+                (is (= 0 (:muistutukset ddb-item)))
                 (is (= "ei_laheteta" (:sms-lahetystila ddb-item))))))))
 
       (testing "update-delivery-status! with VIRHE status"

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as s]
             [oph.ehoks.db :as db]
+            [oph.ehoks.db.db-operations.db-helpers :as db-ops]
             [oph.ehoks.db.dynamodb :as ddb]
             [oph.ehoks.hoks.handler :as hoks-handler]
             [oph.ehoks.hoks-test :as hoks-test]
@@ -163,32 +164,6 @@
                  (map (juxt :tila :kyselytyyppi :arvo-tunniste :kyselylinkki)
                       heratteet)))
 
-          (testing "with unsuccessful sending"
-            (with-mock-responses
-              [(fn [url _]
-                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
-                   {:status 200
-                    :body {:tunnus "test"
-                           :voimassa_loppupvm "2026-04-14"
-                           :vastattu false}}))
-               (fn [^String url _]
-                 (when (s/ends-with? url "/lahetys/v1/viestit")
-                   (throw (ex-info
-                            "clj-http: status 400"
-                            {:status 400
-                             :body (str "{\"validointiVirheet\":["
-                                        "\"jokin on pakollinen\"]}")}))))]
-              (l/handle-unsent-palaute! (first heratteet)))
-            (is (= [["kysely_muodostettu" "aloittaneet"
-                     "https://arvovastaus.csc.fi/v/test"]]
-                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
-                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
-                        (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
-            (is (= [["lahetys_epaonnistunut" nil]]
-                   (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
-                        (l/get-by-tila-and-viestityypit! db/spec)
-                        (map (juxt :viesti-tila :ulkoinen-tunniste))))))
-
           (testing "with successful arvo-status and sending"
             (with-mock-responses
               [(fn [url _]
@@ -223,6 +198,10 @@
                         (l/get-by-tila-and-viestityypit! db/spec)
                         (map (juxt :viesti-tila :ulkoinen-tunniste))))))
 
+          (db-ops/query
+            ["DELETE FROM palaute_viestit WHERE palaute_id=? RETURNING id"
+             (:id (first heratteet))])
+
           (testing "with expired kyselylinkki"
             (with-mock-responses
               [(fn [url _]
@@ -254,6 +233,46 @@
                    (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                         (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                         (map (juxt :tila :kyselytyyppi :kyselylinkki))))))
+
+          (testing "with unsuccessful sending"
+            (with-mock-responses
+              [(fn [url _]
+                 (when (s/ends-with? url "/vastauslinkki/v1/status/testivain")
+                   {:status 200
+                    :body {:tunnus "test"
+                           :voimassa_loppupvm "2026-04-14"
+                           :vastattu false}}))
+               (fn [^String url _]
+                 (when (s/ends-with? url "/lahetys/v1/viestit")
+                   (throw (ex-info
+                            "clj-http: status 400"
+                            {:status 400
+                             :body (str "{\"validointiVirheet\":["
+                                        "\"jokin on pakollinen\"]}")}))))]
+              (l/handle-unsent-palaute! (first heratteet)))
+            (is (= [["kysely_muodostettu" "aloittaneet"
+                     "https://arvovastaus.csc.fi/v/test"]]
+                   (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                        (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
+                        (map (juxt :tila :kyselytyyppi :kyselylinkki)))))
+            (is (= [["lahetys_epaonnistunut" nil]]
+                   (->> {:viestityypit ["email"]
+                         :palaute-id (:id (first heratteet))}
+                        (l/get-by-palaute-and-viestityypit! db/spec)
+                        (map (juxt :tila :ulkoinen-tunniste)))))
+            (let [ddb-item
+                  (ddb/get-item!
+                    :amis
+                    {:toimija_oppija
+                     "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                     :tyyppi_kausi "aloittaneet/2022-2023"})]
+              (is (= "testi.testaaja@testidomain.testi"
+                     (:sahkoposti ddb-item)))
+              (is (= "https://arvovastaus.csc.fi/v/test"
+                     (:kyselylinkki ddb-item)))
+              (is (= 0 (:muistutukset ddb-item)))
+              (is (= "lahetys_epaonnistunut" (:lahetystila ddb-item)))
+              (is (= "ei_laheteta" (:sms-lahetystila ddb-item)))))
 
           (testing "with a record already in Herätepalvelu"
             (ddb/sync-amis-herate!

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -438,7 +438,7 @@
                     {:toimija_oppija
                      "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
                      :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})]
-              (is (nil? (:lahetyspvm herate)))
+              (is (= "2026-04-29" (:lahetyspvm herate)))
               (is (= "lahetys_epaonnistunut" (:lahetystila herate)))
               (is (= "ei_lahetetty" (:sms-lahetystila herate)))
               (is (= "test-message-id-2" (:viestintapalvelu-id herate)))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -357,12 +357,16 @@
                      (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
                           (palaute/get-by-hoks-id-and-kyselytyypit! db/spec)
                           (map (juxt :tila :kyselytyyppi)))))
-              (let [ddb-item (ddb/get-item! :amis
-                               {:toimija_oppija
-                                "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
-                                :tyyppi_kausi "aloittaneet/2022-2023"})]
-                (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
-                (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
+              (let [ddb-item
+                    (ddb/get-item!
+                      :amis
+                      {:toimija_oppija
+                       "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                       :tyyppi_kausi "aloittaneet/2022-2023"})]
+                (is (= "testi.testaaja@testidomain.testi"
+                       (:sahkoposti ddb-item)))
+                (is (= "https://arvovastaus.csc.fi/v/test"
+                       (:kyselylinkki ddb-item)))
                 (is (= "lahetetty" (:lahetystila ddb-item)))
                 (is (= "ei_laheteta" (:sms-lahetystila ddb-item))))))))
 
@@ -427,10 +431,12 @@
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
                         (map (juxt :viesti-tila :ulkoinen-tunniste)))))
-            (is (nil? (ddb/get-item! :amis
-                        {:toimija_oppija
-                         "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
-                         :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})))))))))
+            (is (nil?
+                  (ddb/get-item!
+                    :amis
+                    {:toimija_oppija
+                     "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                     :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})))))))))
 
 (deftest test-handle-palautteet-waiting-for-sending-status!
   (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))
@@ -508,13 +514,16 @@
           (is (= 1 (->> {:viestityypit ["email"] :tila "lahetetty"}
                         (l/get-by-tila-and-viestityypit! db/spec)
                         (count))))
-          (let [ddb-item (ddb/get-item! :amis
-                           {:toimija_oppija
-                            "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
-                            :tyyppi_kausi "aloittaneet/2022-2023"})]
+          (let [ddb-item
+                (ddb/get-item!
+                  :amis
+                  {:toimija_oppija
+                   "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
+                   :tyyppi_kausi "aloittaneet/2022-2023"})]
             (is (some? ddb-item))
             (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
-            (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
+            (is (= "https://arvovastaus.csc.fi/v/test"
+                   (:kyselylinkki ddb-item)))
             (is (= "lahetetty" (:lahetystila ddb-item)))))))))
 
 (deftest test-vastausaika-updated-on-confirmed-delivery!

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -431,12 +431,17 @@
                    (->> {:viestityypit ["email"] :tila "lahetys_epaonnistunut"}
                         (l/get-by-tila-and-viestityypit! db/spec)
                         (map (juxt :viesti-tila :ulkoinen-tunniste)))))
-            (is (nil?
+            (let [herate
                   (ddb/get-item!
                     :amis
                     {:toimija_oppija
                      "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
-                     :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})))))))))
+                     :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})]
+              (is (nil? (:lahetyspvm herate)))
+              (is (= "lahetys_epaonnistunut" (:lahetystila herate)))
+              (is (= "ei_lahetetty" (:sms-lahetystila herate)))
+              (is (= "test-message-id-2" (:viestintapalvelu-id herate)))
+              (is (= "2023-05-17" (:voimassa-loppupvm herate))))))))))
 
 (deftest test-handle-palautteet-waiting-for-sending-status!
   (with-redefs [date/now (constantly (LocalDate/of 2023 4 18))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -457,7 +457,7 @@
                     {:toimija_oppija
                      "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
                      :tyyppi_kausi "tutkinnon_suorittaneet/2022-2023"})]
-              (is (= "2026-04-29" (:lahetyspvm herate)))
+              (is (instance? java.lang.String (:lahetyspvm herate)))
               (is (= "lahetys_epaonnistunut" (:lahetystila herate)))
               (is (= "ei_lahetetty" (:sms-lahetystila herate)))
               (is (= "test-message-id-2" (:viestintapalvelu-id herate)))

--- a/test/oph/ehoks/palaute/lahetys_test.clj
+++ b/test/oph/ehoks/palaute/lahetys_test.clj
@@ -361,10 +361,10 @@
                                {:toimija_oppija
                                 "1.2.246.562.10.10000000009/1.2.246.562.24.12312312319"
                                 :tyyppi_kausi "aloittaneet/2022-2023"})]
-                (is (some? ddb-item))
                 (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
                 (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
-                (is (= "ei_lahetetty" (:lahetystila ddb-item))))))))
+                (is (= "lahetetty" (:lahetystila ddb-item)))
+                (is (= "ei_laheteta" (:sms-lahetystila ddb-item))))))))
 
       (testing "update-delivery-status! with VIRHE status"
         (with-mock-responses
@@ -515,7 +515,7 @@
             (is (some? ddb-item))
             (is (= "testi.testaaja@testidomain.testi" (:sahkoposti ddb-item)))
             (is (= "https://arvovastaus.csc.fi/v/test" (:kyselylinkki ddb-item)))
-            (is (= "ei_lahetetty" (:lahetystila ddb-item)))))))))
+            (is (= "lahetetty" (:lahetystila ddb-item)))))))))
 
 (deftest test-vastausaika-updated-on-confirmed-delivery!
   (testing (str "voimassa_alkupvm and voimassa_loppupvm are updated to reflect "

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -98,26 +98,38 @@
             :paikallinen_tutkinnon_osa_nimi "Paikallinen osa"}))))
 
 (deftest test-combine-tila
-  (are [msg-type kyselytyyppi palaute-tila viesti-tila no-contact-info? expected]
-       (= (op/combine-tila msg-type kyselytyyppi palaute-tila viesti-tila
-                           no-contact-info?)
+  (are [msg-type kyselytyyppi palaute-tila viesti-tila no-contact-info?
+        expected]
+       (= (op/combine-tila
+            msg-type kyselytyyppi palaute-tila viesti-tila no-contact-info?)
           expected)
     ; terminal palaute-tila takes priority over everything
-    :email "aloittaneet" "vastausaika_loppunut" "lahetetty"             false "vastausaika_loppunut"
-    :email "aloittaneet" "vastattu"             "lahetetty"             false "vastattu"
-    :email "aloittaneet" "ei_laheteta"          "lahetetty"             false "ei_laheteta"
+    :email "aloittaneet" "vastausaika_loppunut" "lahetetty"             false
+    "vastausaika_loppunut"
+    :email "aloittaneet" "vastattu"             "lahetetty"             false
+    "vastattu"
+    :email "aloittaneet" "ei_laheteta"          "lahetetty"             false
+    "ei_laheteta"
     ; viesti-tila used when palaute is not yet terminal
-    :email "aloittaneet" "odottaa_kasittelya"   "lahetetty"             false "lahetetty"
-    :email "aloittaneet" "odottaa_kasittelya"   "lahetys_epaonnistunut" false "lahetys_epaonnistunut"
+    :email "aloittaneet" "odottaa_kasittelya"   "lahetetty"             false
+    "lahetetty"
+    :email "aloittaneet" "odottaa_kasittelya"   "lahetys_epaonnistunut" false
+    "lahetys_epaonnistunut"
     ; sms for aloittaneet is always ei_laheteta regardless of contact info
-    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     false "ei_laheteta"
-    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     true  "ei_laheteta"
+    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     false
+    "ei_laheteta"
+    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     true
+    "ei_laheteta"
     ; no contact info → ei_laheteta
-    :email "aloittaneet" "odottaa_kasittelya"   nil                     true  "ei_laheteta"
-    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     true  "ei_laheteta"
+    :email "aloittaneet" "odottaa_kasittelya"   nil                     true
+    "ei_laheteta"
+    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     true
+    "ei_laheteta"
     ; has contact info, nothing sent yet → ei_lahetetty
-    :email "aloittaneet" "odottaa_kasittelya"   nil                     false "ei_lahetetty"
-    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     false "ei_lahetetty"))
+    :email "aloittaneet" "odottaa_kasittelya"   nil                     false
+    "ei_lahetetty"
+    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     false
+    "ei_lahetetty"))
 
 (defn test-not-initiated
   ([ctx reason]

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -97,6 +97,28 @@
             :paikallinen_tutkinnon_osa      true
             :paikallinen_tutkinnon_osa_nimi "Paikallinen osa"}))))
 
+(deftest test-combine-tila
+  (are [msg-type kyselytyyppi palaute-tila viesti-tila no-contact-info? expected]
+       (= (op/combine-tila msg-type kyselytyyppi palaute-tila viesti-tila
+                           no-contact-info?)
+          expected)
+    ; terminal palaute-tila takes priority over everything
+    :email "aloittaneet" "vastausaika_loppunut" "lahetetty"             false "vastausaika_loppunut"
+    :email "aloittaneet" "vastattu"             "lahetetty"             false "vastattu"
+    :email "aloittaneet" "ei_laheteta"          "lahetetty"             false "ei_laheteta"
+    ; viesti-tila used when palaute is not yet terminal
+    :email "aloittaneet" "odottaa_kasittelya"   "lahetetty"             false "lahetetty"
+    :email "aloittaneet" "odottaa_kasittelya"   "lahetys_epaonnistunut" false "lahetys_epaonnistunut"
+    ; sms for aloittaneet is always ei_laheteta regardless of contact info
+    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     false "ei_laheteta"
+    :sms   "aloittaneet" "odottaa_kasittelya"   nil                     true  "ei_laheteta"
+    ; no contact info → ei_laheteta
+    :email "aloittaneet" "odottaa_kasittelya"   nil                     true  "ei_laheteta"
+    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     true  "ei_laheteta"
+    ; has contact info, nothing sent yet → ei_lahetetty
+    :email "aloittaneet" "odottaa_kasittelya"   nil                     false "ei_lahetetty"
+    :sms   "valmistuneet" "odottaa_kasittelya"  nil                     false "ei_lahetetty"))
+
 (defn test-not-initiated
   ([ctx reason]
     (test-not-initiated nil ctx reason))


### PR DESCRIPTION
## Kuvaus muutoksista

Nyt herätteet pitää synkronoida herätepalveluun muistutusviestejä varten sen jälkeen, kun palaute-backend on lähettänyt viestit.  Tässä vaiheessa myös SMS-lähetys jää vielä herätepalvelun vastuulle.

[EH-2031](https://jira.eduuni.fi/browse/EH-2031)

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
