### PR TITLE
EH-2071: calculate vastaamisaika for jaksotunnus as specified

### DIFF
--- a/src/oph/ehoks/external/arvo.clj
+++ b/src/oph/ehoks/external/arvo.clj
@@ -2,9 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [oph.ehoks.config :refer [config]]
             [oph.ehoks.external.connection :as c]
-            [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
-            [oph.ehoks.utils :as utils]
-            [oph.ehoks.utils.string :as u-str])
+            [oph.ehoks.utils :as utils])
   (:import (clojure.lang ExceptionInfo)))
 
 (defn call!
@@ -58,36 +56,6 @@
   "Poistaa kyselytunnuksen Arvosta."
   [tunnus]
   (call! :delete (str "/vastauslinkki/v1/" tunnus) {}))
-
-(defn build-jaksotunnus-request-body
-  "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
-  [{:keys [opiskeluoikeus existing-palaute jakso request-id
-           suoritus koulutustoimija toimipiste niputuspvm]}]
-  (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
-        t-nimi (:tyopaikan-nimi tjk)]
-    {:koulutustoimija_oid       koulutustoimija
-     :tyonantaja                (:tyopaikan-y-tunnus tjk)
-     :tyopaikka                 t-nimi
-     :tyopaikka_normalisoitu    (u-str/normalize t-nimi)
-     :tutkintotunnus            (suoritus/tutkintotunnus suoritus)
-     :tutkinnon_osa             (utils/koodi-uri->koodi
-                                  (:tutkinnon-osa-koodi-uri jakso))
-     :paikallinen_tutkinnon_osa (:nimi jakso)
-     :tutkintonimike            (map :koodiarvo (:tutkintonimike suoritus))
-     :osaamisala                (suoritus/get-osaamisalat
-                                  suoritus (:heratepvm existing-palaute))
-     :tyopaikkajakson_alkupvm   (str (:alku jakso))
-     :tyopaikkajakson_loppupvm  (str (:loppu jakso))
-     :rahoituskausi_pvm         (str (:loppu jakso))
-     :osa_aikaisuus             (:osa-aikaisuustieto jakso)
-     :sopimustyyppi             (utils/koodi-uri->koodi
-                                  (:osaamisen-hankkimistapa-koodi-uri jakso))
-     :oppisopimuksen_perusta    (utils/koodi-uri->koodi
-                                  (:oppisopimuksen-perusta-koodi-uri jakso))
-     :vastaamisajan_alkupvm     (str niputuspvm)
-     :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
-     :toimipiste_oid            toimipiste
-     :request_id                request-id}))
 
 (defn create-jaksotunnus!
   "Create new työelämäpalaute-vastaajatunnus in Arvo."

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -1,7 +1,7 @@
 (ns oph.ehoks.palaute.tyoelama
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
-            [medley.core :refer [map-vals]]
+            [medley.core :refer [map-vals greatest]]
             [oph.ehoks.db :as db]
             [oph.ehoks.db.db-operations.hoks :as db-hoks]
             [oph.ehoks.db.dynamodb :as dynamodb]
@@ -205,13 +205,46 @@
        :viimeinen_vastauspvm (palaute/vastaamisajan-loppupvm
                                heratepvm vastaamisajan-alkupvm)})))
 
+(defn build-jaksotunnus-request-body
+  "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
+  [{:keys [opiskeluoikeus existing-palaute jakso request-id
+           suoritus koulutustoimija toimipiste]}]
+  (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
+        t-nimi (:tyopaikan-nimi tjk)
+        heratepvm (:heratepvm existing-palaute)
+        alkupvm (greatest heratepvm (date/now))
+        loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)]
+    {:koulutustoimija_oid       koulutustoimija
+     :tyonantaja                (:tyopaikan-y-tunnus tjk)
+     :tyopaikka                 t-nimi
+     :tyopaikka_normalisoitu    (u-str/normalize t-nimi)
+     :tutkintotunnus            (suoritus/tutkintotunnus suoritus)
+     :tutkinnon_osa             (utils/koodi-uri->koodi
+                                  (:tutkinnon-osa-koodi-uri jakso))
+     :paikallinen_tutkinnon_osa (:nimi jakso)
+     :tutkintonimike            (map :koodiarvo (:tutkintonimike suoritus))
+     :osaamisala                (suoritus/get-osaamisalat suoritus heratepvm)
+     :tyopaikkajakson_alkupvm   (str (:alku jakso))
+     :tyopaikkajakson_loppupvm  (str (:loppu jakso))
+     :rahoituskausi_pvm         (str (:loppu jakso))
+     :osa_aikaisuus             (:osa-aikaisuustieto jakso)
+     :sopimustyyppi             (utils/koodi-uri->koodi
+                                  (:osaamisen-hankkimistapa-koodi-uri jakso))
+     :oppisopimuksen_perusta    (utils/koodi-uri->koodi
+                                  (:oppisopimuksen-perusta-koodi-uri jakso))
+     :vastaamisajan_alkupvm     alkupvm
+     :vastaamisajan_loppupvm    loppupvm
+     :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
+     :toimipiste_oid            toimipiste
+     :request_id                request-id}))
+
 ;; these use vars (#') because otherwise with-redefs doesn't work on
 ;; them (the map has the original definition even if the function in
 ;; its namespace is redef'd)
 
 (def handlers
   {:check-palaute #'initial-palaute-state-and-reason
-   :arvo-builder #'arvo/build-jaksotunnus-request-body
+   :arvo-builder #'build-jaksotunnus-request-body
    :arvo-caller #'arvo/create-jaksotunnus!
    :heratepalvelu-builder #'build-jaksoherate-record-for-heratepalvelu
    :heratepalvelu-caller #'heratepalvelu/sync-jakso!

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -212,8 +212,10 @@
   (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
         t-nimi (:tyopaikan-nimi tjk)
         heratepvm (:heratepvm existing-palaute)
-        alkupvm (greatest heratepvm (date/now))
-        loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)]
+        today (date/now)
+        alkupvm (greatest heratepvm today)
+        loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
+        e-k-l-p (date/is-after today loppupvm)]
     {:koulutustoimija_oid       koulutustoimija
      :tyonantaja                (:tyopaikan-y-tunnus tjk)
      :tyopaikka                 t-nimi
@@ -234,6 +236,7 @@
                                   (:oppisopimuksen-perusta-koodi-uri jakso))
      :vastaamisajan_alkupvm     alkupvm
      :vastaamisajan_loppupvm    loppupvm
+     :metatiedot                {:ei_kuulu_lahetettavien_perusjoukkoon e-k-l-p}
      :oppilaitos_oid            (:oid (:oppilaitos opiskeluoikeus))
      :toimipiste_oid            toimipiste
      :request_id                request-id}))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -651,6 +651,7 @@
                        #(= (:jakson-yksiloiva-tunniste %) "1") palautteet)
         create-jaksotunnus-counter (atom 0)
         arvo-tunnukset (atom [])
+        arvo-requests (atom [])
         check-current-state-is-same-as-initial-state
         (fn []
           (is (= (hoks-utils/palautteet) initial-palautteet))
@@ -664,13 +665,15 @@
                   koski/get-opiskeluoikeus-info-raw
                   hoks-utils/mock-get-opiskeluoikeus!
                   arvo/create-jaksotunnus!
-                  (fn [_] (let [tunnus (str (UUID/randomUUID))]
-                            (swap! arvo-tunnukset #(conj % tunnus))
-                            (swap! create-jaksotunnus-counter inc)
-                            {:tunnus tunnus}))
+                  (fn [body]
+                    (let [tunnus (str (UUID/randomUUID))]
+                      (swap! arvo-tunnukset conj tunnus)
+                      (swap! arvo-requests conj body)
+                      (swap! create-jaksotunnus-counter inc)
+                      {:tunnus tunnus}))
                   arvo/delete-jaksotunnus
                   (fn [tunnus] (swap! arvo-tunnukset #(remove #{tunnus} %)))
-                  date/now #(LocalDate/of 2024 6 30)]
+                  date/now #(LocalDate/of 2024 2 20)]
       (testing (str "Everything (palaute-backend DB and DynamoDB tables) rolls "
                     "back to its initial state (before the function call) when")
         (testing "Arvo call for vastaajatunnus creation fails."
@@ -730,6 +733,12 @@
           (is (= 2 @create-jaksotunnus-counter))
           (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
+          (is (= [["2024-02-20" "2024-03-05"]
+                  ["2024-02-20" "2024-03-05"]
+                  ["2024-02-20" "2024-03-05"]]
+                 (map (juxt (comp str :vastaamisajan_alkupvm)
+                            (comp str :vastaamisajan_loppupvm))
+                      @arvo-requests)))
           (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
           (is (= "heratepalvelussa"

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -739,6 +739,11 @@
                  (map (juxt (comp str :vastaamisajan_alkupvm)
                             (comp str :vastaamisajan_loppupvm))
                       @arvo-requests)))
+          (is (= [["Testiosa" ["12345" "23456"] "123456"]
+                  ["Testiosa" ["12345" "23456"] "123456"]
+                  ["Testiosa" ["12345" "23456"] "123456"]]
+                 (map (juxt :paikallinen_tutkinnon_osa :tutkintonimike
+                            :tutkintotunnus) @arvo-requests)))
           (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
           (is (= "heratepalvelussa"

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -733,11 +733,13 @@
           (is (= 2 @create-jaksotunnus-counter))
           (vt/create-vastaajatunnus! tep-palaute)
           (is (= 3 @create-jaksotunnus-counter))
-          (is (= [["2024-02-20" "2024-03-05"]
-                  ["2024-02-20" "2024-03-05"]
-                  ["2024-02-20" "2024-03-05"]]
+          (is (= [["2024-02-20" "2024-03-05" false]
+                  ["2024-02-20" "2024-03-05" false]
+                  ["2024-02-20" "2024-03-05" false]]
                  (map (juxt (comp str :vastaamisajan_alkupvm)
-                            (comp str :vastaamisajan_loppupvm))
+                            (comp str :vastaamisajan_loppupvm)
+                            (comp :ei_kuulu_lahetettavien_perusjoukkoon
+                                  :metatiedot))
                       @arvo-requests)))
           (is (= [["Testiosa" ["12345" "23456"] "123456"]
                   ["Testiosa" ["12345" "23456"] "123456"]


### PR DESCRIPTION
## Kuvaus muutoksista

Jaksojen vastausaika ei oikeasti vaikuta siihen, milloin niihin voi vastata, koska ne niputetaan ja nipulla on yksi keskitetty vastausaika.  Lasketaan kuitenkin jaksoille asetuksen mukainen vastausaika.  Tätä voi käyttää sitten myöhemmin myös sen päättelemiseen, kuuluuko jakso vastattavaksi lähetettävien perusjoukkoon vai ei.  Tämä jälkemmäinen tieto aletaan välittää Arvolle vasta sitten, kun siihen on rajapinta.

Speksi: https://wiki.eduuni.fi/spaces/CscArvo/pages/709662045/Tekninen+m%C3%A4%C3%A4rittely+vastausosuuden+laskenta

Tiksu: https://jira.eduuni.fi/browse/EH-2071

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
