### PR TITLE
EH-2083: Only run oppijaindex rebuild in palaute-backend

### DIFF
--- a/resources/db/hoksit/select_opiskeluoikeus_oids_without_info.sql
+++ b/resources/db/hoksit/select_opiskeluoikeus_oids_without_info.sql
@@ -1,5 +1,6 @@
 SELECT h.oppija_oid, h.opiskeluoikeus_oid 
-  FROM hoksit AS h
-    LEFT JOIN opiskeluoikeudet AS o
-      ON h.opiskeluoikeus_oid = o.oid
-        WHERE o.oid IS NULL
+FROM hoksit AS h
+LEFT JOIN opiskeluoikeudet AS o
+	ON h.opiskeluoikeus_oid = o.oid
+WHERE o.oid IS NULL
+  AND h.created_at > now() - interval '1 year';

--- a/resources/dev/src/oph/ehoks/dev_server.clj
+++ b/resources/dev/src/oph/ehoks/dev_server.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.dev-server
   (:require [oph.ehoks.ehoks-app :as ehoks-app]
             [oph.ehoks.db.migrations :as m]
+            [oph.ehoks.main :as main]
             [oph.ehoks.config :refer [config] :as c]
             [oph.ehoks.mocked-routes.mock-routes :as mock]
             [oph.ehoks.oppijaindex :as oppijaindex]
@@ -14,8 +15,7 @@
             [clojure.string :as c-str]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
-            [oph.ehoks.dev-tools :as dev-tools])
-  (:import (java.time Instant Duration)))
+            [oph.ehoks.dev-tools :as dev-tools]))
 
 (defn uri-to-filename [uri]
   (-> uri
@@ -75,34 +75,6 @@
       (wrap-cookies (wrap-reload #'dev-tools/routes))
       (wrap-reload #'ehoks-app/app))))
 
-(defn populate-oppijaindex []
-  (future
-    (log/info "Updating oppijaindex")
-    (oppijaindex/update-oppijat-without-index!)
-    (oppijaindex/update-opiskeluoikeudet-without-index!)
-    (log/info "Updating oppijaindex finished")))
-
-(defn start-app-server! [app app-name config-file]
-  (when (some? config-file)
-    (System/setProperty "config" config-file)
-    (require 'oph.ehoks.config :reload)
-    (when (.endsWith (:opintopolku-host config) "opintopolku.fi")
-      (println "Using prod urls")
-      (System/setProperty
-        "services_file" "resources/prod/services-oph.properties"))
-    (require 'oph.ehoks.external.oph-url :reload))
-  (log/info "Running migrations")
-  (m/migrate!)
-  (log/infof "Starting %s development server..." app-name)
-  (log/info "Not safe for production or public environments.")
-  (when (= app-name "ehoks-palaute")
-    (populate-oppijaindex)
-    (scheduler/run-schedulers! (Instant/now) (Duration/ofSeconds 60)))
-  (jetty/run-jetty app
-                   {:port (:port config)
-                    :join? false
-                    :async? true}))
-
 (defn start [app-name config-file]
   (log/infof "Starting %s with config %s" app-name config-file)
   (let [app (wrap-dev-cors
@@ -110,7 +82,7 @@
                 (wrap-params (wrap-cookies mock/mock-routes))
                 dev-routes
                 (ehoks-app/create-app app-name)))]
-    (start-app-server! app app-name config-file)))
+    (main/start-app-server! app app-name config-file true)))
 
 (defn -main
   ([app-name config-file] (start app-name config-file))

--- a/resources/dev/src/oph/ehoks/dev_server.clj
+++ b/resources/dev/src/oph/ehoks/dev_server.clj
@@ -95,8 +95,8 @@
   (m/migrate!)
   (log/infof "Starting %s development server..." app-name)
   (log/info "Not safe for production or public environments.")
-  (populate-oppijaindex)
   (when (= app-name "ehoks-palaute")
+    (populate-oppijaindex)
     (scheduler/run-schedulers! (Instant/now) (Duration/ofSeconds 60)))
   (jetty/run-jetty app
                    {:port (:port config)

--- a/src/oph/ehoks/db/db_operations/hoks.clj
+++ b/src/oph/ehoks/db/db_operations/hoks.clj
@@ -480,7 +480,8 @@
     [queries/select-hoks-oppijat-without-index-count]))
 
 (defn select-hoks-opiskeluoikeudet-without-index
-  "Hakee tietokannasta opiskeluoikeus OID:t, joilla ei ole tietoja."
+  "Hakee vuotta uudemmista HOKSeista opiskeluoikeus-OID:t, joilla ei
+  ole tietoja."
   []
   (db-ops/query
     [queries/select-hoks-opiskeluoikeudet-without-index]))

--- a/src/oph/ehoks/main.clj
+++ b/src/oph/ehoks/main.clj
@@ -10,12 +10,43 @@
             [oph.ehoks.logging.audit :as audit]
             [oph.ehoks.oppijaindex :as oppijaindex]
             [oph.ehoks.palaute.scheduler :as scheduler]
-            [ring.adapter.jetty :as jetty]))
+            [ring.adapter.jetty :as jetty])
+  (:import (java.time Instant Duration)))
 
 (defn has-arg?
   "Is arg present"
   [args s]
   (some? (some #(when (= (lower-case %) s) %) args)))
+
+(defn populate-oppijaindex []
+  (future
+    (log/info "Updating oppijaindex")
+    (oppijaindex/update-oppijat-without-index!)
+    (oppijaindex/update-opiskeluoikeudet-without-index!)
+    (log/info "Updating oppijaindex finished")))
+
+(defn start-app-server! [app app-name config-file dev?]
+  (when (some? config-file)
+    (System/setProperty "config" config-file)
+    (require 'oph.ehoks.config :reload)
+    (when (.endsWith (:opintopolku-host config) "opintopolku.fi")
+      (log/info "Using prod urls")
+      (System/setProperty
+        "services_file"
+        "resources/prod/services-oph.properties"))
+    (require 'oph.ehoks.external.oph-url :reload))
+  (log/info "Running migrations")
+  (m/migrate!)
+  (log/info "Migrations done.")
+  (when audit/enabled?
+    (audit/start-heartbeat!))
+  (when (= app-name "ehoks-palaute")
+    (populate-oppijaindex)
+    (if dev?
+      (scheduler/run-schedulers! (Instant/now) (Duration/ofSeconds 60))
+      (scheduler/run-schedulers!)))
+  (log/infof "Starting %s listening to port %d" app-name (:port config))
+  (jetty/run-jetty app {:port (:port config) :join? (not dev?) :async? true}))
 
 (defn -main
   "Main entry point"
@@ -33,24 +64,7 @@
         0)
     :else
     (let [app-name (ehoks-app/get-app-name)
-          hoks-app
-          (common-api/create-app
-            (ehoks-app/create-app app-name)
-            (session-store/db-store))]
-      (log/infof "Starting %s listening to port %d" app-name (:port config))
-      (log/info "Running migrations")
-      (m/migrate!)
-      (log/info "Migrations done.")
-      (log/info "Starting oppijaindex update in another thread.")
-      (future
-        (log/info "Updating oppijaindex")
-        (oppijaindex/update-oppijat-without-index!)
-        (oppijaindex/update-opiskeluoikeudet-without-index!)
-        (log/info "Updating oppijaindex finished"))
-      (when audit/enabled?
-        (audit/start-heartbeat!))
-      (when (= app-name "ehoks-palaute")
-        (scheduler/run-schedulers!))
-      (jetty/run-jetty hoks-app {:port (:port config)
-                                 :join? true
-                                 :async? true}))))
+          hoks-app (common-api/create-app
+                     (ehoks-app/create-app app-name)
+                     (session-store/db-store))]
+      (start-app-server! hoks-app app-name nil false))))


### PR DESCRIPTION
## Kuvaus muutoksista

Ei oo mitään erityistä syytä edes, miksi oppijaindex päivitetään juuri käynnistyksessä.  Tämä on nopea muutos siihen, ettei sitä ajeta turhaan kaikkien palveluiden käynnistyksessä.  Ne kun usein tapahtuvat samaan aikaan.

https://jira.eduuni.fi/browse/EH-2083

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
