### PR TITLE
EH-2029: on heratepvm handling, update state of palautteet which would not be formed at all

### DIFF
--- a/src/oph/ehoks/db/sql/palautetapahtuma.sql
+++ b/src/oph/ehoks/db/sql/palautetapahtuma.sql
@@ -24,4 +24,5 @@ join palautteet p on (pt.palaute_id = p.id)
 where p.hoks_id = :hoks-id
   and p.kyselytyyppi in (:v*:kyselytyypit)
   and p.deleted_at is null
+order by created_at asc
 

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -144,6 +144,8 @@
 (defn update-tila!
   "Update palaute (given in :existing-palaute in ctx) to state tila."
   [{:keys [existing-palaute tx] :as ctx} tila reason lisatiedot]
+  (log/info "Updating palaute" (:id existing-palaute) "to state" tila
+            "because of" reason "and" lisatiedot)
   (if (not tx)
     (jdbc/with-db-transaction
       [tx db/spec]

--- a/src/oph/ehoks/palaute/vastaajatunnus.clj
+++ b/src/oph/ehoks/palaute/vastaajatunnus.clj
@@ -106,11 +106,19 @@
               "because of" reason "in" field)
     (if state
       (if (= :odottaa-kasittelya state)
+        ;; case 'everything is OK, proceed'
         (-> ctx
             (create-and-save-tunnus! handlers)
             (sync-to-heratepalvelu! handlers))
+        ;; case 'something is wrong, mark'
         (palaute/update-tila! ctx state reason lisatiedot))
-      (tapahtuma/build-and-insert! ctx reason lisatiedot))))
+      (if (palaute/unhandled? existing-palaute)
+        ;; case 'palaute shouldn't have been formed so prevent handling
+        ;; until next HOKS update'
+        (palaute/update-tila! ctx :ei-laheteta reason lisatiedot)
+        ;; case 'palaute shouldn't have been formed but we need to keep
+        ;; record of it'
+        (tapahtuma/build-and-insert! ctx reason lisatiedot)))))
 
 (defn create-vastaajatunnus!
   "Check that palaute is part of kohderyhmä and create and save

--- a/test/oph/ehoks/palaute/opiskelija_test.clj
+++ b/test/oph/ehoks/palaute/opiskelija_test.clj
@@ -711,7 +711,21 @@
                       db/spec)
                     (map (juxt :vanha-tila :uusi-tila
                                #(update (:lisatiedot %) :request-id count))))))
-        (client/reset-functions!)))))
+        (client/reset-functions!))
+      (testing "ei-laheteta when heratepvm disappears from HOKS"
+        (with-redefs [handling/get-hoks-by-id!
+                      (fn [id] (dissoc (hoks/get-by-id id)
+                                       :ensikertainen-hyvaksyminen))]
+          (->> heratteet
+               (find-first (comp (partial = "aloittaneet") :kyselytyyppi))
+               (vt/create-vastaajatunnus!))
+          (is (= [["odottaa_kasittelya" "odottaa_kasittelya"]
+                  ["odottaa_kasittelya" "odottaa_kasittelya"]
+                  ["odottaa_kasittelya" "ei_laheteta"]
+                  ["odottaa_kasittelya" "ei_laheteta"]]
+                 (->> {:hoks-id (:id hoks) :kyselytyypit ["aloittaneet"]}
+                      (tapahtuma/get-all-by-hoks-id-and-kyselytyypit! db/spec)
+                      (map (juxt :vanha-tila :uusi-tila))))))))))
 
 (deftest test-handle-amis-palautteet-on-heratepvm!
   (with-redefs [date/now (constantly (LocalDate/of 2024 12 18))


### PR DESCRIPTION
## Kuvaus muutoksista

Effectively, marking them as ei_laheteta means that they won't be looked at again until the HOKS is saved next time.

https://jira.eduuni.fi/browse/EH-2029

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
