### PR TITLE
EH-2030: unify date handling (is-after? usage)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -117,7 +117,7 @@
                          [org.clojure/tools.reader "1.5.0"]
                          [io.aviso/pretty "1.4.4"]
                          [instaparse "1.5.0"]]
-  :plugins [[lein-cljfmt "0.6.6" :exclusions [org.clojure/tools.cli]]
+  :plugins [[lein-cljfmt "0.6.6"]
             [lein-auto "0.1.3"]
             [lein-ancient "0.7.0"]
             [lein-cloverage "1.2.4"]
@@ -166,7 +166,8 @@
                                    [ring/ring-devel]
                                    [plumula/diff "0.1.1"]
                                    [clj-kondo]]
-                    :plugins [[lein-bikeshed "0.5.2"]]
+                    :plugins [[lein-bikeshed "0.5.2"
+                               :exclusions [[org.clojure/tools.cli]]]]
                     :env {:config "oph-configuration/test.edn"
                           :aws-region "eu-west-1"
                           :aws-endpoint-url "http://localhost:18000"}}

--- a/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
+++ b/src/oph/ehoks/hoks/osaamisen_hankkimistapa.clj
@@ -1,6 +1,7 @@
 (ns oph.ehoks.hoks.osaamisen-hankkimistapa
   (:require [medley.core :refer [find-first]]
             [oph.ehoks.utils :refer [get-in-and-propagate-fields]]
+            [oph.ehoks.utils.date :as dateutil]
             [hugsql.core :as hugsql])
   (:import [java.time LocalDate]))
 
@@ -47,7 +48,7 @@
 (defn- should-check-hankkimistapa-y-tunnus?
   "Tarkistaa, loppuuko osaamisen hankkimistapa käyttöönottopäivämäärän jälkeen."
   [oh]
-  (.isAfter ^LocalDate (:loppu oh) (LocalDate/of 2021 8 25)))
+  (dateutil/is-after? (:loppu oh) (LocalDate/of 2021 8 25)))
 
 (defn y-tunnus-missing?
   "Puuttuuko Y-tunnus osaamisen hankkimistavasta, vaikka pitäisi olla?"
@@ -61,7 +62,7 @@
   "Onko jaksossa osa-aikaisuustieto, jos pitäisi olla?"
   [oht]
   (let [osa-aikaisuustieto (:osa-aikaisuustieto oht)]
-    (or (not (.isAfter ^LocalDate (:loppu oht) (LocalDate/of 2023 6 30)))
+    (or (not (dateutil/is-after? (:loppu oht) (LocalDate/of 2023 6 30)))
         (not (tyopaikkajakso? oht))
         (and (some? osa-aikaisuustieto)
              (<= 1 osa-aikaisuustieto 100)))))

--- a/src/oph/ehoks/hoks/schema.clj
+++ b/src/oph/ehoks/hoks/schema.clj
@@ -9,6 +9,7 @@
             [oph.ehoks.schema.oid :refer [OpiskeluoikeusOID
                                           OppijaOID
                                           OrganisaatioOID]]
+            [oph.ehoks.utils.date :as dateutil]
             [schema.coerce]
             [schema.core :as s])
   (:import (clojure.lang ExceptionInfo)
@@ -335,13 +336,14 @@
                          (LocalDate/parse))]
     (or (katsotaan-eronneeksi? oo)
         (not oo-loppu)
-        (not (.isAfter ^LocalDate (:loppu oht) oo-loppu)))))
+        (dateutil/is-same-or-before? (:loppu oht) oo-loppu))))
 
 (defn- duration-max-5-years?
   "Osaamisen hankkimistapa kestää enintään 5 vuotta"
   [oht]
-  (not (.isAfter ^LocalDate (:loppu oht)
-                 (.plusYears ^LocalDate (:alku oht) 5))))
+  (dateutil/is-same-or-before?
+    (:loppu oht)
+    (.plusYears ^LocalDate (:alku oht) 5)))
 
 (def OsaamisenHankkimistapa-template
   "Osaamisen hankkimistavan schema eri toiminnoille."
@@ -990,8 +992,8 @@
   "Aika, jonka saa kirjoittaa osaamisen-saavuttamisen-pvm-kenttään."
   (s/constrained
     LocalDate
-    #(and (.isAfter ^LocalDate % (LocalDate/of 2018 1 1))
-          (.isBefore ^LocalDate % (.plusDays (LocalDate/now) 15)))
+    #(and (dateutil/is-after? % (LocalDate/of 2018 1 1))
+          (dateutil/is-after? (.plusDays (LocalDate/now) 15) %))
     "Osaaminen voidaan merkitä saavutetuksi enintään kaksi viikkoa
     tulevaisuuteen ja vähintään vuodelle 2018."))
 

--- a/src/oph/ehoks/oppija/share_handler.clj
+++ b/src/oph/ehoks/oppija/share_handler.clj
@@ -3,6 +3,7 @@
             [oph.ehoks.restful :as rest]
             [oph.ehoks.oppija.schema :as oppija-schema]
             [oph.ehoks.schema :as schema]
+            [oph.ehoks.utils.date :as dateutil]
             [oph.ehoks.db.db-operations.shared-modules :as db]
             [ring.util.http-response :as response]
             [oph.ehoks.hoks.hankittavat :as h])
@@ -23,11 +24,11 @@
   "Check whether jakolinkki is still valid"
   [{:keys [voimassaolo-alku voimassaolo-loppu]}]
   (cond
-    (.isAfter ^LocalDate voimassaolo-alku (LocalDate/now))
+    (dateutil/is-after? voimassaolo-alku (LocalDate/now))
     (throw (ex-info "Shared link not yet active"
                     {:type             :shared-link-inactive
                      :voimassaolo-alku voimassaolo-alku}))
-    (.isBefore ^LocalDate voimassaolo-loppu (LocalDate/now))
+    (dateutil/is-after? (LocalDate/now) voimassaolo-loppu)
     (throw (ex-info "Shared link is expired"
                     {:type              :shared-link-expired
                      :voimassaolo-loppu voimassaolo-loppu}))))

--- a/src/oph/ehoks/palaute.clj
+++ b/src/oph/ehoks/palaute.clj
@@ -39,7 +39,7 @@
   "onko herätteen päivämäärä aikaisintaan kuluvan rahoituskauden alkupvm
   (1.7.)?"
   [^LocalDate herate-date]
-  (not (.isAfter (current-rahoituskausi-alkupvm) herate-date)))
+  (date/is-same-or-before? (current-rahoituskausi-alkupvm) herate-date))
 
 (defn koulutustoimija-oid!
   "Hakee koulutustoimijan OID:n opiskeluoikeudesta, tai organisaatiopalvelusta

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -44,7 +44,7 @@
   [status]
   (when-let [loppupvm (:voimassa-loppupvm status)]
     (let [enddate (LocalDate/parse (first (str/split loppupvm #"T")))]
-      (dateutil/is-after (dateutil/now) enddate))))
+      (dateutil/is-after? (dateutil/now) enddate))))
 
 (defn vastattu?
   "Onko kyselylinkin arvo-statuksessa kysely merkitty vastatuksi?"

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -259,7 +259,7 @@
         heratepvm (:heratepvm existing-palaute)
         alkupvm (greatest heratepvm today)
         loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
-        e-k-l-p (date/is-after today loppupvm)]
+        e-k-l-p (date/is-after? today loppupvm)]
     {:hankintakoulutuksen_toteuttaja @hk-toteuttaja
      :tutkinnon_suorituskieli (or (suoritus/kieli suoritus) "fi")
      :kyselyn_tyyppi (translate-kyselytyyppi (:kyselytyyppi existing-palaute))

--- a/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
+++ b/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
@@ -26,7 +26,7 @@
   [kyselylinkki]
   (not (or (:vastattu kyselylinkki)
            (some->> (:voimassa-loppupvm kyselylinkki)
-                    (date/is-after (date/now))))))
+                    (date/is-after? (date/now))))))
 
 (defn update-status!
   "Fetch the latest status (mainly, `:vastattu` and `voimassa-loppupvm`) of

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -61,7 +61,7 @@
                (date/is-same-or-before? (:alku k-jakso) (:loppu tyoelamajakso))
                (or (not (:loppu k-jakso))
                    (date/is-same-or-before? (:loppu tyoelamajakso)
-                                           (:loppu k-jakso)))))
+                                            (:loppu k-jakso)))))
         (:keskeytymisajanjaksot tyoelamajakso)))
 
 (defn initial-palaute-state-and-reason

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -58,9 +58,9 @@
   [tyoelamajakso]
   (some (fn [k-jakso]
           (and (:loppu tyoelamajakso)
-               (date/is-same-or-before (:alku k-jakso) (:loppu tyoelamajakso))
+               (date/is-same-or-before? (:alku k-jakso) (:loppu tyoelamajakso))
                (or (not (:loppu k-jakso))
-                   (date/is-same-or-before (:loppu tyoelamajakso)
+                   (date/is-same-or-before? (:loppu tyoelamajakso)
                                            (:loppu k-jakso)))))
         (:keskeytymisajanjaksot tyoelamajakso)))
 
@@ -215,7 +215,7 @@
         today (date/now)
         alkupvm (greatest heratepvm today)
         loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
-        e-k-l-p (date/is-after today loppupvm)]
+        e-k-l-p (date/is-after? today loppupvm)]
     {:koulutustoimija_oid       koulutustoimija
      :tyonantaja                (:tyopaikan-y-tunnus tjk)
      :tyopaikka                 t-nimi

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -39,12 +39,12 @@
     (and (not (#{DayOfWeek/SATURDAY DayOfWeek/SUNDAY} dow))
          (<= 7 hour 17))))
 
-(defn is-after
+(defn is-after?
   "Wrapper .isAfter-metodin ympäri, jolla on tyyppianotaatiot."
   [^LocalDate one-date ^LocalDate other-date]
   (.isAfter one-date other-date))
 
-(defn is-same-or-before
+(defn is-same-or-before?
   "Käännetty .isAfter"
   [^LocalDate one-date ^LocalDate other-date]
-  (not (is-after one-date other-date)))
+  (not (is-after? one-date other-date)))


### PR DESCRIPTION
## Kuvaus muutoksista

Käytetään dateutils-avaruuden avukkeita konsistentisti koodissa.

https://jira.eduuni.fi/browse/EH-2030

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
