### PR TITLE
EH-2078: use artifactory proxy for maven central instead of direct connections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,14 @@ jobs:
         with:
           lein: 2.11.2
 
-      - name: Install Dependencies
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        id: leiningen-cache
+        with:
+          path: ~/.m2/repository
+          key: leiningen-${{ hashFiles('project.clj') }}
+
+      - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>96e33d80f1a99b8d0ece9a7070e58ae821559d0f</tag>
+    <tag>e76ce8cea290a854d9a711269235fd4e2f63f3f1</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -69,10 +69,10 @@
   </build>
   <repositories>
     <repository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
+      <id>maven-central-proxy</id>
+      <url>https://artifactory.opintopolku.fi/artifactory/repository/maven-central</url>
       <snapshots>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </snapshots>
       <releases>
         <enabled>true</enabled>
@@ -90,7 +90,7 @@
     </repository>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/Opetushallitus/packages</url>
+      <url>https://maven.pkg.github.com/orgs/Opetushallitus/packages</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/project.clj
+++ b/project.clj
@@ -127,7 +127,10 @@
   ;; taken away if maven-central-proxy goes away, or Maven Central does
   ;; not break builds anymore with 429 responses
   :repositories ^:replace
-  [["maven-central-proxy" "https://artifactory.opintopolku.fi/artifactory/repository/maven-central"]
+  [["maven-central-proxy"
+    {:url "https://artifactory.opintopolku.fi/artifactory/repository/maven-central"
+     :username :env/ARTIFACTORY_USERNAME
+     :password :env/ARTIFACTORY_PASSWORD}]
    ["clojars" "https://repo.clojars.org/"]
    ["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
               :username "private-token"

--- a/project.clj
+++ b/project.clj
@@ -123,12 +123,18 @@
             [lein-cloverage "1.2.4"]
             [lein-eftest "0.6.0"]
             [lein-environ "1.2.0"]]
-  :repositories [["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
-                            :username "private-token"
-                            :password :env/GITHUB_TOKEN}]
-                 ["oph-releases" "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"]
-                 ["oph-snapshots" "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local"]
-                 ["ext-snapshots" "https://artifactory.opintopolku.fi/artifactory/ext-snapshot-local"]]
+  ;; ^:replace to ensure that maven central is not used directly; can be
+  ;; taken away if maven-central-proxy goes away, or Maven Central does
+  ;; not break builds anymore with 429 responses
+  :repositories ^:replace
+  [["maven-central-proxy" "https://artifactory.opintopolku.fi/artifactory/repository/maven-central"]
+   ["clojars" "https://repo.clojars.org/"]
+   ["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
+              :username "private-token"
+              :password :env/GITHUB_TOKEN}]
+   ["oph-releases" "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"]
+   ["oph-snapshots" "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local"]
+   ["ext-snapshots" "https://artifactory.opintopolku.fi/artifactory/ext-snapshot-local"]]
   :main oph.ehoks.main
   :aot [oph.ehoks.main]
   :uberjar-name "ehoks-standalone.jar"

--- a/project.clj
+++ b/project.clj
@@ -123,7 +123,7 @@
             [lein-cloverage "1.2.4"]
             [lein-eftest "0.6.0"]
             [lein-environ "1.2.0"]]
-  :repositories [["github" {:url "https://maven.pkg.github.com/Opetushallitus/packages"
+  :repositories [["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
                             :username "private-token"
                             :password :env/GITHUB_TOKEN}]
                  ["oph-releases" "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"]


### PR DESCRIPTION
## Kuvaus muutoksista

Ei käytetä maven centralia suoraan, koska sieltä lataaminen epäonnistuu silloin tällöin `429 too many connections` -ilmoituksella.

https://jira.eduuni.fi/browse/EH-2078

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
