### PR TITLE
EH-2072: add tyopaikkajakson_kesto field to Arvo request POST .../vastaajatunnus

### DIFF
--- a/oph-configuration/default.edn
+++ b/oph-configuration/default.edn
@@ -27,5 +27,5 @@
  :arvo-username "ehoks"
  :arvo-password ""
  :arvo-url "http://localhost:3000/api"
- :koski-opiskeluoikeus-cache-ttl-millis 2000
+ :koski-opiskeluoikeus-cache-ttl-millis 20000
  :koski-oppija-cache-ttl-millis 5000}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/Opetushallitus/ehoks</url>
     <connection>scm:git:git://github.com/Opetushallitus/ehoks.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ehoks.git</developerConnection>
-    <tag>2d285b2d50333ce88e99699b8a7d6fc875499736</tag>
+    <tag>7bf94000c1abb706b96cd3b2438ae8e1e1d5c3db</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -69,10 +69,10 @@
   </build>
   <repositories>
     <repository>
-      <id>maven-central-proxy</id>
-      <url>https://artifactory.opintopolku.fi/artifactory/repository/maven-central</url>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </snapshots>
       <releases>
         <enabled>true</enabled>
@@ -91,6 +91,16 @@
     <repository>
       <id>github</id>
       <url>https://maven.pkg.github.com/orgs/Opetushallitus/packages</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>upstream-maven-central</id>
+      <url>https://repo1.maven.org/maven2/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/project.clj
+++ b/project.clj
@@ -126,18 +126,18 @@
   ;; ^:replace to ensure that maven central is not used directly; can be
   ;; taken away if maven-central-proxy goes away, or Maven Central does
   ;; not break builds anymore with 429 responses
-  :repositories ^:replace
-  [["maven-central-proxy"
-    {:url "https://artifactory.opintopolku.fi/artifactory/repository/maven-central"
-     :username :env/ARTIFACTORY_USERNAME
-     :password :env/ARTIFACTORY_PASSWORD}]
-   ["clojars" "https://repo.clojars.org/"]
-   ["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
+  :repositories
+  [["github" {:url "https://maven.pkg.github.com/orgs/Opetushallitus/packages"
               :username "private-token"
               :password :env/GITHUB_TOKEN}]
+   ["upstream-maven-central" "https://repo1.maven.org/maven2/"]
    ["oph-releases" "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"]
    ["oph-snapshots" "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local"]
    ["ext-snapshots" "https://artifactory.opintopolku.fi/artifactory/ext-snapshot-local"]]
+  :mirrors {"central" {:name "central"
+                       :url "https://artifactory.opintopolku.fi/artifactory/repository/maven-central"
+                       :username :env/ARTIFACTORY_USERNAME
+                       :password :env/ARTIFACTORY_PASSWORD}}
   :main oph.ehoks.main
   :aot [oph.ehoks.main]
   :uberjar-name "ehoks-standalone.jar"

--- a/src/oph/ehoks/palaute/lahetys.clj
+++ b/src/oph/ehoks/palaute/lahetys.clj
@@ -44,7 +44,7 @@
   [status]
   (when-let [loppupvm (:voimassa-loppupvm status)]
     (let [enddate (LocalDate/parse (first (str/split loppupvm #"T")))]
-      (dateutil/is-after (dateutil/now) enddate))))
+      (dateutil/is-after? (dateutil/now) enddate))))
 
 (defn vastattu?
   "Onko kyselylinkin arvo-statuksessa kysely merkitty vastatuksi?"

--- a/src/oph/ehoks/palaute/opiskelija.clj
+++ b/src/oph/ehoks/palaute/opiskelija.clj
@@ -259,7 +259,7 @@
         heratepvm (:heratepvm existing-palaute)
         alkupvm (greatest heratepvm today)
         loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
-        e-k-l-p (date/is-after today loppupvm)]
+        e-k-l-p (date/is-after? today loppupvm)]
     {:hankintakoulutuksen_toteuttaja @hk-toteuttaja
      :tutkinnon_suorituskieli (or (suoritus/kieli suoritus) "fi")
      :kyselyn_tyyppi (translate-kyselytyyppi (:kyselytyyppi existing-palaute))

--- a/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
+++ b/src/oph/ehoks/palaute/opiskelija/kyselylinkki.clj
@@ -26,7 +26,7 @@
   [kyselylinkki]
   (not (or (:vastattu kyselylinkki)
            (some->> (:voimassa-loppupvm kyselylinkki)
-                    (date/is-after (date/now))))))
+                    (date/is-after? (date/now))))))
 
 (defn update-status!
   "Fetch the latest status (mainly, `:vastattu` and `voimassa-loppupvm`) of

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -59,10 +59,10 @@
   [tyoelamajakso]
   (some (fn [k-jakso]
           (and (:loppu tyoelamajakso)
-               (date/is-same-or-before (:alku k-jakso) (:loppu tyoelamajakso))
+               (date/is-same-or-before? (:alku k-jakso) (:loppu tyoelamajakso))
                (or (not (:loppu k-jakso))
-                   (date/is-same-or-before (:loppu tyoelamajakso)
-                                           (:loppu k-jakso)))))
+                   (date/is-same-or-before? (:loppu tyoelamajakso)
+                                            (:loppu k-jakso)))))
         (:keskeytymisajanjaksot tyoelamajakso)))
 
 (defn initial-palaute-state-and-reason
@@ -237,7 +237,7 @@
         today (date/now)
         alkupvm (greatest heratepvm today)
         loppupvm (palaute/vastaamisajan-loppupvm heratepvm alkupvm)
-        e-k-l-p (date/is-after today loppupvm)]
+        e-k-l-p (date/is-after? today loppupvm)]
     {:koulutustoimija_oid       koulutustoimija
      :tyonantaja                (:tyopaikan-y-tunnus tjk)
      :tyopaikka                 t-nimi

--- a/src/oph/ehoks/palaute/tyoelama.clj
+++ b/src/oph/ehoks/palaute/tyoelama.clj
@@ -11,6 +11,7 @@
             [oph.ehoks.opiskeluoikeus.suoritus :as suoritus]
             [oph.ehoks.palaute :as palaute]
             [oph.ehoks.palaute.tapahtuma :as tapahtuma]
+            [oph.ehoks.palaute.tyoelama.kesto :as kesto]
             [oph.ehoks.palaute.tyoelama.nippu :as nippu]
             [oph.ehoks.utils :as utils]
             [oph.ehoks.utils.date :as date]
@@ -205,10 +206,31 @@
        :viimeinen_vastauspvm (palaute/vastaamisajan-loppupvm
                                heratepvm vastaamisajan-alkupvm)})))
 
+(defn build-tyoelamajakso-for-kesto
+  "Muuntaa palautekäsittelyn kontekstin `ctx` herätepalvelu-tyyliseksi jaksoksi
+  jota `kesto/jaksojen-kestot!` odottaa syötteekseen.  Oikeasti kentistä
+  käytetään vain :oppija_oid, :jakso_alkupvm ja :jakso_loppupvm."
+  [{:keys [hoks jakso existing-palaute]}]
+  {:oppija_oid         (:oppija-oid hoks)
+   :opiskeluoikeus_oid (:opiskeluoikeus-oid hoks)
+   :hoks_id            (:hoks-id existing-palaute)
+   :yksiloiva_tunniste (:jakson-yksiloiva-tunniste existing-palaute)
+   :hankkimistapa_id   (:hankkimistapa-id existing-palaute)
+   :jakso_alkupvm      (:alku jakso)
+   :jakso_loppupvm     (:loppu jakso)
+   :osa_aikaisuus      (:osa-aikaisuustieto jakso)})
+
+(defn context->kesto
+  "Laskee jakson jyvitetyn keston käsittelykontekstista"
+  [ctx]
+  (let [kesto-jakso (build-tyoelamajakso-for-kesto ctx)]
+    (get (kesto/jaksojen-kestot! [kesto-jakso])
+         (kesto/ids kesto-jakso))))
+
 (defn build-jaksotunnus-request-body
   "Luo dataobjektin TEP-jaksotunnuksen luomisrequestille."
   [{:keys [opiskeluoikeus existing-palaute jakso request-id
-           suoritus koulutustoimija toimipiste]}]
+           suoritus koulutustoimija toimipiste] :as ctx}]
   (let [tjk (:tyopaikalla-jarjestettava-koulutus jakso)
         t-nimi (:tyopaikan-nimi tjk)
         heratepvm (:heratepvm existing-palaute)
@@ -228,6 +250,7 @@
      :osaamisala                (suoritus/get-osaamisalat suoritus heratepvm)
      :tyopaikkajakson_alkupvm   (str (:alku jakso))
      :tyopaikkajakson_loppupvm  (str (:loppu jakso))
+     :tyopaikkajakson_kesto     (context->kesto ctx)
      :rahoituskausi_pvm         (str (:loppu jakso))
      :osa_aikaisuus             (:osa-aikaisuustieto jakso)
      :sopimustyyppi             (utils/koodi-uri->koodi

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -1,0 +1,206 @@
+(ns oph.ehoks.palaute.tyoelama.kesto
+  (:require [clojure.tools.logging :as log]
+            [oph.ehoks.external.koski :as koski]
+            [oph.ehoks.utils.date :as dateutil])
+  (:import (java.lang Math)
+           (java.time LocalDate)))
+
+(defn round-vals [m] (reduce-kv #(assoc %1 %2 (Math/round ^Double %3)) {} m))
+
+(defn ids
+  "Returns an array-map of identifiers (HOKS ID & yksiloiva tunniste) that
+  fully identify työpaikkajakso."
+  [jakso]
+  (select-keys jakso [:hoks_id :yksiloiva_tunniste]))
+
+(defn not-in-keskeytymisajanjakso?
+  "Varmistaa, että annettu päivämäärä ei kuulu keskeytymisajanjaksoon."
+  [^LocalDate date keskeytymisajanjaksot]
+  (or (empty? keskeytymisajanjaksot)
+      (every? #(or (and (:alku %) (.isBefore date (:alku %)))
+                   (and (:loppu %) (.isAfter date (:loppu %))))
+              keskeytymisajanjaksot)))
+
+(defn osa-aikaisuuskerroin
+  "Hakee osa-aikaisuustiedon jaksosta ja varmistaa että se on validi (ts.
+  kokonaisluku väliltä 1 - 100). Palauttaa osa-aikaisuuskertoimen, joka
+  lasketaan jakamalla prosentuaalinen osa-aikaisuus 100 %:lla,
+  esim. 80 % / 100 % = 0.8. Jos osa-aikaisuustieto puuttuu tai on ei-validi,
+  palautetaan osa-aikaisuuskertoimena nolla."
+  [jakso]
+  (let [hoks-id            (:hoks_id jakso)
+        yksiloiva-tunniste (:yksiloiva_tunniste jakso)
+        osa-aikaisuus      (:osa_aikaisuus jakso)]
+    (or (cond
+          (nil? osa-aikaisuus)
+          (log/warnf
+            (str "Osa-aikaisuustieto puuttuu jakson (HOKS `%d`, yksilöivä "
+                 "tunniste `%s`) tiedoista. Jakson kestoksi asetetaan nolla.")
+            hoks-id
+            yksiloiva-tunniste)
+          (not (and (integer? osa-aikaisuus)
+                    (pos? osa-aikaisuus)
+                    (>= 100 osa-aikaisuus)))
+          (log/warnf
+            (str "Jakson (HOKS `%d`, yksilöivä tunniste `%s`) osa-aikaisuus "
+                 "`%s` ei ole validi. Jakson kestoksi asetetaan nolla.")
+            hoks-id
+            yksiloiva-tunniste
+            osa-aikaisuus)
+          :else (/ osa-aikaisuus 100.0))
+        0)))
+
+(defn add-loppu-to-jaksot
+  "Lisää jokaiseen paitsi viimeiseen jaksoon kentän :loppu, joka on päivää
+  ennen kuin seuraavan :alku"
+  [jaksot]
+  (conj (mapv (fn [current next]
+                (let [^LocalDate next-starts (:alku next)]
+                  (assoc current :loppu (.minusDays next-starts 1))))
+              jaksot
+              (rest jaksot))
+        (last jaksot)))
+
+(defn get-opiskeluoikeusjaksot
+  [opiskeluoikeus]
+  (->> (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
+       (map dateutil/alku-and-loppu-to-localdate)
+       (sort-by :alku)
+       add-loppu-to-jaksot))
+
+(defn keskeytymisajanjaksot
+  [jakso opiskeluoikeus]
+  (let [keskeytynyt-tila? #{"valiaikaisestikeskeytynyt"}
+        kjaksot-in-jakso (map dateutil/alku-and-loppu-to-localdate
+                              (:keskeytymisajanjaksot jakso))
+        kjaksot-in-opiskeluoikeus
+        (filter #(keskeytynyt-tila? (:koodiarvo (:tila %)))
+                (get-opiskeluoikeusjaksot opiskeluoikeus))]
+    (concat kjaksot-in-jakso kjaksot-in-opiskeluoikeus)))
+
+(defn in-jakso?
+  "Tarkistaa sisältyykö päivämäärä `pvm` jaksoon `jakso`. Oletus on, että
+  sekä pvm että jakson avaimet :alku ja :loppu ovat tyyppiä `LocalDate`.
+  Palauttaa `true` jos päivämäärä sisältyy jaksoon, muuten `false`."
+  [^LocalDate pvm jakso]
+  (let [alku (:alku jakso) loppu (:loppu jakso)]
+    (and (or (.isAfter pvm alku) (.isEqual pvm alku))
+         (or (nil? loppu) (.isBefore pvm loppu) (.isEqual pvm loppu)))))
+
+(defn jakso-active?
+  "Tarkistaa, onko `jakso` aktiivinen päivämääränä `pvm`. Ts. funktiossa
+  tarkistetaan, kuuluuko `pvm` jaksoon ja sisältyykö se mihinkään jakson tai
+  opiskeluoikeuden tiedoissa olevaan keskeytymisajanjaksoon."
+  [jakso opiskeluoikeus pvm]
+  (and (in-jakso? pvm jakso)
+       (some? opiskeluoikeus)
+       (not-any? #(in-jakso? pvm %)
+                 (keskeytymisajanjaksot jakso opiskeluoikeus))))
+
+(defn oppijan-jaksojen-yhden-paivan-kestot
+  "Laskee yhden oppijan aktiivisena olevien jaksojen kestot yhden päivän osalta,
+  eli suorittaa niin sanotun 'jyvityksen'. Tällä tarkoitetaan sitä, että yhden
+  päivän kesto jaetaan tasaisesti kaikille samanaikaisesti aktiivisena oleville
+  (ei keskeytyneille) jaksoille kyseisen päivän osalta.
+
+  Funktio olettaa, että parametrina saadut `jaksot` ovat kaikki saman oppijan
+  jaksoja. `opiskeluoikeudet` hashmap (oid -> opiskeluoikeus) voi sisältää
+  muidenkin oppijoiden opiskeluoikeuksia, sillä kutakin jaksoa vastaava
+  opiskeluoikeus haetaan `opiskeluoikeudet` hashmapista käyttäen jakson
+  tiedoista löytyvää opiskeluoikeuden oid:ta.
+
+  Funktio palauttaa päivänä `pvm` aktiivisena olleiden jaksojen jyvittämällä
+  lasketut kestot hashmapissa, jossa avaimina jaksojen id:t
+  (osaamisenhankkimistapojen) ja arvoina lasketut kestot reaalilukuina.
+
+  Esimerkki:
+  `jaksot` listassa on 4 jaksoa id:illä 1, 2, 3 ja 4. Näistä 1, 2 ja 4 ovat
+  aktiivisia päivänä `pvm` ja 3 on keskeytynyt. Tällöin funktio palauttaa
+  {1 0.333... 2 0.333... 4 0.333...}. Keskeytyneen jakson nollakesto ei ole
+  siis mukana palautettavassa hashmapissa."
+  [jaksot opiskeluoikeudet pvm]
+  (let [active-jakso-ids ; Päivänä `pvm` aktiivisena olevien jaksojen id:t
+        (map ids
+             (filter #(jakso-active? %
+                                     (get opiskeluoikeudet
+                                          (:opiskeluoikeus_oid %))
+                                     pvm)
+                     jaksot))
+        num-of-active-jaksos (count active-jakso-ids)
+        kesto (/ 1.0 num-of-active-jaksos)] ; Jyvitys
+    (zipmap active-jakso-ids (repeat kesto))))
+
+(defn harmonize-date-keys
+  "Harmonisoi jakson alku- ja loppupäivämääriä vastaavat avaimet, jotta
+  kestonlaskennassa voidaan hyödyntää mahdollisimman paljon samoja funktiota."
+  [jakso]
+  (cond-> jakso
+    (:jakso_alkupvm jakso)  (assoc :alku (:jakso_alkupvm jakso))
+    (:jakso_loppupvm jakso) (assoc :loppu (:jakso_loppupvm jakso))))
+
+(defn harmonize-alku-and-loppu-dates
+  "Harmonisoi :jakso_alkupvm ja :jakso_loppupvm avaimet avaimiksi
+  :alku ja :loppu myöhempää prosessointia varten. Muuttaa myös vastaavat
+  päivämäärät myös LocalDate-objekteiksi."
+  [jakso]
+  (dateutil/alku-and-loppu-to-localdate (harmonize-date-keys jakso)))
+
+(defn oppijan-jaksojen-kestot
+  "Laskee kestot jaksoille `jaksot`. Funktio olettaa, että `jaksot` pitävät
+  sisällään ainoastaan yhden oppijan jaksoja. `opiskeluoikeudet` tulee olla
+  hashmap (oid -> opiskeluoikeus). Se voi sisältää muidenkin oppijoiden
+  opiskeluoikeuksia, sillä jaksoja `jaksot` vastaavat opiskeluoikeudet haetaan
+  `opiskeluoikeudet` hashmapista jakson tiedoista löytyvän opiskeluoikeus oid:n
+  perusteella.
+
+  Funktio palauttaa yhden oppijan jaksojen kestot aikavälillä, missä aikavälin
+  alku on jaksojen `jaksot` alkupäivämääristä varhaisin ja loppu vastaavasi
+  päättymispäivistä myöhäisin. Palautuva arvo on hashmap, jossa avaimina
+  jaksojen id:t (osaamisenhankkimistapojen) ja arvoina kestot kokonaislukuina.
+  Yksittäisen jakson kesto voi olla nolla, jos kyseiselle jaksolle ei saada
+  opiskeluoikeutta Koskesta 404-virheen vuoksi, tai jos jakson
+  osa-aikaisuustieto puuttuu tai on virheellinen. Jakson kesto voi myös
+  pyöristyä nollaan, mikäli kokonaiskesto on jotain 0 ja 0.5 väliltä."
+  [oppijan-jaksot opiskeluoikeudet]
+  (when (not-empty oppijan-jaksot)
+    (let [jaksot (map harmonize-alku-and-loppu-dates oppijan-jaksot)
+          ids    (map ids jaksot)]
+      (round-vals ; Pyöristetään kestot lähimpään kokonaislukuun.
+        (merge-with
+          * ; Kerrotaan kestot osa-aikaisuuskertoimilla
+          (reduce (partial merge-with +) ; Summataan yksittäisten päivien kestot
+                  ; Alustetaan alla kaikki kestot nollaksi:
+                  (zipmap ids (repeat 0))
+                  (map (partial oppijan-jaksojen-yhden-paivan-kestot
+                                jaksot
+                                opiskeluoikeudet)
+                       (dateutil/date-range
+                         (first (sort (map :alku jaksot)))
+                         (last  (sort (map :loppu jaksot))))))
+          (zipmap ids (map osa-aikaisuuskerroin jaksot)))))))
+
+(defn get-and-memoize-opiskeluoikeudet!
+  "Funktio hakee `jaksot` listan jaksojen opiskeluoikeuksia Koskesta.
+  Opiskeluoikeudet tallennetaan muistiin hakujen välillä, joten jos listassa on
+  jaksoja jotka jakavat saman opiskeluoikeuden, näiden opiskeluoikeudet
+  tarvitsee hakea Koskesta vain kerran. Näin vältetään turhia GET-pyyntöjä
+  Koskeen."
+  [jaksot]
+  (reduce
+    (fn [memoized-opiskeluoikeudet jakso]
+      (let [hoks-id (:hoks_id jakso)
+            yksiloiva-tunniste (:yksiloiva_tunniste jakso)
+            oo-oid (:opiskeluoikeus_oid jakso)]
+        (if (contains? memoized-opiskeluoikeudet oo-oid)
+          memoized-opiskeluoikeudet
+          (if-let [opiskeluoikeus (koski/get-opiskeluoikeus! oo-oid)]
+            (conj memoized-opiskeluoikeudet [oo-oid opiskeluoikeus])
+            (do (log/warnf (str "Opiskeluoikeutta `%s` ei saatu Koskesta. "
+                                "Jakson (HOKS `%d`, yksilöivä tunniste `%s`) "
+                                "kestoksi asetetaan nolla.")
+                           oo-oid
+                           hoks-id
+                           yksiloiva-tunniste)
+                memoized-opiskeluoikeudet)))))
+    {}
+    jaksot))

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -50,23 +50,23 @@
           :else (/ osa-aikaisuus 100.0))
         0)))
 
-(defn add-loppu-to-jaksot
+(defn add-loppu-to-tilajaksot
   "Lisää jokaiseen paitsi viimeiseen jaksoon kentän :loppu, joka on päivää
   ennen kuin seuraavan :alku"
-  [jaksot]
+  [tilajaksot]
   (conj (mapv (fn [current next]
                 (let [^LocalDate next-starts (:alku next)]
                   (assoc current :loppu (.minusDays next-starts 1))))
-              jaksot
-              (rest jaksot))
-        (last jaksot)))
+              tilajaksot
+              (rest tilajaksot))
+        (last tilajaksot)))
 
 (defn get-opiskeluoikeusjaksot
   [opiskeluoikeus]
   (->> (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
        (map dateutil/alku-and-loppu-to-localdate)
        (sort-by :alku)
-       add-loppu-to-jaksot))
+       add-loppu-to-tilajaksot))
 
 (defn keskeytymisajanjaksot
   [jakso opiskeluoikeus]

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -180,7 +180,7 @@
                          (last  (sort (map :loppu jaksot))))))
           (zipmap ids (map osa-aikaisuuskerroin jaksot)))))))
 
-(defn get-and-memoize-opiskeluoikeudet!
+(defn jaksojen-opiskeluoikeudet!
   "Funktio hakee `jaksot` listan jaksojen opiskeluoikeuksia Koskesta.
   Opiskeluoikeudet tallennetaan muistiin hakujen välillä, joten jos listassa on
   jaksoja jotka jakavat saman opiskeluoikeuden, näiden opiskeluoikeudet
@@ -229,7 +229,7 @@
               (let [concurrent-jaksot
                     (get-concurrent-jaksot-from-hokses! oppijan-jaksot)
                     opiskeluoikeudet
-                    (get-and-memoize-opiskeluoikeudet! concurrent-jaksot)]
+                    (jaksojen-opiskeluoikeudet! concurrent-jaksot)]
                 (oppijan-jaksojen-kestot concurrent-jaksot opiskeluoikeudet))))
        ; Yhdistetään eri oppijoiden jaksoille lasketut kestot yhdeksi
        ; hashmapiksi:

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -1,11 +1,12 @@
 (ns oph.ehoks.palaute.tyoelama.kesto
   (:require [clojure.tools.logging :as log]
+            [medley.core :refer [map-vals]]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.utils.date :as dateutil])
   (:import (java.lang Math)
            (java.time LocalDate)))
 
-(defn round-vals [m] (reduce-kv #(assoc %1 %2 (Math/round ^Double %3)) {} m))
+(def round-vals (partial map-vals Math/round))
 
 (defn ids
   "Returns an array-map of identifiers (HOKS ID & yksiloiva tunniste) that
@@ -16,10 +17,9 @@
 (defn not-in-keskeytymisajanjakso?
   "Varmistaa, että annettu päivämäärä ei kuulu keskeytymisajanjaksoon."
   [^LocalDate date keskeytymisajanjaksot]
-  (or (empty? keskeytymisajanjaksot)
-      (every? #(or (and (:alku %) (.isBefore date (:alku %)))
-                   (and (:loppu %) (.isAfter date (:loppu %))))
-              keskeytymisajanjaksot)))
+  (every? #(or (and (:alku %) (.isBefore date (:alku %)))
+               (and (:loppu %) (.isAfter date (:loppu %))))
+          keskeytymisajanjaksot))
 
 (defn osa-aikaisuuskerroin
   "Hakee osa-aikaisuustiedon jaksosta ja varmistaa että se on validi (ts.
@@ -84,8 +84,8 @@
   Palauttaa `true` jos päivämäärä sisältyy jaksoon, muuten `false`."
   [^LocalDate pvm jakso]
   (let [alku (:alku jakso) loppu (:loppu jakso)]
-    (and (or (.isAfter pvm alku) (.isEqual pvm alku))
-         (or (nil? loppu) (.isBefore pvm loppu) (.isEqual pvm loppu)))))
+    (and (dateutil/is-same-or-before alku pvm)
+         (or (nil? loppu) (dateutil/is-same-or-before pvm loppu)))))
 
 (defn jakso-active?
   "Tarkistaa, onko `jakso` aktiivinen päivämääränä `pvm`. Ts. funktiossa
@@ -186,21 +186,16 @@
   tarvitsee hakea Koskesta vain kerran. Näin vältetään turhia GET-pyyntöjä
   Koskeen."
   [jaksot]
-  (reduce
-    (fn [memoized-opiskeluoikeudet jakso]
-      (let [hoks-id (:hoks_id jakso)
-            yksiloiva-tunniste (:yksiloiva_tunniste jakso)
-            oo-oid (:opiskeluoikeus_oid jakso)]
-        (if (contains? memoized-opiskeluoikeudet oo-oid)
-          memoized-opiskeluoikeudet
-          (if-let [opiskeluoikeus (koski/get-opiskeluoikeus! oo-oid)]
-            (conj memoized-opiskeluoikeudet [oo-oid opiskeluoikeus])
-            (do (log/warnf (str "Opiskeluoikeutta `%s` ei saatu Koskesta. "
-                                "Jakson (HOKS `%d`, yksilöivä tunniste `%s`) "
-                                "kestoksi asetetaan nolla.")
-                           oo-oid
-                           hoks-id
-                           yksiloiva-tunniste)
-                memoized-opiskeluoikeudet)))))
-    {}
-    jaksot))
+  (->> (map :opiskeluoikeus_oid jaksot)
+       (set)
+       (keep #(if-let [opiskeluoikeus (koski/get-opiskeluoikeus! %)]
+                [% opiskeluoikeus]
+                (let [affected-jaksot
+                      (keep (fn [jakso] (and (= % (:opiskeluoikeus_oid jakso))
+                                             [(:hoks_id jakso)
+                                              (:yksiloiva_tunniste jakso)]))
+                            jaksot)]
+                  (log/warn "Opiskeluoikeutta `" % "` ei saatu Koskesta."
+                            "Jaksoille" affected-jaksot
+                            "kestoksi asetetaan nolla."))))
+       (into {})))

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -1,5 +1,6 @@
 (ns oph.ehoks.palaute.tyoelama.kesto
   (:require [clojure.tools.logging :as log]
+            [oph.ehoks.heratepalvelu :as hp]
             [medley.core :refer [map-vals]]
             [oph.ehoks.external.koski :as koski]
             [oph.ehoks.utils.date :as dateutil])
@@ -199,3 +200,39 @@
                             "Jaksoille" affected-jaksot
                             "kestoksi asetetaan nolla."))))
        (into {})))
+
+(defn get-concurrent-jaksot-from-hokses!
+  "Hakee kaikki `jaksot` listassa olevien jaksojen kanssa päällekäin olevat
+  saman oppijan jaksot eHOKSista."
+  [jaksot]
+  (hp/select-tyoelamajaksot-active-between
+    (:oppija_oid (first jaksot))
+    (first (sort (map :jakso_alkupvm jaksot)))
+    (last  (sort (map :jakso_loppupvm jaksot)))))
+
+(defn jaksojen-kestot!
+  "Laskee kestot kaikille `jaksot` listan jaksoille. Lista jaksoista `jaksot`
+  voi pitää sisällään useamman oppijan työpaikkajaksoja: Kestonlaskenta tehdään
+  varsinaisesti aina saman oppijan jaksoille (kts. `oppijan-jaksojen-kestot`),
+  mutta tässä funktiossa `jaksot` ryhmitellään oppija oid:n mukaan ennen
+  `oppijan-jaksojen-kestot`-funktion tekemää kestojen laskemista.
+
+  Palauttaa hashmapin, joka sisältää `jaksot` listan jaksoille lasketut kestot.
+  Hashmapin avaimina jaksojen id:t (HOKS id + yksiloiva tunniste) ja arvoina
+  kestot kokonaislukuina."
+  [jaksot]
+  (->> (group-by :oppija_oid jaksot) ; Ryhmitellään jaksot oppijan perusteella
+       vals
+       ; Haetaan kunkin jakson tapauksessa päällekäiset jaksot eHOKSista
+       ; sekä viimeisin opiskeluoikeustieto Koskesta:
+       (map (fn [oppijan-jaksot]
+              (let [concurrent-jaksot
+                    (get-concurrent-jaksot-from-hokses! oppijan-jaksot)
+                    opiskeluoikeudet
+                    (get-and-memoize-opiskeluoikeudet! concurrent-jaksot)]
+                (oppijan-jaksojen-kestot concurrent-jaksot opiskeluoikeudet))))
+       ; Yhdistetään eri oppijoiden jaksoille lasketut kestot yhdeksi
+       ; hashmapiksi:
+       (apply merge)
+       ; Palautetaan vain niiden jaksojen kestot, jotka ovat `jaksot` listassa:
+       (#(select-keys % (map ids jaksot)))))

--- a/src/oph/ehoks/palaute/tyoelama/kesto.clj
+++ b/src/oph/ehoks/palaute/tyoelama/kesto.clj
@@ -85,8 +85,8 @@
   Palauttaa `true` jos päivämäärä sisältyy jaksoon, muuten `false`."
   [^LocalDate pvm jakso]
   (let [alku (:alku jakso) loppu (:loppu jakso)]
-    (and (dateutil/is-same-or-before alku pvm)
-         (or (nil? loppu) (dateutil/is-same-or-before pvm loppu)))))
+    (and (dateutil/is-same-or-before? alku pvm)
+         (or (nil? loppu) (dateutil/is-same-or-before? pvm loppu)))))
 
 (defn jakso-active?
   "Tarkistaa, onko `jakso` aktiivinen päivämääränä `pvm`. Ts. funktiossa

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -48,3 +48,20 @@
   "Käännetty .isAfter"
   [^LocalDate one-date ^LocalDate other-date]
   (not (is-after one-date other-date)))
+
+(defn alku-and-loppu-to-localdate
+  "Muuntaa parametrina annetun hashmapin :alku ja :loppu -avaimien
+  merkkijonomuotoiset päivämäärät LocalDate:iksi."
+  [jakso]
+  (cond-> jakso
+    (:alku jakso)  (update :alku  #(LocalDate/parse %))
+    (:loppu jakso) (update :loppu #(LocalDate/parse %))))
+
+(defn date-range
+  "Rakentaa laiskan sekvenssin päivämääristä alkupäivämäärän `start` ja
+  loppupäivämäärän `end` perusteella. `start` ja `end` kuuluvat mukaan
+  sekvenssiin."
+  [start end]
+  (let [end+1 (.plusDays ^LocalDate end 1)]
+    (take-while #(.isBefore ^LocalDate % end+1)
+                (iterate #(.plusDays ^LocalDate % 1) start))))

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -49,13 +49,21 @@
   [^LocalDate one-date ^LocalDate other-date]
   (not (is-after one-date other-date)))
 
+(defn ->localdate
+  "Muuntaa merkkijonomuotoisen päivämäärän LocalDate:ksi. Palauttaa jo valmiin
+  LocalDate-arvon sellaisenaan (esim. tietokannasta luetut päivämäärät ovat jo
+  LocalDate-tyyppisiä)."
+  ^LocalDate [d]
+  (if (instance? LocalDate d) d (LocalDate/parse d)))
+
 (defn alku-and-loppu-to-localdate
   "Muuntaa parametrina annetun hashmapin :alku ja :loppu -avaimien
-  merkkijonomuotoiset päivämäärät LocalDate:iksi."
+  päivämäärät LocalDate:iksi. Sietää sekä merkkijono- että LocalDate-muotoiset
+  päivämäärät."
   [jakso]
   (cond-> jakso
-    (:alku jakso)  (update :alku  #(LocalDate/parse %))
-    (:loppu jakso) (update :loppu #(LocalDate/parse %))))
+    (:alku jakso)  (update :alku  ->localdate)
+    (:loppu jakso) (update :loppu ->localdate)))
 
 (defn date-range
   "Rakentaa laiskan sekvenssin päivämääristä alkupäivämäärän `start` ja

--- a/src/oph/ehoks/utils/date.clj
+++ b/src/oph/ehoks/utils/date.clj
@@ -39,15 +39,15 @@
     (and (not (#{DayOfWeek/SATURDAY DayOfWeek/SUNDAY} dow))
          (<= 7 hour 17))))
 
-(defn is-after
+(defn is-after?
   "Wrapper .isAfter-metodin ympäri, jolla on tyyppianotaatiot."
   [^LocalDate one-date ^LocalDate other-date]
   (.isAfter one-date other-date))
 
-(defn is-same-or-before
+(defn is-same-or-before?
   "Käännetty .isAfter"
   [^LocalDate one-date ^LocalDate other-date]
-  (not (is-after one-date other-date)))
+  (not (is-after? one-date other-date)))
 
 (defn ->localdate
   "Muuntaa merkkijonomuotoisen päivämäärän LocalDate:ksi. Palauttaa jo valmiin

--- a/test/oph/ehoks/hoks/hoks_test_utils.clj
+++ b/test/oph/ehoks/hoks/hoks_test_utils.clj
@@ -143,5 +143,13 @@
 (defn mock-get-organisaatio! [oid]
   {:oid oid :tyypit #{"organisaatiotyyppi_03"}})
 
-(defn mock-create-jaksotunnus [_]
+(def mock-jaksotunnukset (atom []))
+
+(defn reset-arvo-requests! [] (reset! mock-jaksotunnukset []))
+(defn last-arvo-jaksotunnus [] (last @mock-jaksotunnukset))
+(defn created-jaksotunnukset [] @mock-jaksotunnukset)
+
+(defn mock-create-jaksotunnus
+  [request]
+  (swap! mock-jaksotunnukset conj request)
   {:tunnus (str (UUID/randomUUID))})

--- a/test/oph/ehoks/palaute/handler_test.clj
+++ b/test/oph/ehoks/palaute/handler_test.clj
@@ -120,6 +120,10 @@
                   data (:data (test-utils/parse-body (:body resp)))]
               (is (= (:status resp) 200) data)
               (is (not (empty? (:vastaajatunnukset data))))
+              (is (= ((juxt :osa_aikaisuus :tyopaikkajakson_alkupvm
+                            :tyopaikkajakson_kesto :tyopaikkajakson_loppupvm)
+                       (hoks-utils/last-arvo-jaksotunnus))
+                     [80 "2024-04-01" 4 "2024-04-05"]))
               ;; TODO: test here that the palaute is synced to DDB with
               ;; hankkimistapa-id
               (is (= (count (hoks-utils/palautteet-joissa-vastaajatunnus)) 1))))

--- a/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
@@ -1,18 +1,11 @@
 (ns oph.ehoks.palaute.tyoelama.kesto-test
   (:require [clojure.test :refer [are deftest is testing]]
-            [clojure.tools.logging.test :refer [with-log logged?]]
+            [clojure.tools.logging.test :refer [with-log logged? the-log]]
             [oph.ehoks.external.koski :as koski]
             [medley.core :refer [map-keys filter-vals]]
+            [oph.ehoks.utils.date :refer [alku-and-loppu-to-localdate]]
             [oph.ehoks.palaute.tyoelama.kesto :as nh])
   (:import (java.time LocalDate)))
-
-(defn alku-and-loppu-to-localdate
-  "Muuntaa parametrina annetun hashmapin :alku ja :loppu -avaimien
-  merkkijonomuotoiset päivämäärät LocalDate:iksi."
-  [jakso]
-  (cond-> jakso
-    (:alku jakso)  (update :alku  #(LocalDate/parse %))
-    (:loppu jakso) (update :loppu #(LocalDate/parse %))))
 
 (def jakso-1 {:opiskeluoikeus_oid "1.2.3.8"
               :oppija_oid "4.4.4.4"
@@ -342,7 +335,8 @@
         (is (= @mock-get-opiskeluoikeus-catch-404-count 3))
         (is (logged? 'oph.ehoks.palaute.tyoelama.kesto
                      :warn
-                     #"Opiskeluoikeutta `1.2.3.4.ei.loydy` ei saatu "))))))
+                     #"Opiskeluoikeutta ` 1.2.3.4.ei.loydy ` ei saatu ")
+            (the-log))))))
 
 (deftest test-get-opiskeluoikeusjaksot
   (testing "Funktio hakee onnistuneesti opiskeluoikeuden opiskeluoikeusjaksot."

--- a/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
@@ -538,16 +538,16 @@
       [jakso-2 jakso-4 jakso-8] [35 104 23]
       [jakso-1 jakso-4 jakso-9 jakso-16] [1 109 28 119])))
 
-(deftest test-get-and-memoize-opiskeluoikeudet
+(deftest test-jaksojen-opiskeluoikeudet!
   (with-log
     (with-redefs [koski/get-opiskeluoikeus! mock-get-opiskeluoikeus-catch-404]
       (testing
        (str "Funktio pitää entuudestaan haetut opiskeluoikeudet muistitssa, "
             "eikä hae niitä toistamiseen. Funktio lokitaa varoituksen, jos "
             "opiskeluoikeutta ei saada koskesta")
-        (is (= (nh/get-and-memoize-opiskeluoikeudet! []) {}))
+        (is (= (nh/jaksojen-opiskeluoikeudet! []) {}))
         (reset! mock-get-opiskeluoikeus-catch-404-count 0)
-        (is (= (nh/get-and-memoize-opiskeluoikeudet!
+        (is (= (nh/jaksojen-opiskeluoikeudet!
                  [jakso-1   ; 1.2.3.8
                   jakso-2   ; 1.2.3.8
                   jakso-5   ; 1.2.3.7

--- a/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [are deftest is testing]]
             [clojure.tools.logging.test :refer [with-log logged? the-log]]
             [oph.ehoks.external.koski :as koski]
-            [medley.core :refer [map-keys filter-vals]]
+            [oph.ehoks.heratepalvelu :as hp]
+            [medley.core :refer [map-keys map-vals filter-vals]]
             [oph.ehoks.utils.date :refer [alku-and-loppu-to-localdate]]
             [oph.ehoks.palaute.tyoelama.kesto :as nh])
   (:import (java.time LocalDate)))
@@ -301,42 +302,14 @@
       (is (false? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 10)
                                                    kjaksot))))))
 
-(def mock-get-opiskeluoikeus-catch-404-count (atom 0))
+(def do-rounding (partial map-vals #(/ (Math/round (* % 100.0)) 100.0)))
 
-(defn- do-rounding [values]
-  (reduce-kv #(assoc %1 %2 (/ (Math/round (* %3 100.0)) 100.0)) {} values))
+(def mock-get-opiskeluoikeus-catch-404-count (atom 0))
 
 (defn- mock-get-opiskeluoikeus-catch-404 [oo-oid]
   (assert oo-oid "Opiskeluoikeus OID `oo-oid` puuttuu")
   (swap! mock-get-opiskeluoikeus-catch-404-count inc)
   (get opiskeluoikeudet oo-oid))
-
-(deftest test-get-and-memoize-opiskeluoikeudet
-  (with-log
-    (with-redefs [koski/get-opiskeluoikeus! mock-get-opiskeluoikeus-catch-404]
-      (testing
-       (str "Funktio pitää entuudestaan haetut opiskeluoikeudet muistitssa, "
-            "eikä hae niitä toistamiseen. Funktio lokitaa varoituksen, jos "
-            "opiskeluoikeutta ei saada koskesta")
-        (is (= (nh/get-and-memoize-opiskeluoikeudet! []) {}))
-        (reset! mock-get-opiskeluoikeus-catch-404-count 0)
-        (is (= (nh/get-and-memoize-opiskeluoikeudet!
-                 [jakso-1   ; 1.2.3.8
-                  jakso-2   ; 1.2.3.8
-                  jakso-5   ; 1.2.3.7
-                  jakso-6   ; 1.2.3.8
-                  jakso-10  ; 1.2.3.7
-                  {:hoks_id 1
-                   :yksiloiva_tunniste "123"
-                   :hankkimistapa_id 123
-                   :opiskeluoikeus_oid "1.2.3.4.ei.loydy"}])
-               {"1.2.3.7" (get opiskeluoikeudet "1.2.3.7")
-                "1.2.3.8" (get opiskeluoikeudet "1.2.3.8")}))
-        (is (= @mock-get-opiskeluoikeus-catch-404-count 3))
-        (is (logged? 'oph.ehoks.palaute.tyoelama.kesto
-                     :warn
-                     #"Opiskeluoikeutta ` 1.2.3.4.ei.loydy ` ei saatu ")
-            (the-log))))))
 
 (deftest test-get-opiskeluoikeusjaksot
   (testing "Funktio hakee onnistuneesti opiskeluoikeuden opiskeluoikeusjaksot."
@@ -564,3 +537,81 @@
       [jakso-2 jakso-3] [74 5]
       [jakso-2 jakso-4 jakso-8] [35 104 23]
       [jakso-1 jakso-4 jakso-9 jakso-16] [1 109 28 119])))
+
+(deftest test-get-and-memoize-opiskeluoikeudet
+  (with-log
+    (with-redefs [koski/get-opiskeluoikeus! mock-get-opiskeluoikeus-catch-404]
+      (testing
+       (str "Funktio pitää entuudestaan haetut opiskeluoikeudet muistitssa, "
+            "eikä hae niitä toistamiseen. Funktio lokitaa varoituksen, jos "
+            "opiskeluoikeutta ei saada koskesta")
+        (is (= (nh/get-and-memoize-opiskeluoikeudet! []) {}))
+        (reset! mock-get-opiskeluoikeus-catch-404-count 0)
+        (is (= (nh/get-and-memoize-opiskeluoikeudet!
+                 [jakso-1   ; 1.2.3.8
+                  jakso-2   ; 1.2.3.8
+                  jakso-5   ; 1.2.3.7
+                  jakso-6   ; 1.2.3.8
+                  jakso-10  ; 1.2.3.7
+                  {:hoks_id 1
+                   :yksiloiva_tunniste "123"
+                   :hankkimistapa_id 123
+                   :opiskeluoikeus_oid "1.2.3.4.ei.loydy"}])
+               {"1.2.3.7" (get opiskeluoikeudet "1.2.3.7")
+                "1.2.3.8" (get opiskeluoikeudet "1.2.3.8")}))
+        (is (= @mock-get-opiskeluoikeus-catch-404-count 3))
+        (is (logged? 'oph.ehoks.palaute.tyoelama.kesto
+                     :warn
+                     #"Opiskeluoikeutta ` 1.2.3.4.ei.loydy ` ei saatu ")
+            (the-log))))))
+
+(defn- mock-get-tyoelamajaksot-active-between!
+  [oppija-oid start end]
+  (assert oppija-oid "oppija-oid puuttuu")
+  (assert start "aikavälin alkupäivämäärä `start` puuttuu")
+  (assert end "aikavälin päättymispäivämäärä `end` puuttuu")
+  (filter #(and (= (:oppija_oid %) oppija-oid)
+                (<= (compare (:jakso_alkupvm %) end) 0)
+                (>= (compare (:jakso_loppupvm %) start) 0))
+          jaksot-1-25))
+
+(deftest test-jaksojen-kestot!
+  (with-redefs
+   [hp/select-tyoelamajaksot-active-between
+    mock-get-tyoelamajaksot-active-between!
+    koski/get-opiskeluoikeus! mock-get-opiskeluoikeus-catch-404]
+    (testing "Funktio laskee kestot oikein"
+      (are [kestot] (= (nh/jaksojen-kestot! (keys kestot))
+                       (map-keys nh/ids kestot))
+        {jakso-2 12}
+        {jakso-9 18}
+        {jakso-21 16}
+        {jakso-1 0 jakso-4 37}
+        {jakso-9 18 jakso-21 16}
+        {jakso-1 0  jakso-2 12 jakso-3 1 jakso-4 37 jakso-5 215 jakso-6 1
+         jakso-7 85 jakso-8 9  jakso-9 18 jakso-10 4 jakso-11 4 jakso-12 4
+         jakso-13 5 jakso-14 725 jakso-15 2 jakso-16 62 jakso-17 0
+         jakso-21 16 jakso-22 25 jakso-23 0 jakso-24 14 jakso-25 13}))
+    (testing (str "Lopputulos on sama kuin kestot laskettaisiin kunkin oppijan "
+                  "jaksoille erikseen. Ts. funktio erottelee eri oppijoiden "
+                  "jaksot kestoja laskiessaan.")
+      (are [jaksot] (= (nh/jaksojen-kestot! jaksot)
+                       (zipmap (map nh/ids jaksot)
+                               (map #(get (nh/jaksojen-kestot! [%])
+                                          (nh/ids %))
+                                    jaksot)))
+        [jakso-9 jakso-23]
+        [jakso-3 jakso-6 jakso-15 jakso-22 jakso-23]
+        jaksot-1-17
+        jaksot-21-25
+        jaksot-1-25))
+    (testing (str "Funktio palauttaa tyhjän listan, jos eHOKSista ei saada "
+                  "`get-tyoelamajaksot-active-between!`-kutsulla.")
+      (with-redefs
+       [hp/select-tyoelamajaksot-active-between (constantly {})]
+        (is (= (nh/jaksojen-kestot! jaksot-1-25) {}))))
+    (testing "Kestot ovat nollia, jos Koskesta ei saada opiskeluoikeuksia."
+      (with-redefs
+       [koski/get-opiskeluoikeus! (constantly nil)]
+        (is (= (nh/jaksojen-kestot! jaksot-1-25)
+               (zipmap (map nh/ids jaksot-1-25) (repeat 0))))))))

--- a/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama/kesto_test.clj
@@ -1,0 +1,572 @@
+(ns oph.ehoks.palaute.tyoelama.kesto-test
+  (:require [clojure.test :refer [are deftest is testing]]
+            [clojure.tools.logging.test :refer [with-log logged?]]
+            [oph.ehoks.external.koski :as koski]
+            [medley.core :refer [map-keys filter-vals]]
+            [oph.ehoks.palaute.tyoelama.kesto :as nh])
+  (:import (java.time LocalDate)))
+
+(defn alku-and-loppu-to-localdate
+  "Muuntaa parametrina annetun hashmapin :alku ja :loppu -avaimien
+  merkkijonomuotoiset päivämäärät LocalDate:iksi."
+  [jakso]
+  (cond-> jakso
+    (:alku jakso)  (update :alku  #(LocalDate/parse %))
+    (:loppu jakso) (update :loppu #(LocalDate/parse %))))
+
+(def jakso-1 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "1"
+              :hankkimistapa_id 1
+              :jakso_alkupvm "2021-10-22"
+              :jakso_loppupvm "2021-10-25"
+              :osa_aikaisuus 40
+              :keskeytymisajanjaksot [{:id 1032
+                                       :osaamisen-hankkimistapa-id 1
+                                       :alku "2022-02-11"
+                                       :loppu "3022-03-01"}]})
+
+(def jakso-2 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "2"
+              :hankkimistapa_id 2
+              :jakso_alkupvm "2021-09-01"
+              :jakso_loppupvm "2021-12-15"
+              :osa_aikaisuus 80
+              :keskeytymisajanjaksot [{:id 1033
+                                       :osaamisen-hankkimistapa-id 2
+                                       :alku "2021-10-22"
+                                       :loppu "2021-10-30"}]})
+
+(def jakso-3 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "3"
+              :hankkimistapa_id 3
+              :jakso_alkupvm "2021-10-11"
+              :jakso_loppupvm "2021-10-21"
+              :osa_aikaisuus 100
+              :keskeytymisajanjaksot [{:id 1030
+                                       :osaamisen-hankkimistapa-id 3
+                                       :alku "2021-10-13"
+                                       :loppu "2021-10-14"}]})
+
+(def jakso-4 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "4"
+              :hankkimistapa_id 4
+              :jakso_alkupvm "2021-05-15"
+              :jakso_loppupvm "2021-12-01"
+              :osa_aikaisuus 70
+              :keskeytymisajanjaksot []})
+
+(def jakso-5 {:opiskeluoikeus_oid "1.2.3.7"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 2
+              :yksiloiva_tunniste "1"
+              :hankkimistapa_id 5
+              :jakso_alkupvm "2021-09-01"
+              :jakso_loppupvm "2023-12-15"
+              :osa_aikaisuus 60
+              :keskeytymisajanjaksot []})
+
+(def jakso-6 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "5"
+              :hankkimistapa_id 6
+              :jakso_alkupvm "2021-10-11"
+              :jakso_loppupvm "2021-10-21"
+              :osa_aikaisuus 100
+              :keskeytymisajanjaksot [{:id 1031
+                                       :osaamisen-hankkimistapa-id 6
+                                       :alku "2021-10-13"
+                                       :loppu "2021-10-14"}]})
+
+(def jakso-7 {:opiskeluoikeus_oid "1.2.3.10"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 3
+              :yksiloiva_tunniste "1"
+              :hankkimistapa_id 7
+              :jakso_alkupvm "2021-01-15"
+              :jakso_loppupvm "2022-04-29"
+              :osa_aikaisuus 50
+              :keskeytymisajanjaksot []})
+
+(def jakso-8 {:opiskeluoikeus_oid "1.2.3.8"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 1
+              :yksiloiva_tunniste "6"
+              :hankkimistapa_id 8
+              :jakso_alkupvm "2021-10-15"
+              :jakso_loppupvm "2021-12-11"
+              :osa_aikaisuus 100
+              :keskeytymisajanjaksot []})
+
+(def jakso-9 {:opiskeluoikeus_oid "1.2.3.6"
+              :oppija_oid "4.4.4.4"
+              :hoks_id 4
+              :yksiloiva_tunniste "1"
+              :hankkimistapa_id 9
+              :jakso_alkupvm "2021-07-03"
+              :jakso_loppupvm "2021-08-26"
+              :osa_aikaisuus 100
+              :keskeytymisajanjaksot []})
+
+(def jakso-10 {:opiskeluoikeus_oid "1.2.3.7"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 2
+               :yksiloiva_tunniste "2"
+               :hankkimistapa_id 10
+               :jakso_alkupvm "2021-08-20"
+               :jakso_loppupvm "2021-09-10"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot [{:id 1191
+                                        :osaamisen-hankkimistapa-id 10
+                                        :alku  "2021-08-25"
+                                        :loppu "2021-08-28"}]})
+
+(def jakso-11 {:opiskeluoikeus_oid "1.2.3.7"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 2
+               :yksiloiva_tunniste "3"
+               :hankkimistapa_id 11
+               :jakso_alkupvm "2021-09-03"
+               :jakso_loppupvm "2021-09-30"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot []})
+
+(def jakso-12 {:opiskeluoikeus_oid "1.2.3.7"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 2
+               :yksiloiva_tunniste "4"
+               :hankkimistapa_id 12
+               :jakso_alkupvm "2021-11-12"
+               :jakso_loppupvm "2021-12-15"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot [{:id 1192
+                                        :osaamisen-hankkimistapa-id 12
+                                        :alku "2021-11-18"
+                                        :loppu "2021-11-25"}]})
+
+(def jakso-13 {:opiskeluoikeus_oid "1.2.3.8"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 1
+               :yksiloiva_tunniste "7"
+               :hankkimistapa_id 13
+               :jakso_alkupvm "2021-09-06"
+               :jakso_loppupvm "2021-10-19"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot [{:id 1029
+                                        :osaamisen-hankkimistapa-id 13
+                                        :alku "2021-10-13"}]})
+
+(def jakso-14 {:opiskeluoikeus_oid "1.2.3.7"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 2
+               :yksiloiva_tunniste "5"
+               :hankkimistapa_id 14
+               :jakso_alkupvm "2021-09-01"
+               :jakso_loppupvm "2024-12-15"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot []})
+
+(def jakso-15 {:opiskeluoikeus_oid "1.2.3.8"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 1
+               :yksiloiva_tunniste "8"
+               :hankkimistapa_id 15
+               :jakso_alkupvm "2021-10-04"
+               :jakso_loppupvm "2021-10-19"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot []})
+
+(def jakso-16 {:opiskeluoikeus_oid "1.2.3.9"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 5
+               :yksiloiva_tunniste "1"
+               :hankkimistapa_id 16
+               :jakso_alkupvm "2021-02-01"
+               :jakso_loppupvm "2021-08-30"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot [{:id 1034
+                                        :osaamisen-hankkimistapa-id 16
+                                        :alku "2021-06-15"}]})
+
+(def jakso-17 {:opiskeluoikeus_oid "1.2.3.10.onnea.etsintaan"
+               :oppija_oid "4.4.4.4"
+               :hoks_id 6
+               :yksiloiva_tunniste "1"
+               :hankkimistapa_id 17
+               :jakso_alkupvm "2021-08-27"
+               :jakso_loppupvm "2022-04-29"
+               :osa_aikaisuus 100
+               :keskeytymisajanjaksot []})
+
+(def jakso-21 {:hankkimistapa_id 21
+               :hoks_id 7
+               :yksiloiva_tunniste "1"
+               :oppija_oid "3.3.3.3"
+               :osa_aikaisuus 100
+               :jakso_alkupvm "2022-01-03"
+               :jakso_loppupvm "2022-02-05"
+               :keskeytymisajanjaksot []
+               :opiskeluoikeus_oid "1.2.3.1"})
+
+(def jakso-22 {:hankkimistapa_id 22
+               :hoks_id 8
+               :yksiloiva_tunniste "1"
+               :oppija_oid "3.3.3.3"
+               :osa_aikaisuus 50
+               :jakso_alkupvm "2022-02-07"
+               :jakso_loppupvm "2022-04-04"
+               :opiskeluoikeus_oid "1.2.3.2"})
+
+(def jakso-23 {:hankkimistapa_id 23
+               :hoks_id 9
+               :yksiloiva_tunniste "1"
+               :oppija_oid "3.3.3.3"
+               :osa_aikaisuus 20
+               :jakso_alkupvm "2022-01-31"
+               :jakso_loppupvm "2022-02-20"
+               :keskeytymisajanjaksot [{:alku "2022-02-16"
+                                        :loppu "2022-02-18"}]
+               :opiskeluoikeus_oid "1.2.3.3"})
+
+(def jakso-24 {:hankkimistapa_id 24
+               :hoks_id 10
+               :yksiloiva_tunniste "1"
+               :oppija_oid "3.3.3.3"
+               :osa_aikaisuus 90
+               :jakso_alkupvm "2022-01-17"
+               :jakso_loppupvm "2022-02-20"
+               :opiskeluoikeus_oid "1.2.3.4"})
+
+(def jakso-25 {:hankkimistapa_id 25
+               :hoks_id 11
+               :yksiloiva_tunniste "1"
+               :oppija_oid "3.3.3.3"
+               :osa_aikaisuus 100
+               :jakso_alkupvm "2022-01-01"
+               :jakso_loppupvm "2022-04-01"
+               :keskeytymisajanjaksot [{:alku "2022-01-12" :loppu "2022-01-12"}
+                                       {:alku "2022-01-16" :loppu "2022-01-18"}]
+               :opiskeluoikeus_oid "1.2.3.5"})
+
+(def jaksot-1-17
+  [jakso-1  jakso-2  jakso-3 jakso-4 jakso-5 jakso-6 jakso-7 jakso-8 jakso-9
+   jakso-10 jakso-11 jakso-12 jakso-13 jakso-14 jakso-15 jakso-16 jakso-17])
+
+(def jaksot-21-25 [jakso-21 jakso-22 jakso-23 jakso-24 jakso-25])
+
+(def jaksot-1-25 (concat jaksot-1-17 jaksot-21-25))
+
+(def opiskeluoikeudet
+  {"1.2.3.1" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2022-01-01" :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.2" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2022-01-01" :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.4" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2022-01-01" :tila {:koodiarvo "lasna"}}
+                      {:alku "2022-01-30" :tila {:koodiarvo "loma"}}
+                      {:alku "2022-02-10" :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.5" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2022-01-01" :tila {:koodiarvo "lasna"}}
+                      {:alku "2022-02-02"
+                       :tila {:koodiarvo "valiaikaisestikeskeytynyt"}}]}}
+   "1.2.3.6" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2020-03-05", :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.7" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2020-04-06", :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.8" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2020-01-01", :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.9" {:tila {:opiskeluoikeusjaksot
+                     [{:alku "2022-08-25", :tila {:koodiarvo "lasna"}}]}}
+   "1.2.3.10" {:tila {:opiskeluoikeusjaksot
+                      [{:alku "2020-10-27", :tila {:koodiarvo "lasna"}}]}}})
+
+(deftest test-not-in-keskeytymisajanjakso?
+  (testing "Varmistaa, että not-in-keskeytymisajanjakso? toimii oikein."
+    (let [kjaksot [{:loppu (LocalDate/of 2022 4 1)}
+                   {:alku  (LocalDate/of 2022 4 4)
+                    :loppu (LocalDate/of 2022 4 6)}
+                   {:alku  (LocalDate/of 2022 4 8)}]]
+      (is (true? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 4) [])))
+      (is (true? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 2)
+                                                  kjaksot)))
+      (is (true? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 7)
+                                                  kjaksot)))
+      (is (false? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 3 30)
+                                                   kjaksot)))
+      (is (false? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 4)
+                                                   kjaksot)))
+      (is (false? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 6)
+                                                   kjaksot)))
+      (is (false? (nh/not-in-keskeytymisajanjakso? (LocalDate/of 2022 4 10)
+                                                   kjaksot))))))
+
+(def mock-get-opiskeluoikeus-catch-404-count (atom 0))
+
+(defn- do-rounding [values]
+  (reduce-kv #(assoc %1 %2 (/ (Math/round (* %3 100.0)) 100.0)) {} values))
+
+(defn- mock-get-opiskeluoikeus-catch-404 [oo-oid]
+  (assert oo-oid "Opiskeluoikeus OID `oo-oid` puuttuu")
+  (swap! mock-get-opiskeluoikeus-catch-404-count inc)
+  (get opiskeluoikeudet oo-oid))
+
+(deftest test-get-and-memoize-opiskeluoikeudet
+  (with-log
+    (with-redefs [koski/get-opiskeluoikeus! mock-get-opiskeluoikeus-catch-404]
+      (testing
+       (str "Funktio pitää entuudestaan haetut opiskeluoikeudet muistitssa, "
+            "eikä hae niitä toistamiseen. Funktio lokitaa varoituksen, jos "
+            "opiskeluoikeutta ei saada koskesta")
+        (is (= (nh/get-and-memoize-opiskeluoikeudet! []) {}))
+        (reset! mock-get-opiskeluoikeus-catch-404-count 0)
+        (is (= (nh/get-and-memoize-opiskeluoikeudet!
+                 [jakso-1   ; 1.2.3.8
+                  jakso-2   ; 1.2.3.8
+                  jakso-5   ; 1.2.3.7
+                  jakso-6   ; 1.2.3.8
+                  jakso-10  ; 1.2.3.7
+                  {:hoks_id 1
+                   :yksiloiva_tunniste "123"
+                   :hankkimistapa_id 123
+                   :opiskeluoikeus_oid "1.2.3.4.ei.loydy"}])
+               {"1.2.3.7" (get opiskeluoikeudet "1.2.3.7")
+                "1.2.3.8" (get opiskeluoikeudet "1.2.3.8")}))
+        (is (= @mock-get-opiskeluoikeus-catch-404-count 3))
+        (is (logged? 'oph.ehoks.palaute.tyoelama.kesto
+                     :warn
+                     #"Opiskeluoikeutta `1.2.3.4.ei.loydy` ei saatu "))))))
+
+(deftest test-get-opiskeluoikeusjaksot
+  (testing "Funktio hakee onnistuneesti opiskeluoikeuden opiskeluoikeusjaksot."
+    (are [oo-oid expected] (= (nh/get-opiskeluoikeusjaksot
+                                (mock-get-opiskeluoikeus-catch-404 oo-oid))
+                              expected)
+      "1.2.3.4" (map alku-and-loppu-to-localdate
+                     [{:tila {:koodiarvo "lasna"}
+                       :alku "2022-01-01"
+                       :loppu "2022-01-29"}
+                      {:tila {:koodiarvo "loma"}
+                       :alku "2022-01-30"
+                       :loppu "2022-02-09"}
+                      {:tila {:koodiarvo "lasna"} :alku "2022-02-10"}])
+      "1.2.3.5" (map alku-and-loppu-to-localdate
+                     [{:tila {:koodiarvo "lasna"}
+                       :alku "2022-01-01"
+                       :loppu "2022-02-01"}
+                      {:tila {:koodiarvo "valiaikaisestikeskeytynyt"}
+                       :alku "2022-02-02"}]))))
+
+(deftest test-in-jakso?
+  (testing "Funktio palauttaa"
+    (let [jakso {:alku  (LocalDate/parse "2022-07-08")
+                 :loppu (LocalDate/parse "2022-12-20")}
+          jakso-2 {:alku (LocalDate/parse "2022-05-01")}]
+      (testing "`true`, kun päivämäärä on"
+        (testing "suljetulla aikavälillä"
+          (are [pvm] (nh/in-jakso? (LocalDate/parse pvm) jakso)
+            "2022-07-08" "2022-12-20" "2022-10-18" "2022-08-31"))
+        (testing "puoliavoimella aikavälillä"
+          (are [pvm] (nh/in-jakso? (LocalDate/parse pvm) jakso-2)
+            "2022-05-01" "2022-05-02" "2022-10-18" "2024-01-01")))
+      (testing "`false`, kun päivämäärä on"
+        (testing "suljetun aikavälin ulkopuolella"
+          (are [pvm] (not (nh/in-jakso? (LocalDate/parse pvm) jakso))
+            "2022-07-07" "2022-12-21" "2021-07-08" "2022-12-30"))
+        (testing "puoliavoimen aikavälin ulkopuolella"
+          (are [pvm] (not (nh/in-jakso? (LocalDate/parse pvm) jakso-2))
+            "2022-04-30" "2022-01-01" "2021-12-30" "2020-06-05"))))))
+
+(deftest test-jakso-active?
+  (let [jakso-1 {:alku (LocalDate/parse "2022-01-03")
+                 :loppu (LocalDate/parse "2022-05-05")
+                 :keskeytymisajanjaksot [{:alku "2022-02-20"
+                                          :loppu "2022-03-03"}
+                                         {:alku "2022-04-08"}]}
+        jakso-2 {:alku (LocalDate/parse "2022-01-01")}
+        opiskeluoikeus-1 (mock-get-opiskeluoikeus-catch-404 "1.2.3.4")
+        opiskeluoikeus-2 (mock-get-opiskeluoikeus-catch-404 "1.2.3.5")]
+    (testing "Funktio palauttaa"
+      (testing (str "`true`, kun päivämäärä on jakson sisällä, eikä se kuulu "
+                    "mihinkään keskeytymisajanjaksoon.")
+        (are [pvm] (nh/jakso-active? jakso-1 opiskeluoikeus-1
+                                     (LocalDate/parse pvm))
+          "2022-01-03" "2022-02-19" "2022-03-04" "2022-04-07" "2022-02-10")
+        (are [pvm] (nh/jakso-active? jakso-2
+                                     opiskeluoikeus-2
+                                     (LocalDate/parse pvm))
+          "2022-01-01" "2022-01-21" "2022-02-01"))
+      (testing "`false`,"
+        (testing "kun opiskeluoikeus on `nil`."
+          (are [pvm] (not (nh/jakso-active? jakso-1 nil (LocalDate/parse pvm)))
+            "2022-01-03" "2022-02-19" "2022-03-04" "2022-04-07" "2022-02-10"))
+        (testing "kun päivämäärä"
+          (testing "sisältyy keskeytymisajanjaksoon."
+            (are [pvm] (not (nh/jakso-active? jakso-1
+                                              opiskeluoikeus-1
+                                              (LocalDate/parse pvm)))
+              "2022-02-20" "2022-03-01" "2022-03-03" "2022-04-08" "2022-05-04")
+            (are [pvm] (not (nh/jakso-active? jakso-2
+                                              opiskeluoikeus-2
+                                              (LocalDate/parse pvm)))
+              "2022-02-02" "2022-03-21" "2023-01-01"))
+          (testing "ei ole jakson alku- ja loppupäivämäärien välillä."
+            (are [pvm] (not (nh/jakso-active? jakso-1
+                                              opiskeluoikeus-1
+                                              (LocalDate/parse pvm)))
+              "2022-01-02" "2022-05-06" "2021-12-30" "2023-01-01")
+            (are [pvm] (not (nh/jakso-active? jakso-2
+                                              opiskeluoikeus-1
+                                              (LocalDate/parse pvm)))
+              "2021-12-31" "2021-03-21" "2019-01-01")))))))
+
+(deftest test-osa-aikaisuuskerroin
+  (with-log
+    (testing (str "Jos osa-aikaisuustieto puuttuu jakson tiedosta, tulkitaan "
+                  "jakson osa-aikaisuudeksi 0 %.")
+      (is (= (nh/osa-aikaisuuskerroin {:hoks_id 1
+                                       :yksiloiva_tunniste "123"
+                                       :hankkimistapa_id 123})
+             0))
+      (is (logged? 'oph.ehoks.palaute.tyoelama.kesto
+                   :warn
+                   #"Osa-aikaisuustieto puuttuu jakson \(HOKS `1`, ")))
+    (testing (str "Osa-aikaisuustiedon ollessa ei-validi, osa-aikaisuuden "
+                  "katsotaan olevan 0 %.")
+      (are [oa]
+           (and (= (nh/osa-aikaisuuskerroin {:hoks_id 1
+                                             :yksiloiva_tunniste 123
+                                             :hankkimistapa_id 123
+                                             :osa_aikaisuus oa})
+                   0)
+                (logged? 'oph.ehoks.palaute.tyoelama.kesto
+                         :warn
+                         #"osa-aikaisuus `[\"0-9.-]*` ei ole validi"))
+        -1 0 120 5.5 "100")))
+  (testing (str "Osa-aikaisuustiedon ollessa validi, funktio hakee "
+                "osa-aikaisuustiedon jaksosta ja palauttaa tämän "
+                "perusteella lasketun osa-aikaisuuskertoimen.")
+    (are [oa] (= (nh/osa-aikaisuuskerroin {:osa_aikaisuus oa})
+                 (/ oa 100.0))
+      1 15 50 98 100)))
+
+(deftest test-keskeytymisajanjaksot
+  (testing
+   (str "Funktio ei palauta yhtään keskeytymisajanjaksoa, kun parametreiksi "
+        "ei ole annettu yhtään jaksoa eikä opiskeluoikeutta.")
+    (is (= (nh/keskeytymisajanjaksot {} {}) '())))
+  (testing
+   (str "Funktio ei palauta yhtään keskeytymisajanjaksoa, kun jakson eikä "
+        "opiskeluoikeuden tietoihin ole merkitty keskeytymisajanjaksoja.")
+    (is (= (nh/keskeytymisajanjaksot
+             jakso-4 {mock-get-opiskeluoikeus-catch-404 "1.2.3.8"})
+           '())))
+  (let [jakso-kjaksot  [{:alku "2022-01-12" :loppu "2022-01-12"}
+                        {:alku "2022-01-16" :loppu "2022-01-18"}]
+        opiskeluoikeus (mock-get-opiskeluoikeus-catch-404 "1.2.3.5")
+        oo-kjaksot     (map alku-and-loppu-to-localdate
+                            [{:alku "2022-02-02"
+                              :tila {:koodiarvo "valiaikaisestikeskeytynyt"}}])]
+    (testing
+     (str "Keskeytymisajanjakso jaksossa, muttei opiskeluoikeudessa. Funktio "
+          "palauttaa pelkästään jakson keskeytymisajanjaksot.")
+      (is (= (nh/keskeytymisajanjaksot
+               {:keskeytymisajanjaksot jakso-kjaksot} {})
+             (map nh/harmonize-alku-and-loppu-dates jakso-kjaksot))))
+    (testing
+     (str "Keskeytymisajanjakso opiskeluoikeudessa, muttei jaksossa. Funktio "
+          "palauttaa pelkästään opiskeluoikeuden keskeytymisajanjaksot.")
+      (is (= (nh/keskeytymisajanjaksot {} opiskeluoikeus) oo-kjaksot)))
+    (testing
+     (str "Keskeytymisajanjaksoja sekä jaksossa että tämän "
+          "opiskeluoikeudessa. Funktio palauttaa molempien kjaksot.")
+      (is (= (nh/keskeytymisajanjaksot jakso-25 opiskeluoikeus)
+             (concat (map nh/harmonize-alku-and-loppu-dates jakso-kjaksot)
+                     oo-kjaksot))))))
+
+(deftest test-oppijan-jaksojen-yhden-paivan-kestot
+  (testing
+   (str "Yhden päivän kesto jaetaan tasaisesti aktiivisena oleville "
+        "jaksoille. Jos yksikään jaksoista ei ole aktiivinen, palautuu "
+        "tyhjä taulu.")
+    (are [y m d kestot]
+         (let [oos (map :opiskeluoikeus_oid (keys kestot))]
+           (= (do-rounding
+                (nh/oppijan-jaksojen-yhden-paivan-kestot
+                  (map nh/harmonize-alku-and-loppu-dates (keys kestot))
+                  (zipmap oos (map mock-get-opiskeluoikeus-catch-404 oos))
+                  (LocalDate/of y m d)))
+              (map-keys nh/ids (filter-vals #(not= % 0) kestot))))
+      2021 10 13  {jakso-3 0}  ; keskeytynyt (jakso)
+      2021 10 14  {jakso-6 0}  ; keskeytynyt (jakso)
+      2021 10 14  {jakso-10 0} ; keskeytynyt (jakso)
+      2022  2  2  {jakso-25 0} ; keskeytynyt (opiskeluoikeus)
+      2021 10 12  {jakso-3 1.0}
+      2021  7 31  {jakso-9 1.0}
+      2021 10 13  {jakso-3 0 jakso-4 1.0}  ; 3 keskeytynyt
+      2021 10 12  {jakso-3 0.5 jakso-4 0.5}
+      ; 2 keskeytynyt, 3 päättynyt:
+      2021 10 25  {jakso-1 0.5 jakso-2 0 jakso-3 0 jakso-4 0.5}
+      ; 1 ei vielä alkanut:
+      2021 10 21  {jakso-1 0 jakso-2 0.33 jakso-3 0.33 jakso-4 0.33}
+      ; 1 ei vielä alkanut, 11 ei vielä alkanut:
+      2021  9  1
+      {jakso-1 0 jakso-5 0.33 jakso-10 0.33 jakso-11 0 jakso-14 0.33}
+      ; 1 ei vielä alkanut
+      2021  9  9
+      {jakso-1 0 jakso-5 0.25 jakso-10 0.25 jakso-11 0.25 jakso-14 0.25}
+      ; 10 päättynyt, 11 päättynyt
+      2021 10 22
+      {jakso-1 0.33 jakso-5 0.33 jakso-10 0 jakso-11 0 jakso-14 0.33})))
+
+(deftest test-oppijan-jaksojen-kestot
+  (testing (str "Funktio palauttaa `nil`, jos jaksot sisältävässä HashMapissa "
+                "ei ole jaksoja.")
+    (is (= (nh/oppijan-jaksojen-kestot {} {:voi-sisaltaa-mita-tahansa nil})
+           nil)))
+  (testing (str "Funktio antaa jakson kestoksi nollan, mikäli "
+                "osa-aikaisuustieto puuttuu tai ei ole validi.")
+    (are [oa] (let [oo-oid (:opiskeluoikeus_oid jakso-2)]
+                (= (nh/oppijan-jaksojen-kestot
+                     [(assoc jakso-2 :osa_aikaisuus oa)]
+                     {oo-oid (get opiskeluoikeudet oo-oid)})
+                   {{:hoks_id 1 :yksiloiva_tunniste "2"} 0}))
+      nil -1 0 101 55.5 "merkkijono" true false {}))
+  (testing (str "Funktio antaa jakson kestoksi nollan, mikäli jakson "
+                "opiskeluoikeus on `nil` tai sitä ei löydy "
+                "`opiskeluoikeudet` hashmapista.")
+    (are [opiskeluoikeudet]
+         (= (nh/oppijan-jaksojen-kestot [jakso-2] opiskeluoikeudet)
+            {{:hoks_id 1 :yksiloiva_tunniste "2"} 0})
+      {} {"1.2.3.8" nil}))
+  (testing "Yhden jakson tapauksessa jakson kesto on jakson päivien
+           yhteenlaskettu lukumäärä (pois lukien keskeytymisajanjakson päivät)
+           kerrottuna osa-aikaisuuskertoimella"
+    (are [jakso expected-kesto]
+         (let [oo-oid (:opiskeluoikeus_oid jakso)]
+           (= (first (vals (nh/oppijan-jaksojen-kestot
+                             [jakso] {oo-oid (get opiskeluoikeudet oo-oid)})))
+              expected-kesto))
+      jakso-1 2   ; 4 päivää • 0.4 = 1.6 päivää ≈ 2 päivää
+      jakso-2 78  ; (107 päivää - 9 k.jakson. päivää) • 0.8 = 78.4 päivää
+                  ;                                         ≈ 78 päivää
+      jakso-3 9   ; (10 päivää - 1 k.jakson. päivää) • 1.0 = 9 päivää
+      jakso-6 9)) ; (10 päivää - 1 k.jakson. päivää) • 1.0 = 9 päivää
+  (testing
+   "Useamman jakson tapauksessa kestot ovat pienempiä jyvityksen seurauksena."
+    (are [jaksot expected-kestot]
+         (= (vals (nh/oppijan-jaksojen-kestot
+                    jaksot
+                    (select-keys opiskeluoikeudet
+                                 (map :opiskeluoikeus_oid jaksot))))
+            expected-kestot)
+      [jakso-2 jakso-3] [74 5]
+      [jakso-2 jakso-4 jakso-8] [35 104 23]
+      [jakso-1 jakso-4 jakso-9 jakso-16] [1 109 28 119])))

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -630,16 +630,28 @@
                   arvo/create-jaksotunnus! hoks-utils/mock-create-jaksotunnus
                   date/now #(LocalDate/of 2024 6 30)]
       (is (= (:status (hoks-utils/create-hoks-in-the-past!)) 200))
+      (hoks-utils/reset-arvo-requests!)
       (vt/handle-tep-palautteet-on-heratepvm! {})
       (let [palautteet (hoks-utils/palautteet-joissa-vastaajatunnus)
             ddb-jaksot (far/scan @ddb/faraday-opts @(ddb/tables :jakso) {})
             ddb-niput  (far/scan @ddb/faraday-opts @(ddb/tables :nippu) {})
+            arvo-requests (hoks-utils/created-jaksotunnukset)
             tapahtumat (db-helpers/query
                          [(str "select * from palaute_tapahtumat "
                                "where uusi_tila = "
                                "'vastaajatunnus_muodostettu'")])]
+        (is (= (count arvo-requests) 5))
         (is (= (count palautteet) 5))
         (is (= (count ddb-jaksot) 5))
+        (is (= (select-keys
+                 (first arvo-requests)
+                 [:tyopaikkajakson_kesto :tyopaikkajakson_alkupvm
+                  :tyopaikkajakson_loppupvm :tutkintonimike :metatiedot])
+               {:tyopaikkajakson_kesto 5,
+                :tyopaikkajakson_alkupvm "2023-12-01",
+                :tyopaikkajakson_loppupvm "2023-12-05",
+                :tutkintonimike '("12345" "23456"),
+                :metatiedot {:ei_kuulu_lahetettavien_perusjoukkoon true}}))
         (test-utils/eq
           (sort-by :yksiloiva_tunniste
                    (map #(dissoc % :tunnus :request_id :hankkimistapa_id)

--- a/test/oph/ehoks/palaute/tyoelama_test.clj
+++ b/test/oph/ehoks/palaute/tyoelama_test.clj
@@ -267,6 +267,25 @@
     (is (= (map :yksiloiva-tunniste (tep/tyopaikkajaksot hoks-test/hoks-1))
            '("1" "3" "4" "7" "9")))))
 
+(deftest test-build-tyoelamajakso-for-kesto
+  (testing (str "The function converts jaksotunnus request context into the "
+                "underscore-keyed jakso format expected by "
+                "`kesto/jaksojen-kestot!`.")
+    (let [ctx {:hoks             hoks-test/hoks-1
+               :jakso            test-jakso
+               :existing-palaute {:hoks-id                   42
+                                  :jakson-yksiloiva-tunniste "1"
+                                  :hankkimistapa-id          2}}]
+      (is (= (tep/build-tyoelamajakso-for-kesto ctx)
+             {:oppija_oid         (:oppija-oid hoks-test/hoks-1)
+              :opiskeluoikeus_oid (:opiskeluoikeus-oid hoks-test/hoks-1)
+              :hoks_id            42
+              :yksiloiva_tunniste "1"
+              :hankkimistapa_id   2
+              :jakso_alkupvm      (:alku test-jakso)
+              :jakso_loppupvm     (:loppu test-jakso)
+              :osa_aikaisuus      (:osa-aikaisuustieto test-jakso)})))))
+
 (deftest test-initial-palaute-state-and-reason
   (testing "On HOKS creation or update"
     (with-redefs [date/now #(LocalDate/of 2023 7 1)]


### PR DESCRIPTION
## Kuvaus muutoksista

Pointtina on saada  kesto laskettua kaikille jaksoille, ei pelkästään niputettaville.  Tää on nyt määritelty siten, että niputettavien jaksojen kesto määräytyy niputuspäivän tilanteen perusteella ja ei-niputettavien (käytännössä abt ne jaksot, joiden vastausaika on jo mennyt) sen hetken perusteella,  jolloin ne saadaan käsiteltyä (jaksonhan "oikea" niputuspäivä on jo mennyt).

Jos jakso sitten päätyy nippuun, kesto lasketaan uudestaan niputuspäivänä ja korvaa vanhan keston (Arvo-devaajilta varmisetettu että tää on OK).

https://jira.eduuni.fi/browse/EH-2072

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
